### PR TITLE
More names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supported games:
  - `Crusader Kings 3`
  - `Imperator: Rome`
 
-The common database currently has over [b]28 thousand[/b] names for over [b]350[/b] languages, settings and time periods.
+The common database currently has over [b]30 thousand[/b] names for over [b]350[/b] languages, settings and time periods.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-This is a mod for various strategy games, that adds new province names based on their culture/faction.
+This is a mod for various strategy games, that adds new place names based on their culture/faction.
 
 The names are meant to provide an immersive and accurate experience for the game's setting and time period.
 
@@ -10,7 +10,7 @@ Supported games:
  - `Crusader Kings 3`
  - `Imperator: Rome`
 
-The common database currently has over [b]27 thousand[/b] names for over [b]300[/b] languages, settings and time periods.
+The common database currently has over [b]28 thousand[/b] names for over [b]350[/b] languages, settings and time periods.
 
 # Installation
 

--- a/assets/steam-workshop-description.txt
+++ b/assets/steam-workshop-description.txt
@@ -2,7 +2,7 @@
 
 [img=https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/banner_description.png][/img]
 
-This is a mod for various strategy games, that adds new province names based on their culture/faction.
+This is a mod for various strategy games, that adds new place names based on their culture/faction.
 
 The names are meant to provide an immersive and accurate experience for the game's setting and time period.
 
@@ -12,7 +12,7 @@ Supported games:
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2217534250]Crusader Kings 3[/url]
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2219177532]Imperator: Rome[/url]
 
-The common database currently has over [b]27 thousand[/b] names for over [b]300[/b] languages, settings and time periods.
+The common database currently has over [b]28 thousand[/b] names for over [b]350[/b] languages, settings and time periods.
 
 [img=https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/banner_useful_links.png][/img]
 

--- a/assets/steam-workshop-description.txt
+++ b/assets/steam-workshop-description.txt
@@ -12,7 +12,7 @@ Supported games:
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2217534250]Crusader Kings 3[/url]
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2219177532]Imperator: Rome[/url]
 
-The common database currently has over [b]28 thousand[/b] names for over [b]350[/b] languages, settings and time periods.
+The common database currently has over [b]30 thousand[/b] names for over [b]350[/b] languages, settings and time periods.
 
 [img=https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/banner_useful_links.png][/img]
 

--- a/languages.xml
+++ b/languages.xml
@@ -1044,7 +1044,10 @@
   </Language>
   <Language>
     <Id>Gothic</Id>
-    <Code iso-639-3="got" />
+    <Code iso-639-2="got" iso-639-3="got" />
+    <GameIds>
+      <GameId game="CK2HIP">gothic</GameId>
+    </GameIds>
   </Language>
   <Language>
     <Id>Gothic_Crimean</Id>
@@ -1347,6 +1350,13 @@
     </GameIds>
   </Language>
   <Language>
+    <Id>Khanty</Id>
+    <Code iso-639-3="kca" />
+    <GameIds>
+      <GameId game="CK2HIP">khanty</GameId>
+    </GameIds>
+  </Language>
+  <Language>
     <Id>Khitan</Id>
     <Code iso-639-3="zkt" />
     <GameIds>
@@ -1356,6 +1366,13 @@
   <Language>
     <Id>Kinyarwanda</Id>
     <Code iso-639-1="rw" iso-639-2="kin" iso-639-3="kin" />
+  </Language>
+  <Language>
+    <Id>Komi</Id>
+    <Code iso-639-3="kpv" />
+    <GameIds>
+      <GameId game="CK2HIP">komi</GameId>
+    </GameIds>
   </Language>
   <Language>
     <Id>Kongo</Id>
@@ -1609,6 +1626,13 @@
   <Language>
     <Id>Maori</Id>
     <Code iso-639-1="mi" iso-639-2="mri" iso-639-3="mri" />
+  </Language>
+  <Language>
+    <Id>Mari</Id>
+    <Code iso-639-2="chm" iso-639-3="chm" />
+    <GameIds>
+      <GameId game="CK2HIP">mari</GameId>
+    </GameIds>
   </Language>
   <Language>
     <Id>Mirandese</Id>

--- a/languages.xml
+++ b/languages.xml
@@ -1635,6 +1635,16 @@
     </GameIds>
   </Language>
   <Language>
+    <Id>Massylian</Id>
+    <GameIds>
+      <GameId game="ImperatorRome">massylian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Numidian</LanguageId>
+      <LanguageId>Socossian</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
     <Id>Mirandese</Id>
     <Code iso-639-3="mwl" />
   </Language>
@@ -1786,6 +1796,16 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Nubian</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Numidian</Id>
+    <GameIds>
+      <GameId game="ImperatorRome">numidian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Massylian</LanguageId>
+      <LanguageId>Socossian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2377,6 +2397,16 @@
   <Language>
     <Id>Silesian</Id>
     <Code iso-639-3="szl" />
+  </Language>
+  <Language>
+    <Id>Socossian</Id>
+    <GameIds>
+      <GameId game="ImperatorRome">socossian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Numidian</LanguageId>
+      <LanguageId>Massylian</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Sogdian</Id> <!-- c. 100 BC – c. 1000 AD, then developed into Yaghnobi -->

--- a/languages.xml
+++ b/languages.xml
@@ -2193,6 +2193,16 @@
     </GameIds>
   </Language>
   <Language>
+    <Id>Sanhaja</Id>
+    <Code iso-639-3="sjs" />
+    <FallbackLanguages>
+      <LanguageId>Zenaga</LanguageId>
+    </FallbackLanguages>
+    <GameIds>
+      <GameId game="CK2HIP">sanhaja</GameId>
+    </GameIds>
+  </Language>
+  <Language>
     <Id>Sardinian</Id>
     <Code iso-639-1="sc" iso-639-3="srd" />
     <GameIds>
@@ -2812,6 +2822,9 @@
   <Language>
     <Id>Zenaga</Id>
     <Code iso-639-2="zen" iso-639-3="zen" />
+    <FallbackLanguages>
+      <LanguageId>Sanhaja</LanguageId>
+    </FallbackLanguages>
     <GameIds>
       <GameId game="CK2HIP">berber</GameId>
       <GameId game="CK3">berber</GameId>

--- a/languages.xml
+++ b/languages.xml
@@ -2682,6 +2682,47 @@
     </FallbackLanguages>
   </Language>
   <Language>
+    <Id>Udi_Early</Id> <!-- c. 2000 BC – c. 300 AD -->
+    <FallbackLanguages>
+      <LanguageId>Udi_Old</LanguageId>
+      <LanguageId>Udi_Middle</LanguageId>
+      <LanguageId>Udi_Modern_Early</LanguageId>
+      <LanguageId>Udi</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Udi_Old</Id> <!-- c. 300 AD – c. 900 AD -->
+    <FallbackLanguages>
+      <LanguageId>Udi_Early</LanguageId>
+      <LanguageId>Udi_Middle</LanguageId>
+      <LanguageId>Udi_Modern_Early</LanguageId>
+      <LanguageId>Udi</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Udi_Middle</Id> <!-- c. 900 AD – c. 1800 AD -->
+    <FallbackLanguages>
+      <LanguageId>Udi_Old</LanguageId>
+      <LanguageId>Udi_Early</LanguageId>
+      <LanguageId>Udi_Modern_Early</LanguageId>
+      <LanguageId>Udi</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Udi_Modern_Early</Id> <!-- c. 1800 AD – c. 1920 AD -->
+    <FallbackLanguages>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Udi</Id> <!-- c. 1920 AD – present -->
+    <FallbackLanguages>
+      <LanguageId>Udi_Modern_Early</LanguageId>
+      <LanguageId>Udi_Middle</LanguageId>
+      <LanguageId>Udi_Old</LanguageId>
+      <LanguageId>Udi_Early</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
     <Id>Ukrainian</Id>
     <Code iso-639-1="uk" iso-639-3="ukr" />
     <FallbackLanguages>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,3 +22,5 @@ build
 cp -rf extras/ck2hip/* out/CK2HIP/
 cp -rf extras/ck3/* out/CK3/
 cp -rf extras/ir/* out/ImperatorRome/
+
+rm out/CK2HIP/descriptor.mod

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,6 +15,8 @@ function build {
     "${MOD_BUILDER_BIN_FILE_PATH}" -l "languages.xml" -t "titles.xml" -o "out/"
 }
 
+[ -d "out/" ] && rm -rf "out/"
+
 build
 
 cp -rf extras/ck2hip/* out/CK2HIP/

--- a/scripts/count-localisations.sh
+++ b/scripts/count-localisations.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-cat titles.xml | grep "Name language" | wc -l
+TITLES_COUNT=$(cat titles.xml | grep "Name language" | wc -l)
+LANGUAGES_COUNT=$(cat languages.xml | grep "/Language>" | wc -l)
+
+echo "Titles: ${TITLES_COUNT}"
+echo "Languages: ${LANGUAGES_COUNT}"

--- a/scripts/find-mistakes.sh
+++ b/scripts/find-mistakes.sh
@@ -3,4 +3,16 @@
 grep -n "parent=\"\([^\"]*\)\"[^>]*>\1<" titles.xml
 grep -n "parent=\"[a-zA-Z][^_]" titles.xml
 grep -n "parent=\"[a-zA-Z][^_]" titles.xml
+
+# Find duplicated Imperator: Rome game IDs
 grep "GameId game=\"ImperatorRome\"" titles.xml | sed 's/[ \t]*<!--.*-->[ \t]*//g' | sort | uniq -c | sed 's/^[ \t]*//g' | grep "^[2-9]"
+
+# Find CK2 parents missing an entry
+for PARENT_ID in $(grep "game=\"CK2HIP\"" titles.xml | \
+                    grep -e "parent=\"[^\"]\+\"" | \
+                    sed 's/.*parent=\"\([^\"]*\)".*/\1/g' | \
+                    sort | uniq); do
+    if [ -z "$(grep "<GameId game=\"CK2HIP\"" titles.xml | grep ">"${PARENT_ID}"<")" ]; then
+        echo "CK2HIP: ${PARENT_ID} entry does not exit"
+    fi
+done

--- a/scripts/fix-orders.sh
+++ b/scripts/fix-orders.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-grep "GameId game=\"CK2HIP\" parent=\"\"" titles.xml | while read -r LINE ; do
+grep "GameId game=\"CK2HIP\".*order=\"\"" titles.xml | while read -r LINE ; do
   TITLE_ID=$(echo ${LINE} | awk -F\> '{print $2}' | awk -F\< '{print $1}')
   ORDER=$(grep "^${TITLE_ID}=" orders.txt | awk -F= '{print $2}')
 

--- a/scripts/get-titles-to-add.sh
+++ b/scripts/get-titles-to-add.sh
@@ -2,13 +2,16 @@
 
 echo "" > titles-to-add.xml
 
-for TITLE in $(cat ck2.txt | grep "\{" | awk -F= '{print $1}' | sed 's/ //g'); do
-    if [ $(grep -c ">"${TITLE}"</GameId" titles.xml) -eq 0 ]; then
-        echo "${TITLE} is not defined"
+for PARENT_ID in $(grep "game=\"CK2HIP\"" titles.xml | \
+                    grep -e "parent=\"[^\"]\+\"" | \
+                    sed 's/.*parent=\"\([^\"]*\)".*/\1/g' | \
+                    sort | uniq); do
+    if [ -z "$(grep "<GameId game=\"CK2HIP\"" titles.xml | grep ">"${PARENT_ID}"<")" ]; then
+        echo "${PARENT_ID} is not defined"
         echo "  <LocationEntity>" >> titles-to-add.xml
-        echo "    <Id>${TITLE:2}</Id>" >> titles-to-add.xml
+        echo "    <Id>${PARENT_ID:2}</Id>" >> titles-to-add.xml
         echo "    <GameIds>" >> titles-to-add.xml
-        echo "      <GameId game=\"CK2HIP\" parent=\"\" order=\"\">${TITLE}</GameId>" >> titles-to-add.xml
+        echo "      <GameId game=\"CK2HIP\" parent=\"\" order=\"\">${PARENT_ID}</GameId>" >> titles-to-add.xml
         echo "    </GameIds>" >> titles-to-add.xml
         echo "    <Names>" >> titles-to-add.xml
         echo "    </Names>" >> titles-to-add.xml

--- a/titles.xml
+++ b/titles.xml
@@ -2656,7 +2656,7 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>visegrad</Id>
+    <Id>visegrad_hungary</Id>
     <GeoNamesId>3042824</GeoNamesId>
     <GameIds>
       <GameId game="CK2HIP" parent="c_esztergom" order="6">b_visegrad</GameId>
@@ -13739,6 +13739,8 @@
     <Id>germany</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="e_hre" order="13">k_germany</GameId>
+      <GameId game="CK3">k_germany</GameId>
+      <GameId game="CK3">e_germany</GameId>
       <GameId game="ImperatorRome">4097</GameId> <!-- Germania -->
     </GameIds>
     <Names>
@@ -20011,6 +20013,7 @@
     <Id>krusevac</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_branicevo" order="3">b_krusevac</GameId>
+      <GameId game="CK3">b_krusevac</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Kruševac</Name>
@@ -20026,6 +20029,15 @@
       <Name language="Slovene">Kruševac</Name>
       <Name language="Turkish_Old">Alaga Hisar</Name>
       <Name language="Turkmen_Medieval">Alaga Hisar</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>koznik</Id>
+    <GameIds>
+      <GameId game="CK3">b_koznik</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Koznik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20673,6 +20685,7 @@
     <Id>serbia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="e_byzantium" order="11">k_serbia</GameId>
+      <GameId game="CK3">k_serbia</GameId>
     </GameIds>
     <Names>
       <Name language="Arpitan">Sèrbie</Name>
@@ -20689,6 +20702,7 @@
       <Name language="Hausa">Serbiya</Name>
       <Name language="Hungarian">Szerbia</Name>
       <Name language="Irish">An tSeirbia</Name>
+      <Name language="Latin_Medieval">Moesia Prima</Name>
       <Name language="Portuguese">Sérvia</Name>
       <Name language="Prussian_Old">Serbija</Name>
       <Name language="Romanian">Serbia</Name>
@@ -20707,6 +20721,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_rashka" order="1">c_rashka</GameId>
       <GameId game="CK2HIP" parent="k_serbia" order="1">d_rashka</GameId>
+      <GameId game="CK3">c_rashka</GameId>
+      <GameId game="CK3">d_rashka</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Rashkës</Name>
@@ -20718,6 +20734,16 @@
       <Name language="Latin">Rascia</Name>
       <Name language="Prussian_Old">Serbija</Name>
       <Name language="Romanian">Rașka</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>novotrgoviste</Id>
+    <GameIds>
+      <GameId game="CK3">b_novotrgoviste</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Novo Trgovište</Name>
+      <Name language="Romanian_Medieval">Tîrgoviște Nou</Name> <!-- Guessed / Translated -->
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20743,9 +20769,19 @@
     <Id>sjenica</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_rashka" order="3">b_sjenica</GameId>
+      <GameId game="CK3">b_sjenica</GameId>
     </GameIds>
     <Names>
       <Name language="Turkish">Seniçe</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>budlimlje</Id>
+    <GameIds>
+      <GameId game="CK3">b_budlimlje</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Budlimlje</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20769,10 +20805,20 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>hvosno</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_rashka" order="2">c_prizren</GameId>
+      <GameId game="CK3">c_hvosno</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Hvosno</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>prizren</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_prizren" order="5">b_prizren</GameId>
-      <GameId game="CK2HIP" parent="d_rashka" order="2">c_prizren</GameId>
+      <GameId game="CK3">b_prizren</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Prizreni</Name>
@@ -20783,6 +20829,7 @@
       <Name language="Lithuanian">Prizrenas</Name>
       <Name language="Oghuz">Pürzeyn</Name>
       <Name language="Pecheneg">Pürzeyn</Name>
+      <Name language="Serbian_Medieval">Prizren</Name>
       <Name language="Turkish_Old">Pürzeyn</Name>
       <Name language="Turkmen_Medieval">Pürzeyn</Name>
     </Names>
@@ -20791,6 +20838,7 @@
     <Id>pristina</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_prizren" order="2">b_pristina</GameId>
+      <GameId game="CK3">b_pristina</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Prishtinë</Name>
@@ -20814,6 +20862,7 @@
       <Name language="Polish">Prisztina</Name>
       <Name language="Romanian">Priștina</Name>
       <Name language="Scottish_Medieval">Prishtina</Name>
+      <Name language="Serbian_Medieval">Priština</Name>
       <Name language="Serbian">Priština</Name>
       <Name language="Slovene">Priština</Name>
       <Name language="Turkish_Old">Pristine</Name>
@@ -20825,6 +20874,7 @@
     <Id>zvecan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_prizren" order="3">b_zvecan</GameId>
+      <GameId game="CK3">b_zvecan</GameId>
     </GameIds>
     <Names>
       <Name language="Gothic_Crimean">Zvetsán</Name>
@@ -20832,14 +20882,16 @@
       <Name language="Oghuz">Izveçen</Name>
       <Name language="Pecheneg">Izveçen</Name>
       <Name language="Romanian">Zvecean</Name>
+      <Name language="Serbian_Medieval">Zvecan</Name>
       <Name language="Turkish_Old">Izveçen</Name>
       <Name language="Turkmen_Medieval">Izveçen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>pec_hvosno</Id>
+    <Id>pec</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_prizren" order="4">b_pec_hvosno</GameId>
+      <GameId game="CK3">b_pec</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Pejë</Name>
@@ -20854,14 +20906,25 @@
       <Name language="Pecheneg">Ipek</Name>
       <Name language="Polish">Pecz</Name>
       <Name language="Romanian">Peci</Name>
+      <Name language="Serbian_Medieval">Pec</Name>
       <Name language="Turkish_Old">Ipek</Name>
       <Name language="Turkmen_Medieval">Ipek</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>podujevo</Id>
+    <GameIds>
+      <GameId game="CK3">b_podujevo</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Podujevo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>debrecen</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_macva" order="2">b_debrc</GameId>
+      <GameId game="CK3">b_debrc</GameId>
       <GameId game="CK3">b_debrecen</GameId>
     </GameIds>
     <Names>
@@ -20923,6 +20986,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_belgrade" order="4">b_belgrade</GameId>
       <GameId game="CK2HIP" parent="d_macva" order="2">c_belgrade</GameId>
+      <GameId game="CK3">b_beograd</GameId>
+      <GameId game="CK3">c_beograd</GameId>
       <GameId game="CK3">d_belgrade</GameId>
       <GameId game="ImperatorRome">4195</GameId> <!-- Singidunum -->
     </GameIds>
@@ -20953,6 +21018,7 @@
       <Name language="Norwegian">Beograd</Name>
       <Name language="Portuguese">Belgrado</Name>
       <Name language="Sardinian">Belgrado</Name>
+      <Name language="Serbian_Medieval">Beograd</Name>
       <Name language="Sicilian">Belgrado</Name>
       <Name language="Slovak">Belehrad</Name>
       <Name language="Slovene">Beograd</Name>
@@ -20966,6 +21032,7 @@
     <Id>smederevo</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_belgrade" order="2">b_smederevo</GameId>
+      <GameId game="CK3">b_smederevo</GameId>
     </GameIds>
     <Names>
       <Name language="German">Semendria</Name>
@@ -20979,6 +21046,7 @@
       <Name language="Polish">Smederewo</Name>
       <Name language="Portuguese">Semêndria</Name>
       <Name language="Romanian">Semendria</Name>
+      <Name language="Serbian_Medieval">Smederevo</Name>
       <Name language="Szekely_Old">Szendrõ</Name>
       <Name language="Turkish_Old">Semendire</Name>
       <Name language="Turkmen_Medieval">Semendire</Name>
@@ -21051,6 +21119,7 @@
     <Id>podrinje</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_hum" order="1">c_hum</GameId>
+      <GameId game="CK3">c_podrinje</GameId>
     </GameIds>
     <Names>
       <Name language="Dalmatian">Drina</Name>
@@ -21058,6 +21127,16 @@
       <Name language="Greek_Medieval">Dreinos</Name>
       <Name language="Latin_Medieval">Drinus</Name>
       <Name language="Romanian">Drina</Name>
+      <Name language="Serbian_Medieval">Podrinje</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hotca</Id>
+    <GameIds>
+      <GameId game="CK3">b_hotca</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Hotca</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -21096,6 +21175,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_zeta" order="4">b_dioclea</GameId>
       <GameId game="CK2HIP" parent="k_serbia" order="4">d_dioclea</GameId>
+      <GameId game="CK3">c_duklja</GameId>
+      <GameId game="CK3">d_duklja</GameId>
       <GameId game="ImperatorRome">4089</GameId> <!-- Diocleia -->
     </GameIds>
     <Names>
@@ -21110,6 +21191,7 @@
       <Name language="Oghuz">Iskodra</Name>
       <Name language="Pecheneg">Iskodra</Name>
       <Name language="Romanian">Doclea</Name>
+      <Name language="Serbian_Medieval">Duklja</Name>
       <Name language="Serbian">Duklja</Name>
       <Name language="Turkish_Old">Iskodra</Name>
       <Name language="Turkmen_Medieval">Iskodra</Name>
@@ -21140,6 +21222,7 @@
     <Id>skadar</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_zeta" order="3">b_skadar</GameId>
+      <GameId game="CK3">b_skadar</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Shkodër</Name>
@@ -21158,6 +21241,7 @@
       <Name language="Polish">Szkodra</Name>
       <Name language="Romanian">Scutari</Name>
       <Name language="Sardinian">Scutari</Name>
+      <Name language="Serbian_Medieval">Skadar</Name>
       <Name language="Sicilian">Scutari</Name>
       <Name language="Slovene">Skader</Name>
       <Name language="Turkish_Old">Iskodra</Name>
@@ -21168,9 +21252,19 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>moraca</Id>
+    <GameIds>
+      <GameId game="CK3">b_moraca</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Moraca</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>podgorica</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_zeta" order="5">b_podgorica</GameId>
+      <GameId game="CK3">b_ribnicapodgorica</GameId>
     </GameIds>
     <Names>
       <Name language="Dalmatian">Podgorizza</Name>
@@ -21187,6 +21281,8 @@
       <Name language="Pecheneg">Podgoriçe</Name>
       <Name language="Romanian">Podgorița</Name>
       <Name language="Sardinian">Podgorizza</Name>
+      <Name language="Serbian_Medieval">Ribnica</Name>
+      <Name language="Serbian">Podgorica</Name>
       <Name language="Sicilian">Podgorizza</Name>
       <Name language="Turkish_Old">Podgoriçe</Name>
       <Name language="Turkmen_Medieval">Podgoriçe</Name>
@@ -21196,9 +21292,19 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>plav</Id>
+    <GameIds>
+      <GameId game="CK3">b_plav</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Plav</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>ulcinj</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_primorje" order="1">b_ulcinj</GameId>
+      <GameId game="CK3">b_ulcinj</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Ulqin</Name>
@@ -21215,6 +21321,7 @@
       <Name language="Oghuz">Ülgün</Name>
       <Name language="Pecheneg">Ülgün</Name>
       <Name language="Sardinian">Dulcigno</Name>
+      <Name language="Serbian_Medieval">Ulcinj</Name>
       <Name language="Sicilian">Dulcigno</Name>
       <Name language="Turkish_Old">Ülgün</Name>
       <Name language="Turkmen_Medieval">Ülgün</Name>
@@ -21253,8 +21360,29 @@
   <LocationEntity>
     <Id>travunija</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="c_travunija" order="3">b_trebinje</GameId>
       <GameId game="CK2HIP" parent="d_dioclea" order="3">c_travunija</GameId>
+      <GameId game="CK3">c_travunia</GameId>
+    </GameIds>
+    <FallbackLocations>
+      <LocationId>trebinje</LocationId>
+    </FallbackLocations>
+    <Names>
+      <Name language="French">Travounie</Name> <!-- Or Travonie -->
+      <Name language="German">Travunien</Name>
+      <Name language="Gothic_Crimean">Terbounía</Name>
+      <Name language="Greek_Medieval">Terbounía</Name>
+      <Name language="Italian">Travunia</Name>
+      <Name language="Latin">Tribunia</Name>
+      <Name language="Polish">Trawunia</Name>
+      <Name language="Romanian">Travunia</Name>
+      <Name language="Serbian_Medieval">Travunija</Name>
+      <Name language="SerboCroatian">Travunija</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>trebinje</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_travunija" order="3">b_trebinje</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Trebing</Name>
@@ -21269,17 +21397,16 @@
       <Name language="German_Middle_High">Trebing</Name>
       <Name language="German_Middle_Low">Trebing</Name>
       <Name language="German_Old_Low">Trebing</Name>
-      <Name language="Gothic_Crimean">Terbounia</Name>
-      <Name language="Greek_Medieval">Terbounia</Name>
+      <Name language="Gothic_Crimean">Terbounía</Name>
+      <Name language="Greek_Medieval">Terbounía</Name>
       <Name language="Italian_Central">Trebigne</Name>
       <Name language="Italian_Medieval">Trebigne</Name>
       <Name language="Langobardic">Trebigne</Name>
-      <Name language="Latin">Travunia</Name>
       <Name language="Ligurian">Trebigne</Name>
       <Name language="Lithuanian">Trebine</Name>
       <Name language="Neapolitan">Trebigne</Name>
-      <Name language="Romanian">Travunia</Name>
       <Name language="Sardinian">Trebigne</Name>
+      <Name language="Serbian_Medieval">Trebinje</Name> <!-- The region is Travunija -->
       <Name language="Sicilian">Trebigne</Name>
       <Name language="Thuringian">Trebing</Name>
       <Name language="Tuscan">Trebigne</Name>
@@ -31213,9 +31340,10 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>besztercebanya</Id>
+    <Id>breznica</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_bars" order="7">b_besztercebanya</GameId>
+      <GameId game="CK3">b_besztercebanya</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Breznica</Name>
@@ -31226,6 +31354,7 @@
       <Name language="German_Middle_High">Neusohl</Name>
       <Name language="Hungarian_Old_Early">Byztercebanýa</Name>
       <Name language="Hungarian_Old">Besztercebánya</Name>
+      <Name language="Serbian_Medieval">Breznica</Name>
       <Name language="Serbian">Breznica</Name>
       <Name language="Slovak_Medieval">Bánská Bystrica</Name>
       <Name language="Slovak">Breznica</Name>
@@ -38605,6 +38734,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_cornwall" order="1">c_cornwall</GameId>
       <GameId game="CK2HIP" parent="k_england" order="4">d_cornwall</GameId>
+      <GameId game="CK3">k_cornwall</GameId>
     </GameIds>
     <Names>
       <Name language="Breton_Middle">Kernow</Name>
@@ -57376,6 +57506,8 @@
     <Id>prokuplje</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_naissus" order="6">b_prokuplje</GameId>
+      <GameId game="CK3">b_prokuplje</GameId>
+      <GameId game="ImperatorRome">4111</GameId> <!-- Hammeum -->
     </GameIds>
     <Names>
       <Name language="Gothic_Crimean">Komplos</Name>
@@ -57383,6 +57515,7 @@
       <Name language="Latin_Medieval">Hammeum</Name>
       <Name language="Oghuz">Ürgüb</Name>
       <Name language="Pecheneg">Ürgüb</Name>
+      <Name language="Serbian_Medieval">Prokuplje</Name>
       <Name language="Turkish_Old">Ürgüb</Name>
       <Name language="Turkmen_Medieval">Ürgüb</Name>
     </Names>
@@ -57408,6 +57541,9 @@
       <GameId game="CK2HIP" parent="c_macva" order="3">b_macva</GameId>
       <GameId game="CK2HIP" parent="d_macva" order="1">c_macva</GameId>
       <GameId game="CK2HIP" parent="k_serbia" order="2">d_macva</GameId>
+      <GameId game="CK3">b_macva</GameId>
+      <GameId game="CK3">c_macva</GameId>
+      <GameId game="CK3">d_macva</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Matschva</Name>
@@ -57419,14 +57555,25 @@
       <Name language="German_Middle_Low">Matschva</Name>
       <Name language="German_Old_Low">Matschva</Name>
       <Name language="Hungarian_Old">Macsó</Name>
+      <Name language="Serbian_Medieval">Mačva</Name>
       <Name language="Szekely_Old">Macsó</Name>
       <Name language="Thuringian">Matschva</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>krupanj</Id>
+    <GameIds>
+      <GameId game="CK3">b_krupanj</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Krupanj</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>uzice</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_macva" order="1">b_uzice</GameId>
+      <GameId game="CK3">b_uzice</GameId>
     </GameIds>
     <Names>
       <Name language="Gothic_Crimean">Kapedounon</Name>
@@ -57434,6 +57581,7 @@
       <Name language="Latin_Medieval">Capedunum</Name>
       <Name language="Oghuz">Öziçe</Name>
       <Name language="Pecheneg">Öziçe</Name>
+      <Name language="Serbian_Medieval">Užice</Name>
       <Name language="Turkish_Old">Öziçe</Name>
       <Name language="Turkmen_Medieval">Öziçe</Name>
     </Names>
@@ -57478,30 +57626,53 @@
     <Id>brskovo</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_polimlje" order="2">b_brskovo</GameId>
+      <GameId game="CK3">b_brskovo</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Byrsgaw</Name>
       <Name language="Bavarian">Byrsgaw</Name>
-      <Name language="Gothic_Crimean">Breskoua</Name>
       <Name language="Dutch_Middle">Byrsgaw</Name>
+      <Name language="Frankish_Low">Byrsgaw</Name>
       <Name language="Frankish">Byrsgaw</Name>
       <Name language="German_Middle_High">Byrsgaw</Name>
-      <Name language="Greek_Medieval">Breskoua</Name>
-      <Name language="Frankish_Low">Byrsgaw</Name>
       <Name language="German_Middle_Low">Byrsgaw</Name>
       <Name language="German_Old_Low">Byrsgaw</Name>
+      <Name language="Gothic_Crimean">Breskoua</Name>
+      <Name language="Greek_Medieval">Breskoua</Name>
       <Name language="Latin_Medieval">Brescoa</Name>
-      <Name language="Alemannic">Byrsgaw</Name>
+      <Name language="Serbian">Brskovo</Name>
       <Name language="Thuringian">Byrsgaw</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>visegrad_serbia</Id>
+    <GeoNamesId>3042824</GeoNamesId>
+    <GameIds>
+      <GameId game="CK3">b_visegrad</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Višegrad</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gorazde</Id>
+    <GameIds>
+      <GameId game="CK3">b_gorazde</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Goražde</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>prijepolje</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_polimlje" order="3">b_prijepolje</GameId>
+      <GameId game="CK3">b_prijepolje</GameId>
     </GameIds>
     <Names>
       <Name language="Oghuz">Pirepolye</Name>
       <Name language="Pecheneg">Pirepolye</Name>
+      <Name language="Serbian_Medieval">Prijepolje</Name>
       <Name language="Turkish_Old">Pirepolye</Name>
       <Name language="Turkmen_Medieval">Pirepolye</Name>
     </Names>
@@ -57559,6 +57730,7 @@
     <Id>drivast</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_zeta" order="1">b_drivast</GameId>
+      <GameId game="CK3">b_drivast</GameId>
     </GameIds>
     <Names>
       <Name language="Arberian">Drisht</Name>
@@ -57572,6 +57744,7 @@
       <Name language="Ligurian">Drivasto</Name>
       <Name language="Neapolitan">Drivasto</Name>
       <Name language="Sardinian">Drivasto</Name>
+      <Name language="Serbian_Medieval">Drivast</Name>
       <Name language="Sicilian">Drivasto</Name>
       <Name language="Tuscan">Drivasto</Name>
       <Name language="Umbrian_Medieval">Drivasto</Name>
@@ -57579,11 +57752,36 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>danj</Id>
+    <GameIds>
+      <GameId game="CK3">b_danj</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Danj</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>bar</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_primorje" order="2">b_bar</GameId>
+      <GameId game="CK3">b_antivari</GameId>
     </GameIds>
     <Names>
+      <Name language="Arberian">Tivari</Name>
+      <Name language="Dalmatian_Medieval">Antivari</Name>
+      <Name language="Gothic_Crimean">Thivárion</Name>
+      <Name language="Greek_Medieval">Thivárion</Name>
+      <Name language="Italian_Central">Antivari</Name>
+      <Name language="Italian_Medieval">Antivari</Name>
+      <Name language="Langobardic">Antivari</Name>
+      <Name language="Latin_Medieval">Antibarium</Name>
+      <Name language="Ligurian">Antivari</Name>
+      <Name language="Neapolitan">Antivari</Name>
+      <Name language="Sardinian">Antivari</Name>
+      <Name language="Sicilian">Antivari</Name>
+      <Name language="Tuscan_Medieval">Antivari</Name>
+      <Name language="Umbrian_Medieval">Antivari</Name>
+      <Name language="Venetian_Medieval">Antivari</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57591,6 +57789,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_primorje" order="4">b_kotor</GameId>
       <GameId game="CK2HIP" parent="d_dioclea" order="2">c_primorje</GameId>
+      <GameId game="CK3">b_cattaro</GameId>
+      <GameId game="CK3">c_pomorje</GameId>
       <GameId game="ImperatorRome">4091</GameId> <!-- Acruvium -->
     </GameIds>
     <Names>
@@ -57608,6 +57808,7 @@
       <Name language="Oghuz">Kotur</Name>
       <Name language="Pecheneg">Kotur</Name>
       <Name language="Sardinian">Cattaro</Name>
+      <Name language="Serbian_Medieval">Kotor</Name>
       <Name language="Sicilian">Cattaro</Name>
       <Name language="Turkish_Old">Kotur</Name>
       <Name language="Turkmen_Medieval">Kotur</Name>
@@ -57643,11 +57844,23 @@
     <Id>onogost</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_travunija" order="2">b_onogost</GameId>
+      <GameId game="CK3">b_onogost</GameId>
     </GameIds>
     <Names>
       <Name language="Gothic_Crimean">Anagastión</Name>
       <Name language="Greek_Medieval">Anagastión</Name>
       <Name language="Latin_Medieval">Anagastum</Name>
+      <Name language="Serbian_Medieval">Onogošt</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>risan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_travunija" order="2">b_risan</GameId>
+      <GameId game="CK3">b_onogost</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Risan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -83643,16 +83856,64 @@
     <Id>zica</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_rashka" order="4">b_zica</GameId>
+      <GameId game="CK3">b_zica</GameId>
     </GameIds>
     <Names>
+      <Name language="Serbian_Medieval">Žica</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gradac</Id>
+    <GameIds>
+      <GameId game="CK3">b_gradac</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Gradac</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>arilje</Id>
+    <GameIds>
+      <GameId game="CK3">b_arilje</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Arilje</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>rujno</Id>
+    <GameIds>
+      <GameId game="CK3">b_rujno</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Rujno</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sumadija</Id>
+    <GameIds>
+      <GameId game="CK3">c_sumadija</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Šumadija</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>rudnik</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_belgrade" order="1">b_rudnik</GameId>
+      <GameId game="CK3">b_rudnik</GameId>
     </GameIds>
     <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kragujevac</Id>
+    <GameIds>
+      <GameId game="CK3">b_kragujevac</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Serbian_Medieval">Kragujevac</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89760,27 +90021,11 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>antibari</Id>
+    <Id>bari</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_bari" order="3">b_bari</GameId>
     </GameIds>
     <Names>
-      <Name language="Arberian">Tivari</Name>
-      <Name language="Dalmatian_Medieval">Antivari</Name>
-      <Name language="Gothic_Crimean">Thivárion</Name>
-      <Name language="Greek_Medieval">Thivárion</Name>
-      <Name language="Italian_Central">Antivari</Name>
-      <Name language="Italian_Medieval">Antivari</Name>
-      <Name language="Italian_Medieval">Antivari</Name>
-      <Name language="Langobardic">Antivari</Name>
-      <Name language="Latin_Medieval">Antibarium</Name>
-      <Name language="Ligurian">Antivari</Name>
-      <Name language="Neapolitan">Antivari</Name>
-      <Name language="Sardinian">Antivari</Name>
-      <Name language="Sicilian">Antivari</Name>
-      <Name language="Tuscan_Medieval">Antivari</Name>
-      <Name language="Umbrian_Medieval">Antivari</Name>
-      <Name language="Venetian_Medieval">Antivari</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -20540,7 +20540,14 @@
       <GameId game="CK2HIP" parent="e_scandinavia" order="1">k_denmark</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Old_Norse">Danmörk</Name>
+      <Name language="English_Old">Denemearc</Name>
+      <Name language="Icelandic_Old">Danmörk</Name>
+      <Name language="Irish_Middle_Norse">Danmörk</Name>
+      <Name language="Norse">Danmörk</Name>
+      <Name language="Norwegian_Old">Danmörk</Name>
       <Name language="Romanian">Danemarca</Name>
+      <Name language="Swedish_Old">Danmörk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20575,6 +20582,7 @@
     </GameIds>
     <Names>
       <Name language="Danish">Jylland</Name>
+      <Name language="German_Middle_High">Jütland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20584,7 +20592,13 @@
       <GameId game="CK2HIP" parent="k_denmark" order="6">d_bornholm</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Old_Norse">Borgundarhólmi</Name>
+      <Name language="Icelandic_Old">Borgundarhólmi</Name>
+      <Name language="Irish_Middle_Norse">Borgundarhólmi</Name>
       <Name language="Latin">Holmus</Name>
+      <Name language="Norse">Borgundarhólmi</Name>
+      <Name language="Norwegian_Old">Borgundarhólmi</Name>
+      <Name language="Swedish_Old">Borgundarhólmi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20623,10 +20637,11 @@
       <GameId game="CK2HIP" parent="e_scandinavia" order="3">k_sweden</GameId>
     </GameIds>
     <Names>
-      <Name language="Lombard">Svezia</Name>
-      <Name language="Latin">Suecia</Name>
-      <Name language="Romanian">Suedia</Name>
       <Name language="Ladino">Suesia</Name>
+      <Name language="Latin">Suecia</Name>
+      <Name language="Lombard">Svezia</Name>
+      <Name language="Norse">Sviþjod</Name>
+      <Name language="Romanian">Suedia</Name>
       <Name language="Swedish">Svea Rike</Name>
     </Names>
   </LocationEntity>
@@ -20638,8 +20653,9 @@
     <Names>
       <Name language="Castilian">Upsala</Name>
       <Name language="Latgalian">Upsãla</Name>
-      <Name language="Lithuanian">Upsala</Name>
       <Name language="Latin">Upsalia</Name>
+      <Name language="Lithuanian">Upsala</Name>
+      <Name language="Norse">Uppsalir</Name>
       <Name language="Vepsian">Uppsal</Name>
     </Names>
   </LocationEntity>
@@ -20687,10 +20703,13 @@
       <GameId game="CK2HIP" parent="k_sweden" order="2">d_ostergotland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Østergøtland</Name>
+      <Name language="English_Old">Goþanland</Name>
       <Name language="Frisian_Old">Goþanlond</Name>
       <Name language="Latin">Gothia</Name>
+      <Name language="Norse">Austrgautland</Name>
+      <Name language="Norwegian_Old">Austrgautland</Name>
       <Name language="Romanian">Ostrogoția</Name>
-      <Name language="English_Old">Goþanland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20710,6 +20729,7 @@
     </GameIds>
     <Names>
       <Name language="Latin">Morea Australis</Name>
+      <Name language="Norse">Möre</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20739,7 +20759,9 @@
       <GameId game="CK2HIP" parent="c_more" order="4">b_vastervik</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Vestervik</Name>
       <Name language="Latin">Vestavicensia</Name>
+      <Name language="Norwegian_Old">Vestervik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20778,7 +20800,10 @@
       <GameId game="CK2HIP" parent="k_sweden" order="3">d_vastergotland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Lødøse</Name>
       <Name language="French_Old">Gothie Occidentale</Name>
+      <Name language="Norse">Vestrgautland</Name>
+      <Name language="Norwegian_Old">Lødøse</Name>
       <Name language="Romanian">Vizigoția</Name>
     </Names>
   </LocationEntity>
@@ -20816,9 +20841,11 @@
       <GameId game="CK2HIP" parent="c_narke" order="2">b_orebro</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Ørebro</Name>
       <Name language="Latgalian">Erebru</Name>
-      <Name language="Lithuanian">Erebru</Name>
       <Name language="Latin">Orebrogia</Name>
+      <Name language="Lithuanian">Erebru</Name>
+      <Name language="Norwegian_Old">Ørebro</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -21257,12 +21284,18 @@
       <GameId game="CK2HIP" parent="k_vladimir" order="5">d_rostov</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Ráðstofa</Name>
+      <Name language="English_Old_Norse">Ráðstofa</Name>
       <Name language="German">Rostow</Name>
       <Name language="Hungarian">Rosztov</Name>
+      <Name language="Irish_Middle_Norse">Ráðstofa</Name>
       <Name language="Latgalian">Rostova</Name>
-      <Name language="Lithuanian">Rostovas</Name>
-      <Name language="Polish">Rostów</Name>
       <Name language="Latin">Rostovia</Name>
+      <Name language="Lithuanian">Rostovas</Name>
+      <Name language="Norse">Ráðstofa</Name>
+      <Name language="Norwegian_Old">Ráðstofa</Name>
+      <Name language="Polish">Rostów</Name>
+      <Name language="Swedish_Old">Ráðstofa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -21604,10 +21637,16 @@
     </GameIds>
     <Names>
       <Name language="Breton_Middle">Mourom</Name>
+      <Name language="Danish_Middle">Móramar</Name>
       <Name language="Dutch_Middle">Moerom</Name>
+      <Name language="English_Old_Norse">Móramar</Name>
       <Name language="French_Old">Mourom</Name>
-      <Name language="Lithuanian">Muromas</Name>
+      <Name language="Irish_Middle_Norse">Móramar</Name>
       <Name language="Latin">Muromum</Name>
+      <Name language="Lithuanian">Muromas</Name>
+      <Name language="Norse">Móramar</Name>
+      <Name language="Norwegian_Old">Móramar</Name>
+      <Name language="Swedish_Old">Móramar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -21667,18 +21706,24 @@
       <Name language="Bulgarian">Polock</Name>
       <Name language="Croatian">Polock</Name>
       <Name language="Czech">Polock</Name>
+      <Name language="Danish_Middle">Pallteskja</Name>
+      <Name language="English_Old_Norse">Pallteskja</Name>
       <Name language="Estonian">Polack</Name>
       <Name language="German_Middle_Low">Polazk</Name>
       <Name language="German_Old_Low">Polazk</Name>
       <Name language="German">Polazk</Name>
       <Name language="Hungarian">Polack</Name>
+      <Name language="Irish_Middle_Norse">Pallteskja</Name>
       <Name language="Italian">Polack</Name>
       <Name language="Latgalian">Polocka</Name>
       <Name language="Latin">Polotia</Name>
       <Name language="Lithuanian">Polockas</Name>
+      <Name language="Norse">Pallteskja</Name>
+      <Name language="Norwegian_Old">Pallteskja</Name>
       <Name language="Polish">Polock</Name>
       <Name language="Romanian">Poloțk</Name>
       <Name language="Serbian">Polock</Name>
+      <Name language="Swedish_Old">Pallteskja</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -26071,6 +26116,7 @@
       <Name language="Dutch_Middle">Utenen</Name>
       <Name language="Franconian_Lorraine">Utenen</Name>
       <Name language="Frankish_Low">Utenen</Name>
+      <Name language="Frankish">Utenen</Name>
       <Name language="German_Middle_High">Utenen</Name>
       <Name language="German_Middle_Low">Utenen</Name>
       <Name language="German_Old_Low">Utenen</Name>
@@ -26166,6 +26212,7 @@
       <Name language="Dutch_Middle">Aliten</Name>
       <Name language="Franconian_Lorraine">Aliten</Name>
       <Name language="Frankish_Low">Aliten</Name>
+      <Name language="Frankish">Aliten</Name>
       <Name language="German_Middle_High">Aliten</Name>
       <Name language="German_Middle_Low">Aliten</Name>
       <Name language="German_Old_Low">Aliten</Name>
@@ -26188,6 +26235,7 @@
       <Name language="Dutch_Middle">Kauen</Name>
       <Name language="Franconian_Lorraine">Kauen</Name>
       <Name language="Frankish_Low">Kauen</Name>
+      <Name language="Frankish">Kauen</Name>
       <Name language="German_Middle_High">Kauen</Name>
       <Name language="German_Middle_Low">Kauen</Name>
       <Name language="German_Old_Low">Kauen</Name>
@@ -26211,6 +26259,7 @@
       <Name language="Dutch_Middle">Raygrod</Name>
       <Name language="Franconian_Lorraine">Raygrod</Name>
       <Name language="Frankish_Low">Raygrod</Name>
+      <Name language="Frankish">Raygrod</Name>
       <Name language="German_Middle_High">Raygrod</Name>
       <Name language="German_Middle_Low">Raygrod</Name>
       <Name language="German_Old_Low">Raygrod</Name>
@@ -26241,9 +26290,14 @@
     </GameIds>
     <Names>
       <Name language="Castilian">Goradnia</Name>
+      <Name language="Czech_Medieval">Grodno</Name>
       <Name language="Danish">Grodno</Name>
       <Name language="Latgalian">Grodna</Name>
       <Name language="Latin">Grodna</Name>
+      <Name language="Polish_Old">Grodno</Name>
+      <Name language="Russian_Medieval">Goroden</Name>
+      <Name language="Slovak_Medieval">Grodno</Name>
+      <Name language="Sorbian">Grodno</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -26317,7 +26371,20 @@
       <GameId game="CK2HIP" parent="c_memel" order="2">b_jurbarkas</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Georgenburg</Name>
+      <Name language="Bavarian_Medieval">Georgenburg</Name>
+      <Name language="Czech_Medieval">Jurbork</Name>
+      <Name language="Dutch_Middle">Georgenburg</Name>
+      <Name language="Frankish_Low">Georgenburg</Name>
+      <Name language="Frankish">Georgenburg</Name>
+      <Name language="German_Middle_High">Georgenburg</Name>
+      <Name language="German_Middle_Low">Georgenburg</Name>
+      <Name language="German_Old_Low">Georgenburg</Name>
       <Name language="Latgalian">Jurbarka</Name>
+      <Name language="Polish_Old">Jurbork</Name>
+      <Name language="Slovak_Medieval">Jurbork</Name>
+      <Name language="Sorbian">Jurbork</Name>
+      <Name language="Thuringian">Georgenburg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -26326,7 +26393,20 @@
       <GameId game="CK2HIP" parent="c_upyte" order="3">b_birzai</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Birsen</Name>
+      <Name language="Bavarian_Medieval">Birsen</Name>
+      <Name language="Czech_Medieval">Birze</Name>
+      <Name language="Dutch_Middle">Birsen</Name>
+      <Name language="Frankish_Low">Birsen</Name>
+      <Name language="Frankish">Birsen</Name>
+      <Name language="German_Middle_High">Birsen</Name>
+      <Name language="German_Middle_Low">Birsen</Name>
+      <Name language="German_Old_Low">Birsen</Name>
       <Name language="Latgalian">Birži</Name>
+      <Name language="Polish_Old">Birze</Name>
+      <Name language="Slovak_Medieval">Birze</Name>
+      <Name language="Sorbian">Birze</Name>
+      <Name language="Thuringian">Birsen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -26337,32 +26417,34 @@
     <Names>
       <Name language="Basque">Prusia</Name>
       <Name language="Bosnian">Prusija</Name>
-      <Name language="Slovene">Prusija</Name>
       <Name language="Castilian">Prusia</Name>
       <Name language="Catalan">Prússia</Name>
       <Name language="Croatian">Prusija</Name>
+      <Name language="Czech_Medieval">Prusy</Name>
       <Name language="Danish">Prøjsen</Name>
       <Name language="Dutch_Middle">Pruisen</Name>
       <Name language="Finnish">Preussi</Name>
       <Name language="French_Old">Prusse</Name>
+      <Name language="German_Middle_Low">Preußen</Name>
+      <Name language="German_Old_Low">Praissen</Name>
       <Name language="German">Preußen</Name>
       <Name language="Irish">An Phrúis</Name>
       <Name language="Italian">Prussia</Name>
+      <Name language="Latin">Borussia</Name>
       <Name language="Lithuanian">Prūsija</Name>
-      <Name language="German_Middle_Low">Preußen</Name>
-      <Name language="German_Old_Low">Praissen</Name>
       <Name language="Neapolitan">Prussia</Name>
       <Name language="Norwegian">Preussen</Name>
       <Name language="Occitan">Prússia</Name>
       <Name language="Polish">Prusy</Name>
       <Name language="Portuguese">Prússia</Name>
-      <Name language="Latin">Borussia</Name>
       <Name language="Romanian">Prusia</Name>
       <Name language="Russian">Prussija</Name>
       <Name language="Sardinian">Prùssia</Name>
       <Name language="Scottish_Medieval">A' Phruis</Name>
       <Name language="Serbian">Prusija</Name>
       <Name language="Sicilian">Prussia</Name>
+      <Name language="Slovak_Medieval">Prusy</Name>
+      <Name language="Slovene">Prusija</Name>
       <Name language="Turkish">Prusya</Name>
       <Name language="Welsh">Prwsia</Name>
     </Names>
@@ -26382,7 +26464,14 @@
       <GameId game="CK2HIP" parent="c_marienburg" order="2">b_frombork</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Frombork</Name>
+      <Name language="Latgalian">Scrando</Name>
       <Name language="Latin">Frauenburgum</Name>
+      <Name language="Lithuanian_Medieval">Scrando</Name>
+      <Name language="Livonian">Scrando</Name>
+      <Name language="Polish_Old">Frombork</Name>
+      <Name language="Prussian_Old">Scrando</Name>
+      <Name language="Sorbian">Frombork</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -26391,6 +26480,13 @@
       <GameId game="CK2HIP" parent="c_galindia" order="1">b_sensburg</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Zadzbork</Name>
+      <Name language="Latgalian">Senas</Name>
+      <Name language="Lithuanian_Medieval">Senas</Name>
+      <Name language="Livonian">Senas</Name>
+      <Name language="Polish_Old">Zadzbork</Name>
+      <Name language="Prussian_Old">Senas</Name>
+      <Name language="Sorbian">Zadzbork</Name>
       <Name language="Vepsian">Mrongovo</Name>
     </Names>
   </LocationEntity>
@@ -48119,7 +48215,23 @@
       <GameId game="CK2HIP" parent="d_barcelona" order="4">c_girona</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Jarunda</Name>
+      <Name language="Arabic_Bedouin">Jarunda</Name>
+      <Name language="Arabic_Egypt">Jarunda</Name>
+      <Name language="Arabic_Levant">Jarunda</Name>
+      <Name language="Arabic_Maghreb">Jarunda</Name>
+      <Name language="Arabic_Yemen">Jarunda</Name>
+      <Name language="Aragonese">Chirona</Name>
+      <Name language="Castilian">Gerona</Name>
       <Name language="Dutch_Middle">Gerona</Name>
+      <Name language="French_Old">Gérone</Name>
+      <Name language="Galician">Xirona</Name>
+      <Name language="Greek_Medieval">Gerounda</Name>
+      <Name language="Hejazi_Arabic">Jarunda</Name>
+      <Name language="Latin_Medieval">Gerunda</Name>
+      <Name language="Leonese">Xerona</Name>
+      <Name language="Portuguese">Gerunda</Name>
+      <Name language="Sicilian_Arabic">Jarunda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48128,7 +48240,15 @@
       <GameId game="CK2HIP" parent="c_girona" order="6">b_ripoll</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ribbul</Name>
+      <Name language="Arabic_Bedouin">Ribbul</Name>
+      <Name language="Arabic_Egypt">Ribbul</Name>
+      <Name language="Arabic_Levant">Ribbul</Name>
+      <Name language="Arabic_Maghreb">Ribbul</Name>
+      <Name language="Arabic_Yemen">Ribbul</Name>
+      <Name language="Hejazi_Arabic">Ribbul</Name>
       <Name language="Latin">Rivipullo</Name>
+      <Name language="Sicilian_Arabic">Ribbul</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48138,7 +48258,19 @@
       <GameId game="CK2HIP" parent="k_aquitaine" order="11">d_urgell</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Urgil</Name>
+      <Name language="Arabic_Bedouin">Urgil</Name>
+      <Name language="Arabic_Egypt">Urgil</Name>
+      <Name language="Arabic_Levant">Urgil</Name>
+      <Name language="Arabic_Maghreb">Urgil</Name>
+      <Name language="Arabic_Yemen">Urgil</Name>
+      <Name language="Aragonese">Urchel</Name>
+      <Name language="Basque">Urtxelu</Name>
+      <Name language="Castilian">Urgel</Name>
+      <Name language="Hejazi_Arabic">Urgil</Name>
       <Name language="Latin">Julia Libyca</Name>
+      <Name language="Leonese">Urgel</Name>
+      <Name language="Sicilian_Arabic">Urgil</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48156,18 +48288,35 @@
       <GameId game="CK2HIP" order="7409">e_spain</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Isbaniyya</Name>
+      <Name language="Arabic_Bedouin">Isbaniyya</Name>
+      <Name language="Arabic_Egypt">Isbaniyya</Name>
+      <Name language="Arabic_Levant">Isbaniyya</Name>
+      <Name language="Arabic_Maghreb">Isbaniyya</Name>
+      <Name language="Arabic_Yemen">Isbaniyya</Name>
+      <Name language="Aragonese">Espanya</Name>
       <Name language="Armenian">Ispania</Name>
+      <Name language="Basque">Espainia</Name>
       <Name language="Breton_Middle">Spagn</Name>
       <Name language="Bulgarian">Ispanija</Name>
+      <Name language="Catalan_Medieval">Espanya</Name>
       <Name language="Danish">Spanien</Name>
       <Name language="Dutch_Middle">Spanje</Name>
+      <Name language="English_Old">Speonland</Name>
+      <Name language="Estonian">Hispaania</Name>
       <Name language="Finnish">Espanja</Name>
+      <Name language="French_Old">Espagne</Name>
       <Name language="Frisian_Old">Spanje</Name>
+      <Name language="Galician">España</Name>
       <Name language="German">Spanien</Name>
+      <Name language="Hejazi_Arabic">Isbaniyya</Name>
       <Name language="Irish">An Spáinn</Name>
       <Name language="Italian">Spagna</Name>
       <Name language="Kurdish">Spanya</Name>
+      <Name language="Ladino">Espanya</Name>
       <Name language="Latgalian">Spanija</Name>
+      <Name language="Latin">Hispania</Name>
+      <Name language="Leonese">España</Name>
       <Name language="Lithuanian">Ispanija</Name>
       <Name language="Lombard">Spagna</Name>
       <Name language="Mongol_Proto">Ispani</Name>
@@ -48178,16 +48327,13 @@
       <Name language="Occitan">Espanha</Name>
       <Name language="Pictish">Sbaen</Name>
       <Name language="Polish">Hiszpania</Name>
+      <Name language="Portuguese">Espanha</Name>
       <Name language="Prussian_Old">Spanija</Name>
-      <Name language="Latin">Hispania</Name>
       <Name language="Romanian">Spania</Name>
       <Name language="Russian">Ispaniya</Name>
-      <Name language="English_Old">Speonland</Name>
-      <Name language="Ladino">Espanya</Name>
-      <Name language="Alemannic">swabiana</Name>
+      <Name language="Sicilian_Arabic">Isbaniyya</Name>
       <Name language="Swedish">Spanien</Name>
       <Name language="Turkish">Ispanya</Name>
-      <Name language="Estonian">Hispaania</Name>
       <Name language="Welsh">Sbaen</Name>
     </Names>
   </LocationEntity>
@@ -48199,27 +48345,42 @@
     </GameIds>
     <Names>
       <Name language="Alemannic">Castellae</Name>
+      <Name language="Arabic_Andalusia">Qashtála</Name>
+      <Name language="Arabic_Bedouin">Qashtála</Name>
+      <Name language="Arabic_Egypt">Qashtála</Name>
+      <Name language="Arabic_Levant">Qashtála</Name>
+      <Name language="Arabic_Maghreb">Qashtála</Name>
+      <Name language="Arabic_Yemen">Qashtála</Name>
+      <Name language="Aragonese">Castiella</Name>
+      <Name language="Basque">Gaztela</Name>
       <Name language="Bulgarian">Kastilija</Name>
+      <Name language="Catalan_Medieval">Castella</Name>
       <Name language="Croatian">Kastilja</Name>
       <Name language="Czech">Kastilsko</Name>
       <Name language="Danish">Castilien</Name>
       <Name language="English_Old">Castellae</Name>
       <Name language="Estonian">Kastiilia</Name>
       <Name language="Finnish">Kastiilia</Name>
+      <Name language="French_Old">Castille</Name>
+      <Name language="Galician">Castela</Name>
       <Name language="German">Kastilien</Name>
       <Name language="Gothic">Castellae</Name>
       <Name language="Greek_Medieval">Kastilli</Name>
+      <Name language="Hejazi_Arabic">Qashtála</Name>
       <Name language="Italian">Castiglia</Name>
       <Name language="Latgalian">Kastilija</Name>
       <Name language="Latin">Castellae</Name>
+      <Name language="Leonese">Castiella</Name>
       <Name language="Lithuanian">Kastilija</Name>
       <Name language="Lombard">Castellae</Name>
       <Name language="Nahuatl">Caxtillan</Name>
       <Name language="Occitan">Castelha</Name>
       <Name language="Polish">Kastylia</Name>
+      <Name language="Portuguese">Castela</Name>
       <Name language="Romanian">Castilia</Name>
       <Name language="Russian">Kastiliya</Name>
       <Name language="Serbian">Kastilja</Name>
+      <Name language="Sicilian_Arabic">Qashtála</Name>
       <Name language="Swedish">Kastilien</Name>
       <Name language="Welsh">Castil</Name>
       <Name language="Yiddish">Kastille</Name>
@@ -48232,9 +48393,19 @@
       <GameId game="CK2HIP" parent="d_castilla" order="1">c_burgos</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Burghush</Name>
+      <Name language="Arabic_Bedouin">Burghush</Name>
+      <Name language="Arabic_Egypt">Burghush</Name>
+      <Name language="Arabic_Levant">Burghush</Name>
+      <Name language="Arabic_Maghreb">Burghush</Name>
+      <Name language="Arabic_Yemen">Burghush</Name>
+      <Name language="Catalan_Medieval">Burchs</Name>
+      <Name language="French_Old">Bourges</Name>
+      <Name language="Hejazi_Arabic">Burghush</Name>
       <Name language="Latgalian">Burgosa</Name>
-      <Name language="Lithuanian">Burgosas</Name>
       <Name language="Latin">Burgi</Name>
+      <Name language="Lithuanian">Burgosas</Name>
+      <Name language="Sicilian_Arabic">Burghush</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48243,7 +48414,22 @@
       <GameId game="CK2HIP" parent="c_burgos" order="5">b_castrojeriz</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at Shigrit</Name>
+      <Name language="Arabic_Bedouin">Qal'at Shigrit</Name>
+      <Name language="Arabic_Egypt">Qal'at Shigrit</Name>
+      <Name language="Arabic_Levant">Qal'at Shigrit</Name>
+      <Name language="Arabic_Maghreb">Qal'at Shigrit</Name>
+      <Name language="Arabic_Yemen">Qal'at Shigrit</Name>
+      <Name language="Aragonese">Castrocheríz</Name>
+      <Name language="Basque">Kastroxeritz</Name>
+      <Name language="Catalan_Medieval">Castrasoritz</Name>
+      <Name language="French_Old">Châteauséri</Name>
+      <Name language="Galician">Castroxeriz</Name>
+      <Name language="Hejazi_Arabic">Qal'at Shigrit</Name>
       <Name language="Latin">Castro Obarto</Name>
+      <Name language="Leonese">Castroxeriz</Name>
+      <Name language="Portuguese">Alcácer do Geriz</Name>
+      <Name language="Sicilian_Arabic">Qal'at Shigrit</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48252,8 +48438,18 @@
       <GameId game="CK2HIP" parent="c_burgos" order="7">b_frias</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Frit</Name>
+      <Name language="Arabic_Bedouin">al-Frit</Name>
+      <Name language="Arabic_Egypt">al-Frit</Name>
+      <Name language="Arabic_Levant">al-Frit</Name>
+      <Name language="Arabic_Maghreb">al-Frit</Name>
+      <Name language="Arabic_Yemen">al-Frit</Name>
       <Name language="Aragonese">Millars</Name>
+      <Name language="Catalan_Medieval">Frïes</Name>
+      <Name language="Hejazi_Arabic">al-Frit</Name>
+      <Name language="Leonese">Fríes</Name>
       <Name language="Occitan">Millars</Name>
+      <Name language="Sicilian_Arabic">al-Frit</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48346,10 +48542,18 @@
       <GameId game="CK2HIP" parent="c_asturias_de_santillana" order="3">b_santander</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sanemder</Name>
+      <Name language="Arabic_Bedouin">Sanemder</Name>
+      <Name language="Arabic_Egypt">Sanemder</Name>
+      <Name language="Arabic_Levant">Sanemder</Name>
+      <Name language="Arabic_Maghreb">Sanemder</Name>
+      <Name language="Arabic_Yemen">Sanemder</Name>
       <Name language="Basque">Sanandere</Name>
+      <Name language="Hejazi_Arabic">Sanemder</Name>
       <Name language="Latgalian">Santandera</Name>
-      <Name language="Lithuanian">Santanderas</Name>
       <Name language="Latin">Portus Victoriae Iuliobrigensium</Name>
+      <Name language="Lithuanian">Santanderas</Name>
+      <Name language="Sicilian_Arabic">Sanemder</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48358,7 +48562,17 @@
       <GameId game="CK2HIP" parent="c_asturias_de_santillana" order="5">b_laredo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Larat</Name>
+      <Name language="Arabic_Bedouin">Larat</Name>
+      <Name language="Arabic_Egypt">Larat</Name>
+      <Name language="Arabic_Levant">Larat</Name>
+      <Name language="Arabic_Maghreb">Larat</Name>
+      <Name language="Arabic_Yemen">Larat</Name>
+      <Name language="French_Old">Larède</Name>
+      <Name language="Hejazi_Arabic">Larat</Name>
       <Name language="Latin">Noega Uescia</Name>
+      <Name language="Leonese">Laréu</Name>
+      <Name language="Sicilian_Arabic">Larat</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -48368,7 +48582,19 @@
       <GameId game="CK2HIP" parent="d_castilla" order="5">c_palencia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Belansiya</Name>
+      <Name language="Arabic_Bedouin">Belansiya</Name>
+      <Name language="Arabic_Egypt">Belansiya</Name>
+      <Name language="Arabic_Levant">Belansiya</Name>
+      <Name language="Arabic_Maghreb">Belansiya</Name>
+      <Name language="Arabic_Yemen">Belansiya</Name>
+      <Name language="Basque">Palentzia</Name>
+      <Name language="Catalan_Medieval">Palència</Name>
+      <Name language="French_Old">Palence</Name>
+      <Name language="Hejazi_Arabic">Belansiya</Name>
       <Name language="Latin">Pallantia</Name>
+      <Name language="Portuguese">Palência</Name>
+      <Name language="Sicilian_Arabic">Belansiya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56057,6 +56283,7 @@
       <GameId game="CK2HIP" parent="c_jylland" order="2">b_randers</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Randrosi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56065,6 +56292,7 @@
       <GameId game="CK2HIP" parent="c_jylland" order="5">b_aarhus</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Árós</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56073,6 +56301,7 @@
       <GameId game="CK2HIP" parent="c_central_jylland" order="4">b_jelling</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Ialang</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56081,6 +56310,7 @@
       <GameId game="CK2HIP" parent="c_northeastern_jylland" order="1">b_aalborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Alabu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56089,6 +56319,7 @@
       <GameId game="CK2HIP" parent="d_jylland" order="4">c_northern_jylland</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Vendill</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56097,6 +56328,7 @@
       <GameId game="CK2HIP" parent="c_northern_jylland" order="3">b_hjoerring</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Jörungr</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56107,6 +56339,11 @@
       <GameId game="CK2HIP" parent="k_denmark" order="5">d_slesvig</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Old_Norse">Sillendi</Name>
+      <Name language="English_Old">Sillende</Name>
+      <Name language="Frisian_West">Sleeswyk</Name>
+      <Name language="German_Middle_High">Schleswig</Name>
+      <Name language="German_Middle_Low">Sleswig</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56115,6 +56352,8 @@
       <GameId game="CK2HIP" parent="c_slesvig" order="1">b_gottorp</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Gottorf</Name>
+      <Name language="German_Middle_Low">Gottorp</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56123,6 +56362,8 @@
       <GameId game="CK2HIP" parent="c_slesvig" order="2">b_roest</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Roest</Name>
+      <Name language="German_Middle_Low">Röst</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56131,6 +56372,8 @@
       <GameId game="CK2HIP" parent="c_slesvig" order="3">b_egernfoerde</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Eckernförde</Name>
+      <Name language="German_Middle_Low">Eckernföör</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56139,6 +56382,8 @@
       <GameId game="CK2HIP" parent="c_slesvig" order="4">b_flensborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Frisian_West">Flensborag</Name>
+      <Name language="German_Middle_High">Flensburg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56147,6 +56392,12 @@
       <GameId game="CK2HIP" parent="c_slesvig" order="5">b_hedeby</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Haithabu</Name>
+      <Name language="German_Middle_Low">Haithabu</Name>
+      <Name language="German_Old_Low">Haithabu</Name>
+      <Name language="Icelandic_Old">Heiðabyr</Name>
+      <Name language="Norse">Heiðabyr</Name>
+      <Name language="Norwegian_Old">Heiðabyr</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56155,6 +56406,13 @@
       <GameId game="CK2HIP" parent="d_slesvig" order="2">c_southern_jylland</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Old">Sillende</Name>
+      <Name language="German_Middle_High">Süderjütland</Name>
+      <Name language="Icelandic_Old">Sillendi</Name>
+      <Name language="Irish_Middle_Norse">Sillendi</Name>
+      <Name language="Norse">Sillendi</Name>
+      <Name language="Norwegian_Old">Sillendi</Name>
+      <Name language="Swedish_Old">Sillendi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56163,6 +56421,8 @@
       <GameId game="CK2HIP" parent="c_southern_jylland" order="1">b_tonder</GameId>
     </GameIds>
     <Names>
+      <Name language="Frisian_West">Tuner</Name>
+      <Name language="German_Middle_High">Tondern</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56171,6 +56431,7 @@
       <GameId game="CK2HIP" parent="c_southern_jylland" order="2">b_haderslev</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Hadersleben</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56179,6 +56440,7 @@
       <GameId game="CK2HIP" parent="c_southern_jylland" order="3">b_aabenraa</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Apenrade</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56187,14 +56449,18 @@
       <GameId game="CK2HIP" parent="c_southern_jylland" order="5">b_sonderborg</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Sonderburg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>north_frisia</Id>
+    <Id>utland</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_slesvig" order="3">c_north_frisia</GameId>
+      <GameId game="CK2HIP" parent="k_denmark" order="7">d_nordfrisland</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Außenlande</Name>
+      <Name language="German_Middle_Low">Uthlande</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56203,6 +56469,8 @@
       <GameId game="CK2HIP" parent="c_north_frisia" order="1">b_tonningfriesland</GameId>
     </GameIds>
     <Names>
+      <Name language="Frisian_West">Taning</Name>
+      <Name language="German_Middle_High">Tönning</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56211,6 +56479,7 @@
       <GameId game="CK2HIP" parent="c_north_frisia" order="2">b_tetenbull</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Tetenbüll</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56219,6 +56488,9 @@
       <GameId game="CK2HIP" parent="c_north_frisia" order="3">b_garding</GameId>
     </GameIds>
     <Names>
+      <Name language="Frisian_West">Gaarn</Name>
+      <Name language="German_Middle_High">Gerdingen</Name>
+      <Name language="German_Middle_Low">Gaarn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56227,6 +56499,8 @@
       <GameId game="CK2HIP" parent="c_north_frisia" order="4">b_pelvorm</GameId>
     </GameIds>
     <Names>
+      <Name language="Frisian_West">Pälweerm</Name>
+      <Name language="German_Middle_High">Pellworm</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56235,14 +56509,8 @@
       <GameId game="CK2HIP" parent="c_north_frisia" order="5">b_leck</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>nordfrisland</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="k_denmark" order="7">d_nordfrisland</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Frisian_West">Leek</Name>
+      <Name language="German_Middle_High">Leck</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56251,6 +56519,7 @@
       <GameId game="CK2HIP" parent="k_sweden" order="1">d_uppland</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Sviþjod</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56259,6 +56528,8 @@
       <GameId game="CK2HIP" parent="c_fjadrundaland" order="1">b_enkoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Enkøbing</Name>
+      <Name language="Norwegian_Old">Enkøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56267,6 +56538,8 @@
       <GameId game="CK2HIP" parent="c_fjadrundaland" order="2">b_alsno</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Alsnø</Name>
+      <Name language="Norwegian_Old">Alsnø</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56275,6 +56548,8 @@
       <GameId game="CK2HIP" parent="d_uppland" order="4">c_gastrikland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Gestrikland</Name>
+      <Name language="Norwegian_Old">Gestrikland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56283,6 +56558,8 @@
       <GameId game="CK2HIP" parent="c_gastrikland" order="6">b_farnebo</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Færnebo</Name>
+      <Name language="Norwegian_Old">Færnebo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56291,6 +56568,8 @@
       <GameId game="CK2HIP" parent="c_aland" order="6">b_finstrom</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Finstrøm</Name>
+      <Name language="Norwegian_Old">Finstrøm</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56299,6 +56578,8 @@
       <GameId game="CK2HIP" parent="c_aland" order="7">b_eckero</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Eckerø</Name>
+      <Name language="Norwegian_Old">Eckerø</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56307,6 +56588,8 @@
       <GameId game="CK2HIP" parent="c_ostergotland" order="3">b_soderkoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Søderkøbing</Name>
+      <Name language="Norwegian_Old">Søderkøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56315,6 +56598,8 @@
       <GameId game="CK2HIP" parent="c_ostergotland" order="4">b_linkoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Linkøbing</Name>
+      <Name language="Norwegian_Old">Linkøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56323,6 +56608,8 @@
       <GameId game="CK2HIP" parent="c_ostergotland" order="5">b_skanninge</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Skænninge</Name>
+      <Name language="Norwegian_Old">Skænninge</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56331,6 +56618,8 @@
       <GameId game="CK2HIP" parent="c_ostergotland" order="6">b_norrkoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Norrkøbing</Name>
+      <Name language="Norwegian_Old">Norrkøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56339,6 +56628,8 @@
       <GameId game="CK2HIP" parent="d_ostergotland" order="3">c_oland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Øland</Name>
+      <Name language="Norwegian_Old">Øland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56347,6 +56638,8 @@
       <GameId game="CK2HIP" parent="c_smaland" order="1">b_nasborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Næsborg</Name>
+      <Name language="Norwegian_Old">Næsborg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56355,6 +56648,8 @@
       <GameId game="CK2HIP" parent="c_smaland" order="3">b_jonkoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Jønkøbing</Name>
+      <Name language="Norwegian_Old">Jønkøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56363,6 +56658,8 @@
       <GameId game="CK2HIP" parent="c_skara" order="1">b_galakvist</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Gælakvist</Name>
+      <Name language="Norwegian_Old">Gælakvist</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56371,6 +56668,8 @@
       <GameId game="CK2HIP" parent="c_skara" order="3">b_lacko</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Læckø</Name>
+      <Name language="Norwegian_Old">Læckø</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56379,6 +56678,15 @@
       <GameId game="CK2HIP" parent="c_skara" order="4">b_arneasborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Arnis</Name>
+      <Name language="Bavarian_Medieval">Arnis</Name>
+      <Name language="Dutch_Middle">Arnis</Name>
+      <Name language="Frankish_Low">Arnis</Name>
+      <Name language="Frankish">Arnis</Name>
+      <Name language="German_Middle_High">Arnis</Name>
+      <Name language="German_Middle_Low">Arnis</Name>
+      <Name language="German_Old_Low">Arnis</Name>
+      <Name language="Thuringian">Arnis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56387,6 +56695,8 @@
       <GameId game="CK2HIP" parent="c_vastergotland" order="1">b_falkoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Falkøbing</Name>
+      <Name language="Norwegian_Old">Falkøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56395,6 +56705,8 @@
       <GameId game="CK2HIP" parent="c_vastergotland" order="4">b_lodose</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Lødøse</Name>
+      <Name language="Norwegian_Old">Lødøse</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56403,6 +56715,8 @@
       <GameId game="CK2HIP" parent="d_sodermandland" order="1">c_varmland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Værmland</Name>
+      <Name language="Norwegian_Old">Vermland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56411,6 +56725,7 @@
       <GameId game="CK2HIP" parent="d_sodermandland" order="2">c_narke</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Nerke</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56419,6 +56734,8 @@
       <GameId game="CK2HIP" parent="c_narke" order="1">b_goksholm</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Gøksholm</Name>
+      <Name language="Norwegian_Old">Gøksholm</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56427,6 +56744,8 @@
       <GameId game="CK2HIP" parent="d_sodermandland" order="3">c_sodermanland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Sødermanland</Name>
+      <Name language="Norwegian_Old">Sødermanland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56435,6 +56754,8 @@
       <GameId game="CK2HIP" parent="c_sodermanland" order="3">b_torshalla</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Torshælla</Name>
+      <Name language="Norwegian_Old">Torshælla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56443,6 +56764,8 @@
       <GameId game="CK2HIP" parent="c_sodermanland" order="4">b_strangnas</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Strængnæs</Name>
+      <Name language="Norwegian_Old">Strængnes</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56451,6 +56774,8 @@
       <GameId game="CK2HIP" parent="c_sodermanland" order="5">b_nykoping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Nykøbing</Name>
+      <Name language="Norwegian_Old">Nykøping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56459,6 +56784,8 @@
       <GameId game="CK2HIP" parent="c_sodermanland" order="7">b_vaderbrunn</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Væderbrunn</Name>
+      <Name language="Norwegian_Old">Væderbrunn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56467,6 +56794,8 @@
       <GameId game="CK2HIP" parent="d_sodermandland" order="4">c_vastmanland</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Vestmanland</Name>
+      <Name language="Norwegian_Old">Vestmanland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56475,6 +56804,8 @@
       <GameId game="CK2HIP" parent="c_vastmanland" order="1">b_vasteras</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Vesterås</Name>
+      <Name language="Norwegian_Old">Vesterås</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56483,6 +56814,8 @@
       <GameId game="CK2HIP" parent="c_vastmanland" order="3">b_kopingshus</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Købingshus</Name>
+      <Name language="Norwegian_Old">Køpingshus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56491,6 +56824,8 @@
       <GameId game="CK2HIP" parent="c_vastmanland" order="4">b_koping</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Købing</Name>
+      <Name language="Norwegian_Old">Køping</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56499,6 +56834,8 @@
       <GameId game="CK2HIP" parent="d_halsingland" order="3">c_dalarna</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Jernbæraland</Name>
+      <Name language="Norwegian_Old">Jernbæraland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56507,6 +56844,8 @@
       <GameId game="CK2HIP" parent="c_angermanland" order="1">b_bjartra</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Bjærtrå</Name>
+      <Name language="Norwegian_Old">Bjertrå</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56515,6 +56854,8 @@
       <GameId game="CK2HIP" parent="c_angermanland" order="2">b_ulvo</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Ulvø</Name>
+      <Name language="Norwegian_Old">Ulvø</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56523,6 +56864,8 @@
       <GameId game="CK2HIP" parent="c_angermanland" order="4">b_skulnas</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Skulnæs</Name>
+      <Name language="Norwegian_Old">Skulnes</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56531,6 +56874,8 @@
       <GameId game="CK2HIP" parent="c_angermanland" order="6">b_harnosand</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Hærnøsand</Name>
+      <Name language="Norwegian_Old">Hærnøsand</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56539,6 +56884,8 @@
       <GameId game="CK2HIP" parent="c_angermanland" order="7">b_ornskoldsvik</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Ørnskøldsvik</Name>
+      <Name language="Norwegian_Old">Ørnskøldsvik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56547,6 +56894,8 @@
       <GameId game="CK2HIP" parent="c_medelpad" order="2">b_alno</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Alnø</Name>
+      <Name language="Norwegian_Old">Alnø</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56555,6 +56904,8 @@
       <GameId game="CK2HIP" parent="c_medelpad" order="4">b_skon</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Skøn</Name>
+      <Name language="Norwegian_Old">Skøn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56563,6 +56914,8 @@
       <GameId game="CK2HIP" parent="c_halsingland" order="3">b_jattendal</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Jættendal</Name>
+      <Name language="Norwegian_Old">Jættendal</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56571,6 +56924,7 @@
       <GameId game="CK2HIP" parent="c_akershus" order="2">b_thorso</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Tosowe</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56635,6 +56989,7 @@
       <GameId game="CK2HIP" parent="c_akershus" order="5">b_sarpsborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Saresburgh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56643,6 +56998,7 @@
       <GameId game="CK2HIP" parent="c_viken" order="3">b_bohus</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Bagahuus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56659,6 +57015,7 @@
       <GameId game="CK2HIP" parent="c_trondelag" order="2">b_sverresborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Sverresburgh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56667,6 +57024,14 @@
       <GameId game="CK2HIP" parent="c_steinkjer" order="4">b_steinkjer</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Stientjie</Name>
+      <Name language="Finnish">Stientjie</Name>
+      <Name language="Karelian">Stientjie</Name>
+      <Name language="Livonian">Stientjie</Name>
+      <Name language="Moksha">Stientjie</Name>
+      <Name language="Sami">Stientjie</Name>
+      <Name language="Samoyed">Stientjie</Name>
+      <Name language="Vepsian_Medieval">Stientjie</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56675,6 +57040,13 @@
       <GameId game="CK2HIP" parent="c_finnmark" order="4">b_vaagan</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Vuogát</Name>
+      <Name language="Finnish">Vuogát</Name>
+      <Name language="Karelian">Vuogát</Name>
+      <Name language="Moksha">Vuogát</Name>
+      <Name language="Sami">Vuogát</Name>
+      <Name language="Samoyed">Vuogát</Name>
+      <Name language="Vepsian_Medieval">Vuogát</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57005,6 +57377,10 @@
       <GameId game="CK2HIP" parent="c_utena" order="2">b_tauragnai</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Tauroginy</Name>
+      <Name language="Polish_Old">Tauroginy</Name>
+      <Name language="Slovak_Medieval">Tauroginy</Name>
+      <Name language="Sorbian">Tauroginy</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57058,6 +57434,11 @@
       <GameId game="CK2HIP" parent="c_lida" order="1">b_shchuchyn</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Szczuczyn</Name>
+      <Name language="Polish_Old">Szczuczyn</Name>
+      <Name language="Russian_Medieval">Szczuczyn</Name>
+      <Name language="Slovak_Medieval">Szczuczyn</Name>
+      <Name language="Sorbian">Szczuczyn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57066,6 +57447,11 @@
       <GameId game="CK2HIP" parent="c_lida" order="3">b_astryna</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Ostryna</Name>
+      <Name language="Polish_Old">Ostryna</Name>
+      <Name language="Russian_Medieval">Ostryna</Name>
+      <Name language="Slovak_Medieval">Ostryna</Name>
+      <Name language="Sorbian">Ostryna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57076,6 +57462,19 @@
       <GameId game="CK2HIP" parent="k_lithuania" order="2">d_trakai</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Traken</Name>
+      <Name language="Bavarian_Medieval">Traken</Name>
+      <Name language="Czech_Medieval">Trokaj</Name>
+      <Name language="Dutch_Middle">Traken</Name>
+      <Name language="Frankish_Low">Traken</Name>
+      <Name language="Frankish">Traken</Name>
+      <Name language="German_Middle_High">Traken</Name>
+      <Name language="German_Middle_Low">Traken</Name>
+      <Name language="German_Old_Low">Traken</Name>
+      <Name language="Polish_Old">Troki</Name>
+      <Name language="Slovak_Medieval">Trokaj</Name>
+      <Name language="Sorbian">Troki</Name>
+      <Name language="Thuringian">Traken</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57084,6 +57483,19 @@
       <GameId game="CK2HIP" parent="c_trakai" order="1">b_raudondvaris</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Rotenhof</Name>
+      <Name language="Bavarian_Medieval">Rotenhof</Name>
+      <Name language="Czech_Medieval">Czervený Dvúr</Name>
+      <Name language="Dutch_Middle">Rotenhof</Name>
+      <Name language="Frankish_Low">Rotenhof</Name>
+      <Name language="Frankish">Rotenhof</Name>
+      <Name language="German_Middle_High">Rotenhof</Name>
+      <Name language="German_Middle_Low">Rotenhof</Name>
+      <Name language="German_Old_Low">Rotenhof</Name>
+      <Name language="Polish_Old">Czerwony Dwór</Name>
+      <Name language="Slovak_Medieval">Czerwony Dwór</Name>
+      <Name language="Sorbian">Czerwony Dwór</Name>
+      <Name language="Thuringian">Rotenhof</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57092,6 +57504,19 @@
       <GameId game="CK2HIP" parent="c_trakai" order="3">b_birstonas</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Birschtannen</Name>
+      <Name language="Bavarian_Medieval">Birschtannen</Name>
+      <Name language="Czech_Medieval">Birštany</Name>
+      <Name language="Dutch_Middle">Birschtannen</Name>
+      <Name language="Frankish_Low">Birschtannen</Name>
+      <Name language="Frankish">Birschtannen</Name>
+      <Name language="German_Middle_High">Birschtannen</Name>
+      <Name language="German_Middle_Low">Birschtannen</Name>
+      <Name language="German_Old_Low">Birschtannen</Name>
+      <Name language="Polish_Old">Birsztany</Name>
+      <Name language="Slovak_Medieval">Birštany</Name>
+      <Name language="Sorbian">Birsztany</Name>
+      <Name language="Thuringian">Birschtannen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57100,6 +57525,15 @@
       <GameId game="CK2HIP" parent="d_trakai" order="2">c_sudovia</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Sudauen</Name>
+      <Name language="Bavarian_Medieval">Sudauen</Name>
+      <Name language="Dutch_Middle">Sudauen</Name>
+      <Name language="Frankish_Low">Sudauen</Name>
+      <Name language="Frankish">Sudauen</Name>
+      <Name language="German_Middle_High">Sudauen</Name>
+      <Name language="German_Middle_Low">Sudauen</Name>
+      <Name language="German_Old_Low">Sudauen</Name>
+      <Name language="Thuringian">Sudauen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57108,6 +57542,10 @@
       <GameId game="CK2HIP" parent="c_sudovia" order="1">b_sejny</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Sejny</Name>
+      <Name language="Polish_Old">Sejny</Name>
+      <Name language="Slovak_Medieval">Sejny</Name>
+      <Name language="Sorbian">Sejny</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57116,6 +57554,19 @@
       <GameId game="CK2HIP" parent="c_sudovia" order="2">b_olecko</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Marggrabowa</Name>
+      <Name language="Bavarian_Medieval">Marggrabowa</Name>
+      <Name language="Czech_Medieval">Oletczko</Name>
+      <Name language="Dutch_Middle">Marggrabowa</Name>
+      <Name language="Frankish_Low">Marggrabowa</Name>
+      <Name language="Frankish">Marggrabowa</Name>
+      <Name language="German_Middle_High">Marggrabowa</Name>
+      <Name language="German_Middle_Low">Marggrabowa</Name>
+      <Name language="German_Old_Low">Marggrabowa</Name>
+      <Name language="Polish_Old">Oletczko</Name>
+      <Name language="Slovak_Medieval">Oletczko</Name>
+      <Name language="Sorbian">Oletczko</Name>
+      <Name language="Thuringian">Marggrabowa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57124,6 +57575,19 @@
       <GameId game="CK2HIP" parent="c_sudovia" order="4">b_elk</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lyck</Name>
+      <Name language="Bavarian_Medieval">Lyck</Name>
+      <Name language="Czech_Medieval">Elk</Name>
+      <Name language="Dutch_Middle">Lyck</Name>
+      <Name language="Frankish_Low">Lyck</Name>
+      <Name language="Frankish">Lyck</Name>
+      <Name language="German_Middle_High">Lyck</Name>
+      <Name language="German_Middle_Low">Lyck</Name>
+      <Name language="German_Old_Low">Lyck</Name>
+      <Name language="Polish_Old">Elk</Name>
+      <Name language="Slovak_Medieval">Elk</Name>
+      <Name language="Sorbian">Elk</Name>
+      <Name language="Thuringian">Lyck</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57132,6 +57596,10 @@
       <GameId game="CK2HIP" parent="c_yatvyagi" order="1">b_skidlius</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Skidel</Name>
+      <Name language="Polish_Old">Skidel</Name>
+      <Name language="Slovak_Medieval">Skidel</Name>
+      <Name language="Sorbian">Skidel</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57140,6 +57608,15 @@
       <GameId game="CK2HIP" parent="c_yatvyagi" order="4">b_kymundsdorf</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Kymundsdorf</Name>
+      <Name language="Bavarian_Medieval">Kymundsdorf</Name>
+      <Name language="Dutch_Middle">Kymundsdorf</Name>
+      <Name language="Frankish_Low">Kymundsdorf</Name>
+      <Name language="Frankish">Kymundsdorf</Name>
+      <Name language="German_Middle_High">Kymundsdorf</Name>
+      <Name language="German_Middle_Low">Kymundsdorf</Name>
+      <Name language="German_Old_Low">Kymundsdorf</Name>
+      <Name language="Thuringian">Kymundsdorf</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57450,6 +57927,19 @@
       <GameId game="CK2HIP" parent="c_upyte" order="1">b_pasvalys</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Poswol</Name>
+      <Name language="Bavarian_Medieval">Poswol</Name>
+      <Name language="Czech_Medieval">Poswol</Name>
+      <Name language="Dutch_Middle">Poswol</Name>
+      <Name language="Frankish_Low">Poswol</Name>
+      <Name language="Frankish">Poswol</Name>
+      <Name language="German_Middle_High">Poswol</Name>
+      <Name language="German_Middle_Low">Poswol</Name>
+      <Name language="German_Old_Low">Poswol</Name>
+      <Name language="Polish_Old">Poswol</Name>
+      <Name language="Slovak_Medieval">Poswol</Name>
+      <Name language="Sorbian">Poswol</Name>
+      <Name language="Thuringian">Poswol</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57458,6 +57948,23 @@
       <GameId game="CK2HIP" parent="d_prussia" order="1">c_sambia</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Samland</Name>
+      <Name language="Bavarian_Medieval">Samland</Name>
+      <Name language="Czech_Medieval">Sambija</Name>
+      <Name language="Danish_Middle">Zambia</Name>
+      <Name language="Dutch_Middle">Samland</Name>
+      <Name language="English_Old_Norse">Zambia</Name>
+      <Name language="Frankish_Low">Samland</Name>
+      <Name language="Frankish">Samland</Name>
+      <Name language="German_Middle_High">Samland</Name>
+      <Name language="German_Middle_Low">Samland</Name>
+      <Name language="German_Old_Low">Samland</Name>
+      <Name language="Irish_Middle_Norse">Zambia</Name>
+      <Name language="Norwegian_Old">Zambia</Name>
+      <Name language="Polish_Old">Sambija</Name>
+      <Name language="Sorbian">Sambija</Name>
+      <Name language="Swedish_Old">Zambia</Name>
+      <Name language="Thuringian">Samland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57466,6 +57973,22 @@
       <GameId game="CK2HIP" parent="c_sambia" order="1">b_fischhausen</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Fischhausen</Name>
+      <Name language="Bavarian_Medieval">Fischhausen</Name>
+      <Name language="Czech_Medieval">Rybaki</Name>
+      <Name language="Dutch_Middle">Fischhausen</Name>
+      <Name language="Frankish_Low">Fischhausen</Name>
+      <Name language="Frankish">Fischhausen</Name>
+      <Name language="German_Middle_High">Fischhausen</Name>
+      <Name language="German_Middle_Low">Fischhausen</Name>
+      <Name language="German_Old_Low">Fischhausen</Name>
+      <Name language="Latgalian">Rybaki</Name>
+      <Name language="Lithuanian_Medieval">Rybaki</Name>
+      <Name language="Livonian">Rybaki</Name>
+      <Name language="Polish_Old">Rybaki</Name>
+      <Name language="Prussian_Old">Rybaki</Name>
+      <Name language="Sorbian">Rybaki</Name>
+      <Name language="Thuringian">Fischhausen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57474,6 +57997,22 @@
       <GameId game="CK2HIP" parent="c_sambia" order="2">b_ilawka</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Eylau</Name>
+      <Name language="Bavarian_Medieval">Eylau</Name>
+      <Name language="Czech_Medieval">Ilavka</Name>
+      <Name language="Dutch_Middle">Eylau</Name>
+      <Name language="Frankish_Low">Eylau</Name>
+      <Name language="Frankish">Eylau</Name>
+      <Name language="German_Middle_High">Eylau</Name>
+      <Name language="German_Middle_Low">Eylau</Name>
+      <Name language="German_Old_Low">Eylau</Name>
+      <Name language="Latgalian">Ylava</Name>
+      <Name language="Lithuanian_Medieval">Ylava</Name>
+      <Name language="Livonian">Ylava</Name>
+      <Name language="Polish_Old">Ilawka</Name>
+      <Name language="Prussian_Old">Ylava</Name>
+      <Name language="Sorbian">Ilawka</Name>
+      <Name language="Thuringian">Eylau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57482,6 +58021,13 @@
       <GameId game="CK2HIP" parent="c_sambia" order="3">b_labiau</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Labiava</Name>
+      <Name language="Latgalian">Labguva</Name>
+      <Name language="Lithuanian_Medieval">Labguva</Name>
+      <Name language="Livonian">Labguva</Name>
+      <Name language="Polish_Old">Labiawa</Name>
+      <Name language="Prussian_Old">Labguva</Name>
+      <Name language="Sorbian">Labiawa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57490,6 +58036,29 @@
       <GameId game="CK2HIP" parent="c_sambia" order="4">b_cranz</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Cranz</Name>
+      <Name language="Bavarian_Medieval">Cranz</Name>
+      <Name language="Czech_Medieval">Kranc</Name>
+      <Name language="Danish_Middle">Kaup</Name>
+      <Name language="Dutch_Middle">Cranz</Name>
+      <Name language="English_Old_Norse">Kaup</Name>
+      <Name language="Frankish_Low">Cranz</Name>
+      <Name language="Frankish">Cranz</Name>
+      <Name language="German_Middle_High">Cranz</Name>
+      <Name language="German_Middle_Low">Cranz</Name>
+      <Name language="German_Old_Low">Cranz</Name>
+      <Name language="Icelandic_Old">Kaup</Name>
+      <Name language="Irish_Middle_Norse">Kaup</Name>
+      <Name language="Latgalian">Krantas</Name>
+      <Name language="Lithuanian_Medieval">Krantas</Name>
+      <Name language="Livonian">Krantas</Name>
+      <Name language="Norse">Kaup</Name>
+      <Name language="Norwegian_Old">Kaup</Name>
+      <Name language="Polish_Old">Kranc</Name>
+      <Name language="Prussian_Old">Krantas</Name>
+      <Name language="Sorbian">Kranc</Name>
+      <Name language="Swedish_Old">Kaup</Name>
+      <Name language="Thuringian">Cranz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57498,6 +58067,23 @@
       <GameId game="CK2HIP" parent="c_sambia" order="5">b_kreuzburgnatangia</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Creuzburg</Name>
+      <Name language="Bavarian_Medieval">Creuzburg</Name>
+      <Name language="Dutch_Middle">Creuzburg</Name>
+      <Name language="Frankish_Low">Creuzburg</Name>
+      <Name language="Frankish">Creuzburg</Name>
+      <Name language="German_Middle_High">Creuzburg</Name>
+      <Name language="German_Middle_Low">Creuzburg</Name>
+      <Name language="German_Old_Low">Creuzburg</Name>
+      <Name language="Latgalian">Kryžbarkas</Name>
+      <Name language="Lithuanian_Medieval">Kryžbarkas</Name>
+      <Name language="Livonian">Kryžbarkas</Name>
+      <Name language="Polish_Old">Kryzbork</Name>
+      <Name language="Prussian_Old">Kryžbarkas</Name>
+      <Name language="Russian_Medieval">Slawskoje</Name>
+      <Name language="Slovak_Medieval">Kryzbork</Name>
+      <Name language="Sorbian">Kryzbork</Name>
+      <Name language="Thuringian">Creuzburg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57506,6 +58092,24 @@
       <GameId game="CK2HIP" parent="c_sambia" order="6">b_konigsberg</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Königsberg</Name>
+      <Name language="Bavarian_Medieval">Königsberg</Name>
+      <Name language="Czech_Medieval">Králowec</Name>
+      <Name language="Dutch_Middle">Königsberg</Name>
+      <Name language="Frankish_Low">Königsberg</Name>
+      <Name language="Frankish">Königsberg</Name>
+      <Name language="German_Middle_High">Königsberg</Name>
+      <Name language="German_Middle_Low">Königsberg</Name>
+      <Name language="German_Old_Low">Königsberg</Name>
+      <Name language="Latgalian">Twangste</Name>
+      <Name language="Lithuanian_Medieval">Twangste</Name>
+      <Name language="Livonian">Twangste</Name>
+      <Name language="Polish_Old">Królewiec</Name>
+      <Name language="Prussian_Old">Twangste</Name>
+      <Name language="Russian_Medieval">Korolevets</Name>
+      <Name language="Slovak_Medieval">Králowec</Name>
+      <Name language="Sorbian">Królewiec</Name>
+      <Name language="Thuringian">Königsberg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57514,6 +58118,13 @@
       <GameId game="CK2HIP" parent="c_sambia" order="7">b_tapiau</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Tajpava</Name>
+      <Name language="Latgalian">Surgurbi</Name>
+      <Name language="Lithuanian_Medieval">Surgurbi</Name>
+      <Name language="Livonian">Surgurbi</Name>
+      <Name language="Polish_Old">Tapiawa</Name>
+      <Name language="Prussian_Old">Surgurbi</Name>
+      <Name language="Sorbian">Tapiawa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57522,6 +58133,10 @@
       <GameId game="CK2HIP" parent="c_marienburg" order="1">b_balga</GameId>
     </GameIds>
     <Names>
+      <Name language="Latgalian">Honeda</Name>
+      <Name language="Lithuanian_Medieval">Honeda</Name>
+      <Name language="Livonian">Honeda</Name>
+      <Name language="Prussian_Old">Honeda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57530,6 +58145,13 @@
       <GameId game="CK2HIP" parent="c_marienburg" order="3">b_braunsberg</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Branevo</Name>
+      <Name language="Latgalian">Brusebergue</Name>
+      <Name language="Lithuanian_Medieval">Brusebergue</Name>
+      <Name language="Livonian">Brusebergue</Name>
+      <Name language="Polish_Old">Braniewo</Name>
+      <Name language="Prussian_Old">Brusebergue</Name>
+      <Name language="Sorbian">Braniewo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57565,6 +58187,22 @@
       <GameId game="CK2HIP" parent="c_galindia" order="2">b_angersburg</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Angersburg</Name>
+      <Name language="Bavarian_Medieval">Angersburg</Name>
+      <Name language="Czech_Medieval">Wegorzewo</Name>
+      <Name language="Dutch_Middle">Angersburg</Name>
+      <Name language="Frankish_Low">Angersburg</Name>
+      <Name language="Frankish">Angersburg</Name>
+      <Name language="German_Middle_High">Angersburg</Name>
+      <Name language="German_Middle_Low">Angersburg</Name>
+      <Name language="German_Old_Low">Angersburg</Name>
+      <Name language="Latgalian">Unguris</Name>
+      <Name language="Lithuanian_Medieval">Unguris</Name>
+      <Name language="Livonian">Unguris</Name>
+      <Name language="Polish_Old">Wegorzewo</Name>
+      <Name language="Prussian_Old">Unguris</Name>
+      <Name language="Sorbian">Wegorzewo</Name>
+      <Name language="Thuringian">Angersburg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57573,6 +58211,22 @@
       <GameId game="CK2HIP" parent="c_galindia" order="3">b_lotzen</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lötzen</Name>
+      <Name language="Bavarian_Medieval">Lötzen</Name>
+      <Name language="Czech_Medieval">Gižicko</Name>
+      <Name language="Dutch_Middle">Lötzen</Name>
+      <Name language="Frankish_Low">Lötzen</Name>
+      <Name language="Frankish">Lötzen</Name>
+      <Name language="German_Middle_High">Lötzen</Name>
+      <Name language="German_Middle_Low">Lötzen</Name>
+      <Name language="German_Old_Low">Lötzen</Name>
+      <Name language="Latgalian">Lëcai</Name>
+      <Name language="Lithuanian_Medieval">Lëcai</Name>
+      <Name language="Livonian">Lëcai</Name>
+      <Name language="Polish_Old">Gizycko</Name>
+      <Name language="Prussian_Old">Lëcai</Name>
+      <Name language="Sorbian">Gizycko</Name>
+      <Name language="Thuringian">Lötzen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57589,6 +58243,21 @@
       <GameId game="CK2HIP" parent="c_pomesania" order="1">b_malbork</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lötzen</Name>
+      <Name language="Bavarian_Medieval">Lötzen</Name>
+      <Name language="Czech_Medieval">Malbork</Name>
+      <Name language="Dutch_Middle">Lötzen</Name>
+      <Name language="Frankish_Low">Lötzen</Name>
+      <Name language="Frankish">Lötzen</Name>
+      <Name language="German_Middle_Low">Lötzen</Name>
+      <Name language="German_Old_Low">Lötzen</Name>
+      <Name language="Latgalian">Malbork</Name>
+      <Name language="Lithuanian_Medieval">Malbork</Name>
+      <Name language="Livonian">Malbork</Name>
+      <Name language="Polish_Old">Malbork</Name>
+      <Name language="Prussian_Old">Malbork</Name>
+      <Name language="Sorbian">Malbork</Name>
+      <Name language="Thuringian">Lötzen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57597,6 +58266,21 @@
       <GameId game="CK2HIP" parent="c_pomesania" order="2">b_marienwerder</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lötzen</Name>
+      <Name language="Bavarian_Medieval">Lötzen</Name>
+      <Name language="Czech_Medieval">Kwidzyn</Name>
+      <Name language="Dutch_Middle">Lötzen</Name>
+      <Name language="Frankish_Low">Lötzen</Name>
+      <Name language="Frankish">Lötzen</Name>
+      <Name language="German_Middle_Low">Lötzen</Name>
+      <Name language="German_Old_Low">Lötzen</Name>
+      <Name language="Latgalian">Kwedina</Name>
+      <Name language="Lithuanian_Medieval">Kwedina</Name>
+      <Name language="Livonian">Kwedina</Name>
+      <Name language="Polish_Old">Kwidzyn</Name>
+      <Name language="Prussian_Old">Kwedina</Name>
+      <Name language="Sorbian">Kwidzyn</Name>
+      <Name language="Thuringian">Lötzen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57605,6 +58289,21 @@
       <GameId game="CK2HIP" parent="c_pomesania" order="3">b_dzierzgon</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lötzen</Name>
+      <Name language="Bavarian_Medieval">Lötzen</Name>
+      <Name language="Czech_Medieval">Dzierzgon</Name>
+      <Name language="Dutch_Middle">Lötzen</Name>
+      <Name language="Frankish_Low">Lötzen</Name>
+      <Name language="Frankish">Lötzen</Name>
+      <Name language="German_Middle_Low">Lötzen</Name>
+      <Name language="German_Old_Low">Lötzen</Name>
+      <Name language="Latgalian">Dzežgona</Name>
+      <Name language="Lithuanian_Medieval">Dzežgona</Name>
+      <Name language="Livonian">Dzežgona</Name>
+      <Name language="Polish_Old">Dzierzgon</Name>
+      <Name language="Prussian_Old">Dzežgona</Name>
+      <Name language="Sorbian">Dzierzgon</Name>
+      <Name language="Thuringian">Lötzen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57613,6 +58312,21 @@
       <GameId game="CK2HIP" parent="c_pomesania" order="4">b_prabuty</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lötzen</Name>
+      <Name language="Bavarian_Medieval">Lötzen</Name>
+      <Name language="Czech_Medieval">Prabuty</Name>
+      <Name language="Dutch_Middle">Lötzen</Name>
+      <Name language="Frankish_Low">Lötzen</Name>
+      <Name language="Frankish">Lötzen</Name>
+      <Name language="German_Middle_Low">Lötzen</Name>
+      <Name language="German_Old_Low">Lötzen</Name>
+      <Name language="Latgalian">Reizija</Name>
+      <Name language="Lithuanian_Medieval">Reizija</Name>
+      <Name language="Livonian">Reizija</Name>
+      <Name language="Polish_Old">Prabuty</Name>
+      <Name language="Prussian_Old">Reizija</Name>
+      <Name language="Sorbian">Prabuty</Name>
+      <Name language="Thuringian">Lötzen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66095,6 +66809,19 @@
       <GameId game="CK2HIP" parent="c_girona" order="1">b_cabrera</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qabrira</Name>
+      <Name language="Arabic_Bedouin">Qabrira</Name>
+      <Name language="Arabic_Egypt">Qabrira</Name>
+      <Name language="Arabic_Levant">Qabrira</Name>
+      <Name language="Arabic_Maghreb">Qabrira</Name>
+      <Name language="Arabic_Yemen">Qabrira</Name>
+      <Name language="Aragonese">Crapera</Name>
+      <Name language="Basque">Ahuntzoa</Name>
+      <Name language="French_Old">Chevrière</Name>
+      <Name language="Galician">Cabreira</Name>
+      <Name language="Hejazi_Arabic">Qabrira</Name>
+      <Name language="Portuguese">Cabreira</Name>
+      <Name language="Sicilian_Arabic">Qabrira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66103,6 +66830,15 @@
       <GameId game="CK2HIP" parent="c_girona" order="3">b_la_bisbal</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Fundynid</Name>
+      <Name language="Arabic_Bedouin">Fundynid</Name>
+      <Name language="Arabic_Egypt">Fundynid</Name>
+      <Name language="Arabic_Levant">Fundynid</Name>
+      <Name language="Arabic_Maghreb">Fundynid</Name>
+      <Name language="Arabic_Yemen">Fundynid</Name>
+      <Name language="Basque">Bisbal</Name>
+      <Name language="Hejazi_Arabic">Fundynid</Name>
+      <Name language="Sicilian_Arabic">Fundynid</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66111,6 +66847,16 @@
       <GameId game="CK2HIP" parent="c_girona" order="4">b_besalu</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bish al-Udd</Name>
+      <Name language="Arabic_Bedouin">Bish al-Udd</Name>
+      <Name language="Arabic_Egypt">Bish al-Udd</Name>
+      <Name language="Arabic_Levant">Bish al-Udd</Name>
+      <Name language="Arabic_Maghreb">Bish al-Udd</Name>
+      <Name language="Arabic_Yemen">Bish al-Udd</Name>
+      <Name language="Basque">Besalu</Name>
+      <Name language="French_Old">Besalu</Name>
+      <Name language="Hejazi_Arabic">Bish al-Udd</Name>
+      <Name language="Sicilian_Arabic">Bish al-Udd</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66119,6 +66865,14 @@
       <GameId game="CK2HIP" parent="c_girona" order="5">b_bas</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Abbas</Name>
+      <Name language="Arabic_Bedouin">Abbas</Name>
+      <Name language="Arabic_Egypt">Abbas</Name>
+      <Name language="Arabic_Levant">Abbas</Name>
+      <Name language="Arabic_Maghreb">Abbas</Name>
+      <Name language="Arabic_Yemen">Abbas</Name>
+      <Name language="Hejazi_Arabic">Abbas</Name>
+      <Name language="Sicilian_Arabic">Abbas</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66127,6 +66881,17 @@
       <GameId game="CK2HIP" parent="c_girona" order="7">b_figueres</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Figyira</Name>
+      <Name language="Arabic_Bedouin">Figyira</Name>
+      <Name language="Arabic_Egypt">Figyira</Name>
+      <Name language="Arabic_Levant">Figyira</Name>
+      <Name language="Arabic_Maghreb">Figyira</Name>
+      <Name language="Arabic_Yemen">Figyira</Name>
+      <Name language="Castilian">Figueras</Name>
+      <Name language="Galician">Figueiras</Name>
+      <Name language="Hejazi_Arabic">Figyira</Name>
+      <Name language="Portuguese">Figueiras</Name>
+      <Name language="Sicilian_Arabic">Figyira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66135,6 +66900,20 @@
       <GameId game="CK2HIP" parent="c_urgell" order="4">b_castellciutat</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at al-Madina</Name>
+      <Name language="Arabic_Bedouin">Qal'at al-Madina</Name>
+      <Name language="Arabic_Egypt">Qal'at al-Madina</Name>
+      <Name language="Arabic_Levant">Qal'at al-Madina</Name>
+      <Name language="Arabic_Maghreb">Qal'at al-Madina</Name>
+      <Name language="Arabic_Yemen">Qal'at al-Madina</Name>
+      <Name language="Aragonese">Castielciudat</Name>
+      <Name language="Basque">Gaztelua-Hiri</Name>
+      <Name language="French_Old">Châteauville</Name>
+      <Name language="Galician">Castrocidade</Name>
+      <Name language="Hejazi_Arabic">Qal'at al-Madina</Name>
+      <Name language="Leonese">Ciacastillu</Name>
+      <Name language="Portuguese">Castelocidade</Name>
+      <Name language="Sicilian_Arabic">Qal'at al-Madina</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66143,6 +66922,21 @@
       <GameId game="CK2HIP" parent="c_urgell" order="2">b_laseudurgell</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Urgil</Name>
+      <Name language="Arabic_Bedouin">Urgil</Name>
+      <Name language="Arabic_Egypt">Urgil</Name>
+      <Name language="Arabic_Levant">Urgil</Name>
+      <Name language="Arabic_Maghreb">Urgil</Name>
+      <Name language="Arabic_Yemen">Urgil</Name>
+      <Name language="Aragonese">Seu d'Urchel</Name>
+      <Name language="Basque">Urtxeluko Egoitza</Name>
+      <Name language="Castilian">Seo de Urgel</Name>
+      <Name language="French_Old">Siège d'Urgell</Name>
+      <Name language="Galician">Sé de Urgell</Name>
+      <Name language="Hejazi_Arabic">Urgil</Name>
+      <Name language="Leonese">La Seu d'Urgel</Name>
+      <Name language="Portuguese">Sé de Urgell</Name>
+      <Name language="Sicilian_Arabic">Urgil</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66151,6 +66945,14 @@
       <GameId game="CK2HIP" parent="c_urgell" order="3">b_balaguer</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Balagay</Name>
+      <Name language="Arabic_Bedouin">Balagay</Name>
+      <Name language="Arabic_Egypt">Balagay</Name>
+      <Name language="Arabic_Levant">Balagay</Name>
+      <Name language="Arabic_Maghreb">Balagay</Name>
+      <Name language="Arabic_Yemen">Balagay</Name>
+      <Name language="Hejazi_Arabic">Balagay</Name>
+      <Name language="Sicilian_Arabic">Balagay</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66159,6 +66961,20 @@
       <GameId game="CK2HIP" parent="c_urgell" order="4">b_ager</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ayyir</Name>
+      <Name language="Arabic_Bedouin">Ayyir</Name>
+      <Name language="Arabic_Egypt">Ayyir</Name>
+      <Name language="Arabic_Levant">Ayyir</Name>
+      <Name language="Arabic_Maghreb">Ayyir</Name>
+      <Name language="Arabic_Yemen">Ayyir</Name>
+      <Name language="Basque">Ager</Name>
+      <Name language="Castilian">Ager</Name>
+      <Name language="Catalan_Medieval">Àger</Name>
+      <Name language="Galician">Ager</Name>
+      <Name language="Hejazi_Arabic">Ayyir</Name>
+      <Name language="Leonese">Agier</Name>
+      <Name language="Portuguese">Ager</Name>
+      <Name language="Sicilian_Arabic">Ayyir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66167,6 +66983,14 @@
       <GameId game="CK2HIP" parent="c_urgell" order="5">b_gerri</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Yiri</Name>
+      <Name language="Arabic_Bedouin">Yiri</Name>
+      <Name language="Arabic_Egypt">Yiri</Name>
+      <Name language="Arabic_Levant">Yiri</Name>
+      <Name language="Arabic_Maghreb">Yiri</Name>
+      <Name language="Arabic_Yemen">Yiri</Name>
+      <Name language="Hejazi_Arabic">Yiri</Name>
+      <Name language="Sicilian_Arabic">Yiri</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66175,6 +66999,16 @@
       <GameId game="CK2HIP" parent="c_urgell" order="6">b_camarassa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qamarassa</Name>
+      <Name language="Arabic_Bedouin">Qamarassa</Name>
+      <Name language="Arabic_Egypt">Qamarassa</Name>
+      <Name language="Arabic_Levant">Qamarassa</Name>
+      <Name language="Arabic_Maghreb">Qamarassa</Name>
+      <Name language="Arabic_Yemen">Qamarassa</Name>
+      <Name language="Basque">Kamarasa</Name>
+      <Name language="French_Old">Camarase</Name>
+      <Name language="Hejazi_Arabic">Qamarassa</Name>
+      <Name language="Sicilian_Arabic">Qamarassa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66183,6 +67017,14 @@
       <GameId game="CK2HIP" parent="d_urgell" order="2">c_pallars</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Balirs</Name>
+      <Name language="Arabic_Bedouin">Balirs</Name>
+      <Name language="Arabic_Egypt">Balirs</Name>
+      <Name language="Arabic_Levant">Balirs</Name>
+      <Name language="Arabic_Maghreb">Balirs</Name>
+      <Name language="Arabic_Yemen">Balirs</Name>
+      <Name language="Hejazi_Arabic">Balirs</Name>
+      <Name language="Sicilian_Arabic">Balirs</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66191,6 +67033,20 @@
       <GameId game="CK2HIP" parent="d_urgell" order="3">c_cerdanya</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sartániyya</Name>
+      <Name language="Arabic_Bedouin">Sartániyya</Name>
+      <Name language="Arabic_Egypt">Sartániyya</Name>
+      <Name language="Arabic_Levant">Sartániyya</Name>
+      <Name language="Arabic_Maghreb">Sartániyya</Name>
+      <Name language="Arabic_Yemen">Sartániyya</Name>
+      <Name language="Basque">Zerdaña</Name>
+      <Name language="Castilian">Cerdaña</Name>
+      <Name language="French_Old">Cerdagne</Name>
+      <Name language="Galician">Cerdaña</Name>
+      <Name language="Hejazi_Arabic">Sartániyya</Name>
+      <Name language="Leonese">Cerdaña</Name>
+      <Name language="Portuguese">Cerdanha</Name>
+      <Name language="Sicilian_Arabic">Sartániyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66199,6 +67055,21 @@
       <GameId game="CK2HIP" parent="c_burgos" order="1">b_mirandadeebro</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Miranda al-A'bra</Name>
+      <Name language="Arabic_Bedouin">Miranda al-A'bra</Name>
+      <Name language="Arabic_Egypt">Miranda al-A'bra</Name>
+      <Name language="Arabic_Levant">Miranda al-A'bra</Name>
+      <Name language="Arabic_Maghreb">Miranda al-A'bra</Name>
+      <Name language="Arabic_Yemen">Miranda al-A'bra</Name>
+      <Name language="Aragonese">Miranda d'Ebro</Name>
+      <Name language="Basque">Miranda Ebroko</Name>
+      <Name language="Catalan_Medieval">Miranda d'Ebre</Name>
+      <Name language="French_Old">Mirande d'Èbre</Name>
+      <Name language="Galician">Miranda do Ebro</Name>
+      <Name language="Hejazi_Arabic">Miranda al-A'bra</Name>
+      <Name language="Leonese">Miranda d'Ebro</Name>
+      <Name language="Portuguese">Miranda do Ebro</Name>
+      <Name language="Sicilian_Arabic">Miranda al-A'bra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66207,6 +67078,19 @@
       <GameId game="CK2HIP" parent="c_burgos" order="3">b_onya</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Unniyya</Name>
+      <Name language="Arabic_Bedouin">Unniyya</Name>
+      <Name language="Arabic_Egypt">Unniyya</Name>
+      <Name language="Arabic_Levant">Unniyya</Name>
+      <Name language="Arabic_Maghreb">Unniyya</Name>
+      <Name language="Arabic_Yemen">Unniyya</Name>
+      <Name language="Aragonese">Onya</Name>
+      <Name language="Basque">Onia</Name>
+      <Name language="Catalan_Medieval">Onya</Name>
+      <Name language="French_Old">Ogne</Name>
+      <Name language="Hejazi_Arabic">Unniyya</Name>
+      <Name language="Portuguese">Onha</Name>
+      <Name language="Sicilian_Arabic">Unniyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66215,6 +67099,14 @@
       <GameId game="CK2HIP" parent="c_burgos" order="4">b_lara</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">La'ra</Name>
+      <Name language="Arabic_Bedouin">La'ra</Name>
+      <Name language="Arabic_Egypt">La'ra</Name>
+      <Name language="Arabic_Levant">La'ra</Name>
+      <Name language="Arabic_Maghreb">La'ra</Name>
+      <Name language="Arabic_Yemen">La'ra</Name>
+      <Name language="Hejazi_Arabic">La'ra</Name>
+      <Name language="Sicilian_Arabic">La'ra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66223,6 +67115,18 @@
       <GameId game="CK2HIP" parent="c_burgos" order="6">b_arandadeduero</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Aran</Name>
+      <Name language="Arabic_Bedouin">al-Aran</Name>
+      <Name language="Arabic_Egypt">al-Aran</Name>
+      <Name language="Arabic_Levant">al-Aran</Name>
+      <Name language="Arabic_Maghreb">al-Aran</Name>
+      <Name language="Arabic_Yemen">al-Aran</Name>
+      <Name language="Basque">Aranda Dueroko</Name>
+      <Name language="French_Old">Arande de Dure</Name>
+      <Name language="Galician">Aranda do Douro</Name>
+      <Name language="Hejazi_Arabic">al-Aran</Name>
+      <Name language="Portuguese">Aranda do Douro</Name>
+      <Name language="Sicilian_Arabic">al-Aran</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66271,6 +67175,16 @@
       <GameId game="CK2HIP" parent="c_asturias_de_santillana" order="2">b_liebana</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Libbana</Name>
+      <Name language="Arabic_Bedouin">Libbana</Name>
+      <Name language="Arabic_Egypt">Libbana</Name>
+      <Name language="Arabic_Levant">Libbana</Name>
+      <Name language="Arabic_Maghreb">Libbana</Name>
+      <Name language="Arabic_Yemen">Libbana</Name>
+      <Name language="Catalan_Medieval">Lièbana</Name>
+      <Name language="French_Old">Liébane</Name>
+      <Name language="Hejazi_Arabic">Libbana</Name>
+      <Name language="Sicilian_Arabic">Libbana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66279,6 +67193,15 @@
       <GameId game="CK2HIP" parent="c_asturias_de_santillana" order="4">b_castrourdiales</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at Urdyl</Name>
+      <Name language="Arabic_Bedouin">Qal'at Urdyl</Name>
+      <Name language="Arabic_Egypt">Qal'at Urdyl</Name>
+      <Name language="Arabic_Levant">Qal'at Urdyl</Name>
+      <Name language="Arabic_Maghreb">Qal'at Urdyl</Name>
+      <Name language="Arabic_Yemen">Qal'at Urdyl</Name>
+      <Name language="Basque">Kastro Urdiales</Name>
+      <Name language="Hejazi_Arabic">Qal'at Urdyl</Name>
+      <Name language="Sicilian_Arabic">Qal'at Urdyl</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66287,6 +67210,20 @@
       <GameId game="CK2HIP" parent="c_asturias_de_santillana" order="6">b_sanvicentedelabarquera</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Barsuqa</Name>
+      <Name language="Arabic_Bedouin">Barsuqa</Name>
+      <Name language="Arabic_Egypt">Barsuqa</Name>
+      <Name language="Arabic_Levant">Barsuqa</Name>
+      <Name language="Arabic_Maghreb">Barsuqa</Name>
+      <Name language="Arabic_Yemen">Barsuqa</Name>
+      <Name language="Aragonese">Sant Vicenç d'a Barquera</Name>
+      <Name language="Basque">Donibixente Barkera</Name>
+      <Name language="Catalan_Medieval">San Vicenç de la Barquera</Name>
+      <Name language="French_Old">Saint Vincent de la Barquére</Name>
+      <Name language="Galician">San Vicente da Barqueira</Name>
+      <Name language="Hejazi_Arabic">Barsuqa</Name>
+      <Name language="Portuguese">São Vicente da Barqueira</Name>
+      <Name language="Sicilian_Arabic">Barsuqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66295,6 +67232,18 @@
       <GameId game="CK2HIP" parent="c_asturias_de_santillana" order="7">b_santonya</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Santunna</Name>
+      <Name language="Arabic_Bedouin">Santunna</Name>
+      <Name language="Arabic_Egypt">Santunna</Name>
+      <Name language="Arabic_Levant">Santunna</Name>
+      <Name language="Arabic_Maghreb">Santunna</Name>
+      <Name language="Arabic_Yemen">Santunna</Name>
+      <Name language="Aragonese">Santonya</Name>
+      <Name language="Catalan_Medieval">Santonya</Name>
+      <Name language="French_Old">Santogne</Name>
+      <Name language="Hejazi_Arabic">Santunna</Name>
+      <Name language="Portuguese">Santonha</Name>
+      <Name language="Sicilian_Arabic">Santunna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66303,6 +67252,16 @@
       <GameId game="CK2HIP" parent="c_palencia" order="1">b_carrion</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qarun</Name>
+      <Name language="Arabic_Bedouin">Qarun</Name>
+      <Name language="Arabic_Egypt">Qarun</Name>
+      <Name language="Arabic_Levant">Qarun</Name>
+      <Name language="Arabic_Maghreb">Qarun</Name>
+      <Name language="Arabic_Yemen">Qarun</Name>
+      <Name language="Basque">Karrion</Name>
+      <Name language="French_Old">Carrion</Name>
+      <Name language="Hejazi_Arabic">Qarun</Name>
+      <Name language="Sicilian_Arabic">Qarun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66311,6 +67270,19 @@
       <GameId game="CK2HIP" parent="c_palencia" order="3">b_duenyas</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Dunniyya</Name>
+      <Name language="Arabic_Bedouin">Dunniyya</Name>
+      <Name language="Arabic_Egypt">Dunniyya</Name>
+      <Name language="Arabic_Levant">Dunniyya</Name>
+      <Name language="Arabic_Maghreb">Dunniyya</Name>
+      <Name language="Arabic_Yemen">Dunniyya</Name>
+      <Name language="Aragonese">Duenyas</Name>
+      <Name language="Catalan_Medieval">Duenyas</Name>
+      <Name language="French_Old">Dognes</Name>
+      <Name language="Hejazi_Arabic">Dunniyya</Name>
+      <Name language="Leonese">Dueñes</Name>
+      <Name language="Portuguese">Duenhas</Name>
+      <Name language="Sicilian_Arabic">Dunniyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66319,6 +67291,18 @@
       <GameId game="CK2HIP" parent="c_palencia" order="4">b_saldanya</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Gili-Zalan</Name>
+      <Name language="Arabic_Bedouin">Gili-Zalan</Name>
+      <Name language="Arabic_Egypt">Gili-Zalan</Name>
+      <Name language="Arabic_Levant">Gili-Zalan</Name>
+      <Name language="Arabic_Maghreb">Gili-Zalan</Name>
+      <Name language="Arabic_Yemen">Gili-Zalan</Name>
+      <Name language="Aragonese">Saldanya</Name>
+      <Name language="Catalan_Medieval">Saldanya</Name>
+      <Name language="French_Old">Saldagne</Name>
+      <Name language="Hejazi_Arabic">Gili-Zalan</Name>
+      <Name language="Portuguese">Saldanha</Name>
+      <Name language="Sicilian_Arabic">Gili-Zalan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66327,6 +67311,17 @@
       <GameId game="CK2HIP" parent="c_palencia" order="5">b_aguilardecampoo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Nasr al-Qampud</Name>
+      <Name language="Arabic_Bedouin">Nasr al-Qampud</Name>
+      <Name language="Arabic_Egypt">Nasr al-Qampud</Name>
+      <Name language="Arabic_Levant">Nasr al-Qampud</Name>
+      <Name language="Arabic_Maghreb">Nasr al-Qampud</Name>
+      <Name language="Arabic_Yemen">Nasr al-Qampud</Name>
+      <Name language="Catalan_Medieval">Àguilar de Campoo</Name>
+      <Name language="French_Old">Aiglère de Campoo</Name>
+      <Name language="Hejazi_Arabic">Nasr al-Qampud</Name>
+      <Name language="Portuguese">Aguiar de Campoo</Name>
+      <Name language="Sicilian_Arabic">Nasr al-Qampud</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66335,6 +67330,17 @@
       <GameId game="CK2HIP" parent="c_palencia" order="6">b_astudillo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Astudd</Name>
+      <Name language="Arabic_Bedouin">Astudd</Name>
+      <Name language="Arabic_Egypt">Astudd</Name>
+      <Name language="Arabic_Levant">Astudd</Name>
+      <Name language="Arabic_Maghreb">Astudd</Name>
+      <Name language="Arabic_Yemen">Astudd</Name>
+      <Name language="French_Old">Astudille</Name>
+      <Name language="Hejazi_Arabic">Astudd</Name>
+      <Name language="Leonese">Astudillu</Name>
+      <Name language="Portuguese">Astudilho</Name>
+      <Name language="Sicilian_Arabic">Astudd</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82272,6 +83278,7 @@
       <GameId game="CK2HIP" parent="d_opplandene" order="1">c_hedmark</GameId>
     </GameIds>
     <Names>
+      <Name language="Norse">Uppland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -52046,21 +52046,28 @@
     <Id>algiers</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_al_djazair" order="1">b_algiers</GameId>
+      <GameId game="ImperatorRome">3118</GameId> <!-- Icosium -->
     </GameIds>
     <Names>
       <Name language="Croatian">Alžir</Name>
       <Name language="Finnish">Alger</Name>
       <Name language="French_Old">Alger</Name>
       <Name language="German">Algier</Name>
+      <Name language="Greek_Ancient">Ikosion</Name>
+      <Name language="Greek_Medieval">Ikosion</Name>
       <Name language="Hungarian">Algír</Name>
       <Name language="Icelandic">Algeirsborg</Name>
       <Name language="Irish">Alger</Name>
       <Name language="Italian">Algeri</Name>
       <Name language="Kyrgyz">Alger</Name>
+      <Name language="Latin_Ancient">Icosium</Name>
+      <Name language="Latin_Medieval">Icosium</Name>
       <Name language="Lithuanian">Alžyras</Name>
       <Name language="Norwegian">Alger</Name>
+      <Name language="Phoenician">Awikasam</Name>
       <Name language="Polish">Algier</Name>
       <Name language="Portuguese">Argel</Name>
+      <Name language="Punic">Awikasam</Name>
       <Name language="Romanian">Alger</Name>
       <Name language="Slovak">Alžír</Name>
       <Name language="Turkish">Cezayir</Name>
@@ -52090,13 +52097,15 @@
       <GameId game="CK2HIP" parent="c_tlemcen" order="1">b_tlemcen</GameId>
       <GameId game="CK2HIP" parent="d_tlemcen" order="1">c_tlemcen</GameId>
       <GameId game="CK2HIP" parent="k_maghreb" order="2">d_tlemcen</GameId>
+      <GameId game="ImperatorRome">3087</GameId> <!-- Pomaria -->
     </GameIds>
     <Names>
       <Name language="Castilian">Tremecén</Name>
+      <Name language="Greek_Medieval">Pomaria</Name>
+      <Name language="Latin_Late">Pomaria</Name>
+      <Name language="Latin_Medieval">Pomaria</Name>
       <Name language="Lithuanian">Tlemsenas</Name>
       <Name language="Polish">Tilimsan</Name>
-      <Name language="Latin">Syrorum</Name>
-      <Name language="Latin_Late">Pomaria</Name>
       <Name language="Turkish">Tilimsan</Name>
     </Names>
   </LocationEntity>
@@ -52115,6 +52124,7 @@
       <GameId game="CK2HIP" parent="d_tlemcen" order="2">c_orania</GameId>
     </GameIds>
     <Names>
+      <Name language="Phoenician">Shigan</Name>
       <Name language="Portuguese">Orânia</Name>
     </Names>
   </LocationEntity>
@@ -52125,8 +52135,10 @@
     </GameIds>
     <Names>
       <Name language="Castilian">Orán</Name>
+      <Name language="Greek_Medieval">Unica Colonia</Name>
       <Name language="Hungarian">Orán</Name>
       <Name language="Italian">Orano</Name>
+      <Name language="Latin_Medieval">Unica Colonia</Name>
       <Name language="Lithuanian">Oranas</Name>
       <Name language="Portuguese">Orã</Name>
     </Names>
@@ -52172,13 +52184,19 @@
     <Id>asilah</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tangiers" order="2">b_asilah</GameId>
+      <GameId game="ImperatorRome">3064</GameId> <!-- Arzeila -->
     </GameIds>
     <Names>
       <Name language="Castilian">Arcila</Name>
+      <Name language="Greek_Ancient">Arzeila</Name>
       <Name language="Italian">Assila</Name>
+      <Name language="Latin_Ancient">Zilil</Name>
+      <Name language="Latin_Medieval">Zilil</Name>
       <Name language="Lithuanian">Asila</Name>
+      <Name language="Phoenician">Arzeila</Name>
       <Name language="Polish">Asila</Name>
       <Name language="Portuguese">Arzila</Name>
+      <Name language="Punic">Arzeila</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52203,10 +52221,13 @@
     <Id>tetouan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_cebta" order="2">b_tetouan</GameId>
+      <GameId game="ImperatorRome">3085</GameId> <!-- Tamuda -->
     </GameIds>
     <Names>
       <Name language="Castilian">Tetuán</Name>
       <Name language="Croatian">Tetuan</Name>
+      <Name language="Greek_Medieval">Tamuda</Name>
+      <Name language="Latin_Medieval">Tamuda</Name>
       <Name language="Lithuanian">Tetuanas</Name>
       <Name language="Polish">Tetuan</Name>
       <Name language="Turkish">Tetuan</Name>
@@ -52219,7 +52240,6 @@
       <GameId game="CK2HIP" parent="d_tangiers" order="3">c_nakur</GameId>
     </GameIds>
     <Names>
-      <Name language="Latin">Rusaddir Superior</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72722,8 +72742,23 @@
     <Id>leptismagna</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tripolitana" order="2">b_leptismagna</GameId>
+      <GameId game="ImperatorRome">3306</GameId> <!-- Leptis Magna -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Labda</Name>
+      <Name language="Arabic_Bedouin">Labda</Name>
+      <Name language="Arabic_Egypt">Labda</Name>
+      <Name language="Arabic_Levant">Labda</Name>
+      <Name language="Arabic_Maghreb">Labda</Name>
+      <Name language="Arabic_Yemen">Labda</Name>
+      <Name language="Greek_Ancient">Leptis Megale</Name>
+      <Name language="Greek_Medieval">Lepcis Magna</Name>
+      <Name language="Hejazi_Arabic">Labda</Name>
+      <Name language="Latin_Ancient">Leptis Magna</Name>
+      <Name language="Latin_Medieval">Lepcis Magna</Name>
+      <Name language="Phoenician">Lapki</Name>
+      <Name language="Punic">Lapki</Name>
+      <Name language="Sicilian_Arabic">Labda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72754,8 +72789,15 @@
     <Id>maghmadas</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_syrte" order="2">b_maghmadas</GameId>
+      <GameId game="ImperatorRome">3167</GameId> <!-- Macomades -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Macomades</Name>
+      <Name language="Greek_Medieval">Macomades Selorum</Name>
+      <Name language="Latin_Ancient">Macomades</Name>
+      <Name language="Latin_Medieval">Macomades Selorum</Name>
+      <Name language="Phoenician">Makoma</Name>
+      <Name language="Punic">Makoma</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72892,16 +72934,22 @@
     <Id>badis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_biskra" order="1">b_badis</GameId>
+      <GameId game="ImperatorRome">3169</GameId> <!-- Badias -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Badias</Name>
+      <Name language="Latin_Medieval">Badias</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sidiokba</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_biskra" order="3">b_sidiokba</GameId>
+      <GameId game="ImperatorRome">3154</GameId> <!-- Gemellae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Gemellae</Name>
+      <Name language="Latin_Medieval">Gemellae</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72910,6 +72958,8 @@
       <GameId game="CK2HIP" parent="c_biskra" order="5">b_tehouda</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thabudeos</Name>
+      <Name language="Latin_Medieval">Thabudeos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72918,6 +72968,8 @@
       <GameId game="CK2HIP" parent="c_biskra" order="6">b_bigou</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Mesarfelta</Name>
+      <Name language="Latin_Medieval">Mesarfelta</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72934,22 +72986,30 @@
       <GameId game="CK2HIP" parent="c_tell_atlas" order="1">b_masila</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Lambaesis</Name>
+      <Name language="Latin_Medieval">Lambaesis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>tabna</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tell_atlas" order="2">b_tabna</GameId>
+      <GameId game="ImperatorRome">3152</GameId> <!-- Thubunae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thubunae</Name>
+      <Name language="Latin_Medieval">Thubunae</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>maqqara</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tell_atlas" order="4">b_maqqara</GameId>
+      <GameId game="ImperatorRome">3151</GameId> <!-- Macri -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Macri</Name>
+      <Name language="Latin_Medieval">Macri</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72957,16 +73017,26 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_zab" order="4">c_tabassa</GameId>
       <GameId game="CK2HIP" parent="c_tabassa" order="1">b_tabassa</GameId>
+      <GameId game="ImperatorRome">3203</GameId> <!-- Theveste -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Theveste</Name>
+      <Name language="Latin_Medieval">Theveste</Name>
+      <Name language="Punic">Tbessa</Name>
+      <Name language="Latin_Ancient">Theveste</Name>
+      <Name language="Massylian">Tbessa</Name>
+      <Name language="Phoenician">Tbessa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>khenchela</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tabassa" order="2">b_khenchela</GameId>
+      <GameId game="ImperatorRome">3168</GameId> <!-- Mascula Tiberia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Mascula Tiberia</Name>
+      <Name language="Latin_Medieval">Mascula Tiberia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72989,8 +73059,11 @@
     <Id>qalathuwara</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_atlas_mnt" order="3">b_qalathuwara</GameId>
+      <GameId game="ImperatorRome">3099</GameId> <!-- Ala Miliaria -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Ala Miliaria</Name>
+      <Name language="Latin_Medieval">Ala Miliaria</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72998,16 +73071,22 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_lemdiyya" order="1">b_achir</GameId>
       <GameId game="CK2HIP" parent="d_alger" order="2">c_lemdiyya</GameId>
+      <GameId game="ImperatorRome">3131</GameId> <!-- Auzia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Auzia</Name>
+      <Name language="Latin_Medieval">Auzia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>lemdiyya</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_lemdiyya" order="2">b_lemdiyya</GameId>
+      <GameId game="ImperatorRome">3119</GameId> <!-- Lambdia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Lambdia</Name>
+      <Name language="Latin_Medieval">Lambdia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -73022,8 +73101,11 @@
     <Id>miliana</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_al_djazair" order="2">b_miliana</GameId>
+      <GameId game="ImperatorRome">3115</GameId> <!-- Zucchabar -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Zucchabar</Name>
+      <Name language="Latin_Medieval">Zucchabar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -73032,30 +73114,37 @@
       <GameId game="CK2HIP" parent="c_al_djazair" order="3">b_sharshal</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Iol Caesarea</Name>
+      <Name language="Latin_Medieval">Iol Caesarea</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>elachour</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_al_djazair" order="4">b_elachour</GameId>
+      <GameId game="ImperatorRome">3120</GameId> <!-- Rusguniae -->
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>snassen</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_alger" order="4">c_snassen</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Ancient">Rhoustonion</Name>
+      <Name language="Latin_Ancient">Rusguniae</Name>
+      <Name language="Latin_Medieval">Rusguniae</Name>
+      <Name language="Phoenician">Rushgunay</Name>
+      <Name language="Punic">Rushgunay</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>tanas</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_snassen" order="2">b_tanas</GameId>
+      <GameId game="CK2HIP" parent="d_alger" order="4">c_snassen</GameId>
+      <GameId game="ImperatorRome">3108</GameId> <!-- Cartennae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Kartennai</Name>
+      <Name language="Latin_Ancient">Cartennae</Name>
+      <Name language="Latin_Medieval">Cartenna</Name>
+      <Name language="Phoenician">Qartan</Name>
+      <Name language="Punic">Qartan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -73064,38 +73153,55 @@
       <GameId game="CK2HIP" parent="c_snassen" order="3">b_mostaganem</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Portus Megas</Name>
+      <Name language="Latin_Medieval">Portus Magnus</Name>
+      <Name language="Punic">Murustaga</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sidibelabbes</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tlemcen" order="2">b_sidibelabbes</GameId>
+      <GameId game="ImperatorRome">3089</GameId> <!-- Altava -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Altava</Name>
+      <Name language="Latin_Medieval">Altava</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>kasribnsinan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_orania" order="2">b_kasribnsinan</GameId>
+      <GameId game="ImperatorRome">3088</GameId> <!-- Albulae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Albulae</Name>
+      <Name language="Latin_Medieval">Albulae</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>marsafarukh</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_orania" order="4">b_marsafarukh</GameId>
+      <GameId game="ImperatorRome">3101</GameId> <!-- Quiza Xenitana -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Quiza Cenitana</Name>
+      <Name language="Latin_Medieval">Quiza Cenitana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>arshgul</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_hanyan" order="2">b_arshgul</GameId>
+      <GameId game="ImperatorRome">3086</GameId> <!-- Siga -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Siga</Name>
+      <Name language="Greek_Medieval">Siga</Name>
+      <Name language="Latin_Medieval">Siga</Name>
+      <Name language="Punic">Shigan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -73118,48 +73224,66 @@
     <Id>tangiers</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tangiers" order="1">b_tangiers</GameId>
+      <GameId game="ImperatorRome">3061</GameId> <!-- Tingis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Tingis</Name>
+      <Name language="Greek_Medieval">Tingis</Name>
+      <Name language="Latin_Ancient">Tingi</Name>
+      <Name language="Latin_Medieval">Tingis</Name>
+      <Name language="Phoenician">Tinga</Name>
+      <Name language="Punic">Tinga</Name>
+      <Name language="Socossian">Tingi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>kasrkutama</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tangiers" order="3">b_kasrkutama</GameId>
+      <GameId game="ImperatorRome">3077</GameId> <!-- Oppidum Novum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Oppidum Novum</Name>
+      <Name language="Latin_Medieval">Oppidum Novum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>laraiche</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tangiers" order="4">b_laraiche</GameId>
+      <GameId game="ImperatorRome">3062</GameId> <!-- Lixus -->
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>cebta</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_tangiers" order="2">c_cebta</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Ancient">Lixos</Name>
+      <Name language="Greek_Medieval">Lixos</Name>
+      <Name language="Latin_Ancient">Lixus</Name>
+      <Name language="Latin_Medieval">Lixus</Name>
+      <Name language="Phoenician">Lakish</Name>
+      <Name language="Punic">Lakish</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>cueta</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_cebta" order="1">b_cueta</GameId>
+      <GameId game="CK2HIP" parent="d_tangiers" order="2">c_cebta</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Septem</Name>
+      <Name language="Latin_Medieval">Septem</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>melilla</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_nakur" order="3">b_melilla</GameId>
+      <GameId game="ImperatorRome">3080</GameId> <!-- Rusaddir -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Ryssadeiron</Name>
+      <Name language="Latin_Ancient">Flavia</Name>
+      <Name language="Phoenician">Rusaddir</Name>
+      <Name language="Punic">Rusaddir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78466,6 +78590,16 @@
       <GameId game="CK2HIP" parent="c_zyriane" order="1">b_koryazhma</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Koryažma</Name>
+      <Name language="Bulgarian_Old">Koryažma</Name>
+      <Name language="Croatian_Medieval">Koryažma</Name>
+      <Name language="Czech_Medieval">Koryažma</Name>
+      <Name language="Polish_Old">Koryažma</Name>
+      <Name language="Russian_Medieval">Koryažma</Name>
+      <Name language="Serbian_Medieval">Koryažma</Name>
+      <Name language="Slovak_Medieval">Koryažma</Name>
+      <Name language="Slovene_Medieval">Koryažma</Name>
+      <Name language="Sorbian">Koryažma</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78474,6 +78608,16 @@
       <GameId game="CK2HIP" parent="c_zyriane" order="2">b_solvychegodsk</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Usolsk</Name>
+      <Name language="Bulgarian_Old">Usolsk</Name>
+      <Name language="Croatian_Medieval">Usolsk</Name>
+      <Name language="Czech_Medieval">Usolsk</Name>
+      <Name language="Polish_Old">Usolsk</Name>
+      <Name language="Russian_Medieval">Usolsk</Name>
+      <Name language="Serbian_Medieval">Usolsk</Name>
+      <Name language="Slovak_Medieval">Usolsk</Name>
+      <Name language="Slovene_Medieval">Usolsk</Name>
+      <Name language="Sorbian">Usolsk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78482,6 +78626,16 @@
       <GameId game="CK2HIP" parent="c_zyriane" order="3">b_yarensk</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Yarensk</Name>
+      <Name language="Bulgarian_Old">Yarensk</Name>
+      <Name language="Croatian_Medieval">Yarensk</Name>
+      <Name language="Czech_Medieval">Yarensk</Name>
+      <Name language="Polish_Old">Yarensk</Name>
+      <Name language="Russian_Medieval">Yarensk</Name>
+      <Name language="Serbian_Medieval">Yarensk</Name>
+      <Name language="Slovak_Medieval">Yarensk</Name>
+      <Name language="Slovene_Medieval">Yarensk</Name>
+      <Name language="Sorbian">Yarensk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78543,6 +78697,17 @@
       <GameId game="CK2HIP" parent="c_chud" order="4">b_shenkursk</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Shengkar</Name>
+      <Name language="Finnish">Shengkar</Name>
+      <Name language="Karelian">Shengkar</Name>
+      <Name language="Khanty">Shengkar</Name>
+      <Name language="Komi">Shengkar</Name>
+      <Name language="Livonian">Shengkar</Name>
+      <Name language="Mari">Shengkar</Name>
+      <Name language="Moksha">Shengkar</Name>
+      <Name language="Sami">Shengkar</Name>
+      <Name language="Samoyed">Shengkar</Name>
+      <Name language="Vepsian_Medieval">Shengkar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78823,6 +78988,14 @@
       <GameId game="CK2HIP" parent="c_tbilisi" order="4">b_rustavi</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Rustaq</Name>
+      <Name language="Arabic_Bedouin">Rustaq</Name>
+      <Name language="Arabic_Egypt">Rustaq</Name>
+      <Name language="Arabic_Levant">Rustaq</Name>
+      <Name language="Arabic_Maghreb">Rustaq</Name>
+      <Name language="Arabic_Yemen">Rustaq</Name>
+      <Name language="Hejazi_Arabic">Rustaq</Name>
+      <Name language="Sicilian_Arabic">Rustaq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78956,6 +79129,7 @@
       <GameId game="CK2HIP" parent="c_kyunglung" order="1">b_kyunglung</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">K'üeh-lung</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78964,6 +79138,7 @@
       <GameId game="CK2HIP" parent="c_kyunglung" order="2">b_gurugem</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Ku-ru-chia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78972,6 +79147,7 @@
       <GameId game="CK2HIP" parent="c_kyunglung" order="3">b_tirthapuri</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Te-je-ta-po-je</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -78996,6 +79172,7 @@
       <GameId game="CK2HIP" parent="c_kyunglung" order="6">b_xalazakung</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Hsia-la-tzu-kung</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79004,6 +79181,7 @@
       <GameId game="CK2HIP" parent="c_kyunglung" order="7">b_gyanyima</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Ke-an-ni-ma</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79012,6 +79190,7 @@
       <GameId game="CK2HIP" parent="c_purang" order="2">b_khorzhak</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Ge-chia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79020,6 +79199,7 @@
       <GameId game="CK2HIP" parent="c_purang" order="3">b_teglakar</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Degelaka</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79036,6 +79216,7 @@
       <GameId game="CK2HIP" parent="c_purang" order="5">b_zhangja</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Sheng-chieh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79044,6 +79225,7 @@
       <GameId game="CK2HIP" parent="c_purang" order="6">b_dulung</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">To-lung</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79061,6 +79243,7 @@
       <GameId game="CK2HIP" parent="c_gegyai" order="2">b_zhungpa</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Hsiung-pa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79069,6 +79252,7 @@
       <GameId game="CK2HIP" parent="c_gegyai" order="3">b_yakra</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Ya-je</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79077,6 +79261,7 @@
       <GameId game="CK2HIP" parent="c_gegyai" order="4">b_chuktsang</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Ch'iëh-tsang</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79085,6 +79270,7 @@
       <GameId game="CK2HIP" parent="c_gegyai" order="5">b_arkog</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">A-kuo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79093,6 +79279,7 @@
       <GameId game="CK2HIP" parent="c_gegyai" order="6">b_kelle</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">K'o-le</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79101,6 +79288,7 @@
       <GameId game="CK2HIP" parent="c_gegyai" order="7">b_sekhadrig</GameId>
     </GameIds>
     <Names>
+      <Name language="Chinese_Middle">Se-k'a-chih</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79607,6 +79795,9 @@
       <GameId game="CK3">d_sky_lords</GameId>
     </GameIds>
     <Names>
+      <Name language="English">Lords of the Sky</Name>
+      <Name language="Romanian">Lorzii Cerului</Name>
+      <Name language="Spanish">Los Señores de los Cielos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -13825,6 +13825,7 @@
       <Name language="Danish_Middle">Rómverska keisaradæmið</Name>
       <Name language="English_Old_Norse">Rómverska keisaradæmið</Name>
       <Name language="Georgian">Romis Imperia</Name>
+      <Name language="Greek_Medieval">Basileia Rhõmaiõn</Name>
       <Name language="Hungarian_Old">Római Birodalom</Name>
       <Name language="Icelandic_Old">Rómverska keisaradæmið</Name>
       <Name language="Irish_Middle_Norse">Rómverska keisaradæmið</Name>
@@ -18658,12 +18659,15 @@
       <Name language="Arabic_Egypt">Sisiya</Name>
       <Name language="Arabic_Levant">Sisiya</Name>
       <Name language="Arabic_Maghreb">Sisiya</Name>
+      <Name language="Arabic_Yemen">Sisiya</Name>
       <Name language="Armenian_Middle">Sis</Name>
       <Name language="Dutch_Middle">Sisi</Name>
       <Name language="French_Old">Sisa</Name>
       <Name language="German">Sissi</Name>
+      <Name language="Hejazi_Arabic">Sisiya</Name>
       <Name language="Norman">Sisa</Name>
       <Name language="Oghuz">Kozan</Name>
+      <Name language="Sicilian_Arabic">Sisiya</Name>
       <Name language="Turkish_Old">Kozan</Name>
       <Name language="Turkmen_Medieval">Kozan</Name>
     </Names>
@@ -23801,7 +23805,7 @@
       <Name language="French_Old">Pologne</Name>
       <Name language="Galician">Polonia</Name>
       <Name language="German">Polen</Name>
-      <Name language="Gothic">Polonia</Name>
+      <Name language="Gothic">Pulinaland</Name>
       <Name language="Greek_Medieval">Polonía</Name>
       <Name language="Hungarian">Lengyelország</Name>
       <Name language="Icelandic_Old">Pulinaland</Name>
@@ -27596,7 +27600,19 @@
       <GameId game="CK2HIP" parent="c_pogesania" order="3">b_elbing</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Truso</Name>
+      <Name language="English_Old_Norse">Truso</Name>
+      <Name language="Gothic">Truso</Name>
+      <Name language="Irish_Middle_Norse">Truso</Name>
+      <Name language="Latgalian">Elblonga</Name>
       <Name language="Latin">Elbinga</Name>
+      <Name language="Lithuanian_Medieval">Elbingas</Name>
+      <Name language="Livonian">Truso</Name>
+      <Name language="Norwegian_Old">Truso</Name>
+      <Name language="Polish_Old">Elblag</Name>
+      <Name language="Prussian_Old">Elbings</Name>
+      <Name language="Sorbian">Elblag</Name>
+      <Name language="Swedish_Old">Truso</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -27605,7 +27621,14 @@
       <GameId game="CK2HIP" parent="c_pogesania" order="4">b_ostroda</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Ostrzeda</Name>
+      <Name language="Latgalian">Austrati</Name>
       <Name language="Latin">Osteroda</Name>
+      <Name language="Lithuanian_Medieval">Austrati</Name>
+      <Name language="Livonian">Austrati</Name>
+      <Name language="Polish_Old">Ostróda</Name>
+      <Name language="Prussian_Old">Austrati</Name>
+      <Name language="Sorbian">Ostróda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -41380,8 +41403,23 @@
       <GameId game="CK2HIP" parent="c_ossory" order="6">b_kilkenny</GameId>
     </GameIds>
     <Names>
-      <Name language="Lithuanian">Kilkenis</Name>
+      <Name language="Breton_Middle">Cill Chainnigh</Name>
+      <Name language="Cornish_Middle">Cill Chainnigh</Name>
+      <Name language="Cumbric">Cill Chainnigh</Name>
+      <Name language="Danish_Middle">Kilkanice</Name>
+      <Name language="English_Old_Norse">Kilkanice</Name>
+      <Name language="English_Old">Kilkanice</Name>
+      <Name language="Gothic">Kilkanice</Name>
+      <Name language="Icelandic_Old">Kilkanice</Name>
+      <Name language="Irish_Middle_Norse">Cheeill Chennee</Name>
+      <Name language="Irish_Middle">Cill Chainnigh</Name>
       <Name language="Latin">Canicopolis</Name>
+      <Name language="Lithuanian">Kilkenis</Name>
+      <Name language="Norse">Kilkanice</Name>
+      <Name language="Norwegian_Old">Kilkanice</Name>
+      <Name language="Scottish_Medieval">Cill Chainnigh</Name>
+      <Name language="Swedish_Old">Kilkanice</Name>
+      <Name language="Welsh_Middle">Cill Chainnigh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -43566,7 +43604,7 @@
   <LocationEntity>
     <Id>bari</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="c_bari" order="2">b_bari</GameId>
+      <GameId game="CK2HIP" parent="c_bari" order="3">b_bari</GameId>
       <GameId game="CK2HIP" parent="k_sicily" order="7">d_bari</GameId>
       <GameId game="ImperatorRome">66</GameId>
     </GameIds>
@@ -51133,7 +51171,17 @@
       <GameId game="CK2HIP" parent="c_murcia" order="1">b_molinalaseca</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mulínat as-Sikka</Name>
+      <Name language="Arabic_Bedouin">Mulínat as-Sikka</Name>
+      <Name language="Arabic_Egypt">Mulínat as-Sikka</Name>
+      <Name language="Arabic_Levant">Mulínat as-Sikka</Name>
+      <Name language="Arabic_Maghreb">Mulínat as-Sikka</Name>
+      <Name language="Arabic_Yemen">Mulínat as-Sikka</Name>
+      <Name language="Basque">Molina Seka</Name>
+      <Name language="French_Old">Molina-la-Sèche</Name>
+      <Name language="Hejazi_Arabic">Mulínat as-Sikka</Name>
       <Name language="Lombard">Mulìna</Name>
+      <Name language="Sicilian_Arabic">Mulínat as-Sikka</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -51143,7 +51191,16 @@
       <GameId game="CK2HIP" parent="d_murcia" order="2">c_almansa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Mansaf</Name>
+      <Name language="Arabic_Bedouin">al-Mansaf</Name>
+      <Name language="Arabic_Egypt">al-Mansaf</Name>
+      <Name language="Arabic_Levant">al-Mansaf</Name>
+      <Name language="Arabic_Maghreb">al-Mansaf</Name>
+      <Name language="Arabic_Yemen">al-Mansaf</Name>
+      <Name language="French_Old">Almanse</Name>
+      <Name language="Hejazi_Arabic">al-Mansaf</Name>
       <Name language="Latin">Arva</Name>
+      <Name language="Sicilian_Arabic">al-Mansaf</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -51152,6 +51209,16 @@
       <GameId game="CK2HIP" parent="c_almansa" order="4">b_albacete</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Basít</Name>
+      <Name language="Aragonese">Albacet</Name>
+      <Name language="Basque">Albazete</Name>
+      <Name language="Arabic_Bedouin">al-Basít</Name>
+      <Name language="Arabic_Egypt">al-Basít</Name>
+      <Name language="Hejazi_Arabic">al-Basít</Name>
+      <Name language="Arabic_Levant">al-Basít</Name>
+      <Name language="Arabic_Maghreb">al-Basít</Name>
+      <Name language="Sicilian_Arabic">al-Basít</Name>
+      <Name language="Arabic_Yemen">al-Basít</Name>
       <Name language="Latgalian">Albasete</Name>
       <Name language="Lithuanian">Albasete</Name>
     </Names>
@@ -51162,7 +51229,22 @@
       <GameId game="CK2HIP" parent="c_almansa" order="6">b_villarrobledo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qariya as-Sindiyyan</Name>
+      <Name language="Arabic_Bedouin">al-Qariya as-Sindiyyan</Name>
+      <Name language="Arabic_Egypt">al-Qariya as-Sindiyyan</Name>
+      <Name language="Arabic_Levant">al-Qariya as-Sindiyyan</Name>
+      <Name language="Arabic_Maghreb">al-Qariya as-Sindiyyan</Name>
+      <Name language="Arabic_Yemen">al-Qariya as-Sindiyyan</Name>
+      <Name language="Aragonese">Vila-Robret</Name>
+      <Name language="Basque">Herriharitz</Name>
+      <Name language="Catalan_Medieval">Vila-roureda</Name>
+      <Name language="French_Old">Ville-Chênaie</Name>
+      <Name language="Galician">Vilacarballeira</Name>
+      <Name language="Hejazi_Arabic">al-Qariya as-Sindiyyan</Name>
       <Name language="Latin">Robletum</Name>
+      <Name language="Leonese">Villacarballeda</Name>
+      <Name language="Portuguese">Vilacarvalheira</Name>
+      <Name language="Sicilian_Arabic">al-Qariya as-Sindiyyan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52740,6 +52822,9 @@
     </GameIds>
     <Names>
       <Name language="Alan">Partavi</Name>
+      <Name language="Armenian_Middle">Partaw</Name>
+      <Name language="Georgian">Bardavi</Name>
+      <Name language="Udi_Middle">Ardhan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52749,6 +52834,13 @@
     </GameIds>
     <Names>
       <Name language="Alan">Gandza</Name>
+      <Name language="Armenian_Middle">Gandzak</Name>
+      <Name language="Georgian">Gandza</Name>
+      <Name language="Oghuz">Gence</Name>
+      <Name language="Persian_Middle">Ganjak</Name>
+      <Name language="Turkish_Old">Gence</Name>
+      <Name language="Turkmen_Medieval">Gence</Name>
+      <Name language="Udi_Middle">Ardhan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56995,6 +57087,12 @@
       <GameId game="CK2HIP" parent="d_armenia_minor" order="1">c_tarsos</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Darson</Name>
+      <Name language="French_Old">Tarse</Name>
+      <Name language="Norman">Tarse</Name>
+      <Name language="Oghuz">Tarsus</Name>
+      <Name language="Turkish_Old">Tarsus</Name>
+      <Name language="Turkmen_Medieval">Tarsus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57011,6 +57109,8 @@
       <GameId game="CK2HIP" parent="c_tarsos" order="3">b_barbaron</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Chateau de Barbaron</Name>
+      <Name language="Norman">Chateau de Barbaron</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57019,6 +57119,17 @@
       <GameId game="CK2HIP" parent="c_tarsos" order="4">b_zephyrium</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qalamiya</Name>
+      <Name language="Arabic_Bedouin">al-Qalamiya</Name>
+      <Name language="Arabic_Egypt">al-Qalamiya</Name>
+      <Name language="Arabic_Levant">al-Qalamiya</Name>
+      <Name language="Arabic_Maghreb">al-Qalamiya</Name>
+      <Name language="Arabic_Yemen">al-Qalamiya</Name>
+      <Name language="Hejazi_Arabic">al-Qalamiya</Name>
+      <Name language="Oghuz">Mersin</Name>
+      <Name language="Sicilian_Arabic">al-Qalamiya</Name>
+      <Name language="Turkish_Old">Mersin</Name>
+      <Name language="Turkmen_Medieval">Mersin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57027,6 +57138,17 @@
       <GameId game="CK2HIP" parent="c_tarsos" order="5">b_pendosis</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Badandun</Name>
+      <Name language="Arabic_Bedouin">al-Badandun</Name>
+      <Name language="Arabic_Egypt">al-Badandun</Name>
+      <Name language="Arabic_Levant">al-Badandun</Name>
+      <Name language="Arabic_Maghreb">al-Badandun</Name>
+      <Name language="Arabic_Yemen">al-Badandun</Name>
+      <Name language="Hejazi_Arabic">al-Badandun</Name>
+      <Name language="Oghuz">Pozanti</Name>
+      <Name language="Sicilian_Arabic">al-Badandun</Name>
+      <Name language="Turkish_Old">Pozanti</Name>
+      <Name language="Turkmen_Medieval">Pozanti</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57035,6 +57157,17 @@
       <GameId game="CK2HIP" parent="c_tarsos" order="6">b_gouglak</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hisn al-Saqaliba</Name>
+      <Name language="Arabic_Bedouin">Hisn al-Saqaliba</Name>
+      <Name language="Arabic_Egypt">Hisn al-Saqaliba</Name>
+      <Name language="Arabic_Levant">Hisn al-Saqaliba</Name>
+      <Name language="Arabic_Maghreb">Hisn al-Saqaliba</Name>
+      <Name language="Arabic_Yemen">Hisn al-Saqaliba</Name>
+      <Name language="Hejazi_Arabic">Hisn al-Saqaliba</Name>
+      <Name language="Oghuz">Gülek</Name>
+      <Name language="Sicilian_Arabic">Hisn al-Saqaliba</Name>
+      <Name language="Turkish_Old">Gülek</Name>
+      <Name language="Turkmen_Medieval">Gülek</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57043,6 +57176,20 @@
       <GameId game="CK2HIP" parent="c_adana" order="1">b_alharuniya</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Haruniya</Name>
+      <Name language="Arabic_Bedouin">al-Haruniya</Name>
+      <Name language="Arabic_Egypt">al-Haruniya</Name>
+      <Name language="Arabic_Levant">al-Haruniya</Name>
+      <Name language="Arabic_Maghreb">al-Haruniya</Name>
+      <Name language="Arabic_Yemen">al-Haruniya</Name>
+      <Name language="Armenian_Middle">Harunia</Name>
+      <Name language="French_Old">Haronia</Name>
+      <Name language="Hejazi_Arabic">al-Haruniya</Name>
+      <Name language="Norman">Haronia</Name>
+      <Name language="Oghuz">Haruniye</Name>
+      <Name language="Sicilian_Arabic">al-Haruniya</Name>
+      <Name language="Turkish_Old">Haruniye</Name>
+      <Name language="Turkmen_Medieval">Haruniye</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57051,6 +57198,20 @@
       <GameId game="CK2HIP" parent="c_adana" order="3">b_mamistra</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Massisah</Name>
+      <Name language="Arabic_Bedouin">al-Massisah</Name>
+      <Name language="Arabic_Egypt">al-Massisah</Name>
+      <Name language="Arabic_Levant">al-Massisah</Name>
+      <Name language="Arabic_Maghreb">al-Massisah</Name>
+      <Name language="Arabic_Yemen">al-Massisah</Name>
+      <Name language="Armenian_Middle">Mamistra</Name>
+      <Name language="French_Old">Mamistra</Name>
+      <Name language="Hejazi_Arabic">al-Massisah</Name>
+      <Name language="Norman">Mamistra</Name>
+      <Name language="Oghuz">Misis</Name>
+      <Name language="Sicilian_Arabic">al-Massisah</Name>
+      <Name language="Turkish_Old">Misis</Name>
+      <Name language="Turkmen_Medieval">Misis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57059,6 +57220,23 @@
       <GameId game="CK2HIP" parent="c_adana" order="4">b_lajazzo</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Ayas</Name>
+      <Name language="Dalmatian_Medieval">Laiazzo</Name>
+      <Name language="French_Old">Laicas</Name>
+      <Name language="Italian_Central">Laiazzo</Name>
+      <Name language="Italian_Medieval">Laiazzo</Name>
+      <Name language="Langobardic">Laiazzo</Name>
+      <Name language="Ligurian">Laiazzo</Name>
+      <Name language="Neapolitan">Laiazzo</Name>
+      <Name language="Norman">Laicas</Name>
+      <Name language="Oghuz">Yumurtalik</Name>
+      <Name language="Sardinian">Laiazzo</Name>
+      <Name language="Sicilian">Laiazzo</Name>
+      <Name language="Turkish_Old">Yumurtalik</Name>
+      <Name language="Turkmen_Medieval">Yumurtalik</Name>
+      <Name language="Tuscan_Medieval">Laiazzo</Name>
+      <Name language="Umbrian_Medieval">Laiazzo</Name>
+      <Name language="Venetian_Medieval">Laiazzo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57067,6 +57245,10 @@
       <GameId game="CK2HIP" parent="c_adana" order="5">b_yilankale</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Levonkla</Name>
+      <Name language="Oghuz">Yilankale</Name>
+      <Name language="Turkish_Old">Yilankale</Name>
+      <Name language="Turkmen_Medieval">Yilankale</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57075,6 +57257,10 @@
       <GameId game="CK2HIP" parent="c_adana" order="6">b_savrandacastle</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Saruantik'ar</Name>
+      <Name language="Oghuz">Savranda</Name>
+      <Name language="Turkish_Old">Savranda</Name>
+      <Name language="Turkmen_Medieval">Savranda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57083,6 +57269,20 @@
       <GameId game="CK2HIP" parent="c_sis" order="2">b_anazarba</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ayn-Zarba</Name>
+      <Name language="Arabic_Bedouin">Ayn-Zarba</Name>
+      <Name language="Arabic_Egypt">Ayn-Zarba</Name>
+      <Name language="Arabic_Levant">Ayn-Zarba</Name>
+      <Name language="Arabic_Maghreb">Ayn-Zarba</Name>
+      <Name language="Arabic_Yemen">Ayn-Zarba</Name>
+      <Name language="Armenian_Middle">Anazarwa</Name>
+      <Name language="French_Old">Naversa</Name>
+      <Name language="Hejazi_Arabic">Ayn-Zarba</Name>
+      <Name language="Norman">Naversa</Name>
+      <Name language="Oghuz">Anavarza</Name>
+      <Name language="Sicilian_Arabic">Ayn-Zarba</Name>
+      <Name language="Turkish_Old">Anavarza</Name>
+      <Name language="Turkmen_Medieval">Anavarza</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57091,6 +57291,10 @@
       <GameId game="CK2HIP" parent="c_sis" order="3">b_vakha</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Vakhay</Name>
+      <Name language="Oghuz">Feke</Name>
+      <Name language="Turkish_Old">Feke</Name>
+      <Name language="Turkmen_Medieval">Feke</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57099,6 +57303,9 @@
       <GameId game="CK2HIP" parent="c_sis" order="4">b_trazak</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Horzum</Name>
+      <Name language="Turkish_Old">Horzum</Name>
+      <Name language="Turkmen_Medieval">Horzum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57107,6 +57314,7 @@
       <GameId game="CK2HIP" parent="c_sis" order="5">b_bardzberd</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Partzerpert</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58798,6 +59006,13 @@
       <GameId game="CK2HIP" parent="c_bezhetsky_verh" order="1">b_staryaladoga</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Aldeigjuburgh</Name>
+      <Name language="English_Old_Norse">Aldeigjuborg</Name>
+      <Name language="Gothic">Aldeigjuborg</Name>
+      <Name language="Irish_Middle_Norse">Aldeigjuborg</Name>
+      <Name language="Norse">Aldeigjuborg</Name>
+      <Name language="Norwegian_Old">Aldeigjuborg</Name>
+      <Name language="Swedish_Old">Aldeigjuborg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59678,6 +59893,7 @@
       <Name language="German_Middle_High">Samland</Name>
       <Name language="German_Middle_Low">Samland</Name>
       <Name language="German_Old_Low">Samland</Name>
+      <Name language="Gothic">Zambia</Name>
       <Name language="Irish_Middle_Norse">Zambia</Name>
       <Name language="Norwegian_Old">Zambia</Name>
       <Name language="Polish_Old">Sambija</Name>
@@ -59766,6 +59982,7 @@
       <Name language="German_Middle_High">Cranz</Name>
       <Name language="German_Middle_Low">Cranz</Name>
       <Name language="German_Old_Low">Cranz</Name>
+      <Name language="Gothic">Kaup</Name>
       <Name language="Icelandic_Old">Kaup</Name>
       <Name language="Irish_Middle_Norse">Kaup</Name>
       <Name language="Latgalian">Krantas</Name>
@@ -60062,6 +60279,13 @@
       <GameId game="CK2HIP" parent="c_pogesania" order="1">b_tolkmicko</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Tolkmicko</Name>
+      <Name language="Latgalian">Tolkmicko</Name>
+      <Name language="Lithuanian_Medieval">Tolkmicko</Name>
+      <Name language="Livonian">Tolkmicko</Name>
+      <Name language="Polish_Old">Tolkmicko</Name>
+      <Name language="Prussian_Old">Tolkmicko</Name>
+      <Name language="Sorbian">Tolkmicko</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60070,6 +60294,13 @@
       <GameId game="CK2HIP" parent="c_pogesania" order="2">b_dzialdowo</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Dzialdovo</Name>
+      <Name language="Latgalian">Dzialdowo</Name>
+      <Name language="Lithuanian_Medieval">Dzialdowo</Name>
+      <Name language="Livonian">Dzialdowo</Name>
+      <Name language="Polish_Old">Dzialdowo</Name>
+      <Name language="Prussian_Old">Dzialdowo</Name>
+      <Name language="Sorbian">Dzialdowo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60086,6 +60317,13 @@
       <GameId game="CK2HIP" parent="c_bartia" order="1">b_gierdawy</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Gierdawy</Name>
+      <Name language="Latgalian">Girdau</Name>
+      <Name language="Lithuanian_Medieval">Girdau</Name>
+      <Name language="Polish_Old">Gierdawy</Name>
+      <Name language="Prussian_Old">Girdau</Name>
+      <Name language="Slovak_Medieval">Gierdawy</Name>
+      <Name language="Sorbian">Gierdawy</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61859,8 +62097,11 @@
     <Id>derna</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tobruk" order="2">b_derna</GameId>
+      <GameId game="ImperatorRome">3363</GameId> <!-- Darnis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Darnis</Name>
+      <Name language="Latin_Medieval">Darnis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61869,14 +62110,19 @@
       <GameId game="CK2HIP" parent="c_tobruk" order="2">b_bardia</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Petras Megas</Name>
+      <Name language="Latin_Medieval">Petras Maior</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>acroma</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tobruk" order="7">b_acroma</GameId>
+      <GameId game="ImperatorRome">3369</GameId> <!-- Gonia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Gonia</Name>
+      <Name language="Latin_Medieval">Gonia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65970,6 +66216,20 @@
       <GameId game="CK2HIP" parent="c_kildare" order="4">b_old_leighlin</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Seanleithghlinn</Name>
+      <Name language="Cornish_Middle">Seanleithghlinn</Name>
+      <Name language="Cumbric">Seanleithghlinn</Name>
+      <Name language="Danish_Middle">Ealdleiglin</Name>
+      <Name language="English_Old_Norse">Ealdleiglin</Name>
+      <Name language="English_Old">Ealdleiglin</Name>
+      <Name language="Gothic">Ealdleiglin</Name>
+      <Name language="Icelandic_Old">Ealdleiglin</Name>
+      <Name language="Irish_Middle_Norse">Ealdleiglin</Name>
+      <Name language="Irish_Middle">Seanleithghlinn</Name>
+      <Name language="Norwegian_Old">Ealdleiglin</Name>
+      <Name language="Scottish_Medieval">Seanleithghlinn</Name>
+      <Name language="Swedish_Old">Ealdleiglin</Name>
+      <Name language="Welsh_Middle">Seanleithghlinn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65994,6 +66254,21 @@
       <GameId game="CK2HIP" parent="c_wicklow" order="1">b_wicklow</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Cill Mhantáin</Name>
+      <Name language="Cornish_Middle">Cill Mhantáin</Name>
+      <Name language="Cumbric">Cill Mhantáin</Name>
+      <Name language="Danish_Middle">Wykynlo</Name>
+      <Name language="English_Old_Norse">Wykynlo</Name>
+      <Name language="English_Old">Wygingelow</Name>
+      <Name language="Gothic">Wykynlo</Name>
+      <Name language="Icelandic_Old">Wykynlo</Name>
+      <Name language="Irish_Middle_Norse">Wykynlo</Name>
+      <Name language="Irish_Middle">Cill Mhantáin</Name>
+      <Name language="Norse">Wykynlo</Name>
+      <Name language="Norwegian_Old">Wykynlo</Name>
+      <Name language="Scottish_Medieval">Cill Mhantáin</Name>
+      <Name language="Swedish_Old">Wykynlo</Name>
+      <Name language="Welsh_Middle">Cill Mhantáin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66002,6 +66277,20 @@
       <GameId game="CK2HIP" parent="c_wicklow" order="2">b_arklow</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Inbhear Mór</Name>
+      <Name language="Cornish_Middle">Inbhear Mór</Name>
+      <Name language="Cumbric">Inbhear Mór</Name>
+      <Name language="Danish_Middle">Inver Mooar</Name>
+      <Name language="English_Old_Norse">Inver Mooar</Name>
+      <Name language="Gothic">Inver Mooar</Name>
+      <Name language="Icelandic_Old">Inver Mooar</Name>
+      <Name language="Irish_Middle_Norse">Arnkell-lág</Name>
+      <Name language="Irish_Middle">Inbhear Mór</Name>
+      <Name language="Norse">Inver Mooar</Name>
+      <Name language="Norwegian_Old">Inver Mooar</Name>
+      <Name language="Scottish_Medieval">Inbhear Mór</Name>
+      <Name language="Swedish_Old">Inver Mooar</Name>
+      <Name language="Welsh_Middle">Inbhear Mór</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66010,6 +66299,21 @@
       <GameId game="CK2HIP" parent="c_wicklow" order="3">b_glendalough</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Gleann Dá Loch</Name>
+      <Name language="Cornish_Middle">Gleann Dá Loch</Name>
+      <Name language="Cumbric">Gleann Dá Loch</Name>
+      <Name language="Danish_Middle">Glanda-lág</Name>
+      <Name language="English_Old_Norse">Glanda-lág</Name>
+      <Name language="English_Old">Glandalag</Name>
+      <Name language="Gothic">Glanda-lág</Name>
+      <Name language="Icelandic_Old">Glanda-lág</Name>
+      <Name language="Irish_Middle_Norse">Glanda-lág</Name>
+      <Name language="Irish_Middle">Gleann Dá Loch</Name>
+      <Name language="Norse">Glanda-lág</Name>
+      <Name language="Norwegian_Old">Glanda-lág</Name>
+      <Name language="Scottish_Medieval">Gleann Dá Loch</Name>
+      <Name language="Swedish_Old">Glanda-lág</Name>
+      <Name language="Welsh_Middle">Gleann Dá Loch</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66018,6 +66322,21 @@
       <GameId game="CK2HIP" parent="c_wicklow" order="4">b_carnew</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Carn an Bhua</Name>
+      <Name language="Cornish_Middle">Carn an Bhua</Name>
+      <Name language="Cumbric">Carn an Bhua</Name>
+      <Name language="Danish_Middle">Carnebothe</Name>
+      <Name language="English_Old_Norse">Carnebothe</Name>
+      <Name language="English_Old">Carnebothe</Name>
+      <Name language="Gothic">Carnebothe</Name>
+      <Name language="Icelandic_Old">Carnebothe</Name>
+      <Name language="Irish_Middle_Norse">Carn an Bhua</Name>
+      <Name language="Irish_Middle">Carn an Bhua</Name>
+      <Name language="Norse">Carnebothe</Name>
+      <Name language="Norwegian_Old">Carnebothe</Name>
+      <Name language="Scottish_Medieval">Carn an Bhua</Name>
+      <Name language="Swedish_Old">Carnebothe</Name>
+      <Name language="Welsh_Middle">Carn an Bhua</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69353,6 +69672,16 @@
       <GameId game="CK2HIP" parent="c_tudela" order="1">b_tudela</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tutíla</Name>
+      <Name language="Arabic_Bedouin">Tutíla</Name>
+      <Name language="Arabic_Egypt">Tutíla</Name>
+      <Name language="Arabic_Levant">Tutíla</Name>
+      <Name language="Arabic_Maghreb">Tutíla</Name>
+      <Name language="Arabic_Yemen">Tutíla</Name>
+      <Name language="Basque">Tutera</Name>
+      <Name language="French_Old">Tudèle</Name>
+      <Name language="Hejazi_Arabic">Tutíla</Name>
+      <Name language="Sicilian_Arabic">Tutíla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69361,6 +69690,17 @@
       <GameId game="CK2HIP" parent="c_tudela" order="2">b_cascante</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qashqant</Name>
+      <Name language="Arabic_Bedouin">Qashqant</Name>
+      <Name language="Arabic_Egypt">Qashqant</Name>
+      <Name language="Arabic_Levant">Qashqant</Name>
+      <Name language="Arabic_Maghreb">Qashqant</Name>
+      <Name language="Arabic_Yemen">Qashqant</Name>
+      <Name language="Aragonese">Cascant</Name>
+      <Name language="Basque">Kaskante</Name>
+      <Name language="Catalan_Medieval">Cascant</Name>
+      <Name language="Hejazi_Arabic">Qashqant</Name>
+      <Name language="Sicilian_Arabic">Qashqant</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69369,6 +69709,21 @@
       <GameId game="CK2HIP" parent="c_tudela" order="3">b_carcastillo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qarqastal</Name>
+      <Name language="Arabic_Bedouin">Qarqastal</Name>
+      <Name language="Arabic_Egypt">Qarqastal</Name>
+      <Name language="Arabic_Levant">Qarqastal</Name>
+      <Name language="Arabic_Maghreb">Qarqastal</Name>
+      <Name language="Arabic_Yemen">Qarqastal</Name>
+      <Name language="Aragonese">Carcastiellu</Name>
+      <Name language="Basque">Zarrakaztelu</Name>
+      <Name language="Catalan_Medieval">Carcastell</Name>
+      <Name language="French_Old">Carchatel</Name>
+      <Name language="Galician">Carcastro</Name>
+      <Name language="Hejazi_Arabic">Qarqastal</Name>
+      <Name language="Leonese">Carcastiellu</Name>
+      <Name language="Portuguese">Carcastelo</Name>
+      <Name language="Sicilian_Arabic">Qarqastal</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69377,6 +69732,20 @@
       <GameId game="CK2HIP" parent="c_tudela" order="4">b_valtierra</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Wadi al-Dira</Name>
+      <Name language="Arabic_Bedouin">Wadi al-Dira</Name>
+      <Name language="Arabic_Egypt">Wadi al-Dira</Name>
+      <Name language="Arabic_Levant">Wadi al-Dira</Name>
+      <Name language="Arabic_Maghreb">Wadi al-Dira</Name>
+      <Name language="Arabic_Yemen">Wadi al-Dira</Name>
+      <Name language="Aragonese">Val Tierra</Name>
+      <Name language="Basque">Baltierra</Name>
+      <Name language="Catalan_Medieval">Valterra</Name>
+      <Name language="French_Old">Valterre</Name>
+      <Name language="Galician">Valterra</Name>
+      <Name language="Hejazi_Arabic">Wadi al-Dira</Name>
+      <Name language="Portuguese">Valterra</Name>
+      <Name language="Sicilian_Arabic">Wadi al-Dira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70989,6 +71358,17 @@
       <GameId game="CK2HIP" parent="c_murcia" order="5">b_alcantarilla</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qantara</Name>
+      <Name language="Arabic_Bedouin">al-Qantara</Name>
+      <Name language="Arabic_Egypt">al-Qantara</Name>
+      <Name language="Arabic_Levant">al-Qantara</Name>
+      <Name language="Arabic_Maghreb">al-Qantara</Name>
+      <Name language="Arabic_Yemen">al-Qantara</Name>
+      <Name language="Basque">Alkantarilla</Name>
+      <Name language="Catalan_Medieval">Alcàntareta</Name>
+      <Name language="Hejazi_Arabic">al-Qantara</Name>
+      <Name language="Portuguese">Alcântarela</Name>
+      <Name language="Sicilian_Arabic">al-Qantara</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70997,6 +71377,22 @@
       <GameId game="CK2HIP" parent="c_murcia" order="2">b_medinasiyasa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Madína Siyasa</Name>
+      <Name language="Arabic_Bedouin">Madína Siyasa</Name>
+      <Name language="Arabic_Egypt">Madína Siyasa</Name>
+      <Name language="Arabic_Levant">Madína Siyasa</Name>
+      <Name language="Arabic_Maghreb">Madína Siyasa</Name>
+      <Name language="Arabic_Yemen">Madína Siyasa</Name>
+      <Name language="Aragonese">Cieza</Name>
+      <Name language="Basque">Zieza</Name>
+      <Name language="Castilian">Cieza</Name>
+      <Name language="Catalan_Medieval">Cieza</Name>
+      <Name language="French_Old">Cieza</Name>
+      <Name language="Galician">Cieza</Name>
+      <Name language="Hejazi_Arabic">Madína Siyasa</Name>
+      <Name language="Leonese">Cieza</Name>
+      <Name language="Portuguese">Cieza</Name>
+      <Name language="Sicilian_Arabic">Madína Siyasa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71005,6 +71401,17 @@
       <GameId game="CK2HIP" parent="c_almansa" order="7">b_villena</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bilyana</Name>
+      <Name language="Arabic_Bedouin">Bilyana</Name>
+      <Name language="Arabic_Egypt">Bilyana</Name>
+      <Name language="Arabic_Levant">Bilyana</Name>
+      <Name language="Arabic_Maghreb">Bilyana</Name>
+      <Name language="Arabic_Yemen">Bilyana</Name>
+      <Name language="Basque">Bilena</Name>
+      <Name language="French_Old">Villène</Name>
+      <Name language="Hejazi_Arabic">Bilyana</Name>
+      <Name language="Portuguese">Vilhena</Name>
+      <Name language="Sicilian_Arabic">Bilyana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71013,6 +71420,17 @@
       <GameId game="CK2HIP" parent="c_almansa" order="4">b_hellin</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Iyyuh</Name>
+      <Name language="Arabic_Bedouin">Iyyuh</Name>
+      <Name language="Arabic_Egypt">Iyyuh</Name>
+      <Name language="Arabic_Levant">Iyyuh</Name>
+      <Name language="Arabic_Maghreb">Iyyuh</Name>
+      <Name language="Arabic_Yemen">Iyyuh</Name>
+      <Name language="Basque">Hellin</Name>
+      <Name language="Catalan_Medieval">Hellí</Name>
+      <Name language="French_Old">Hellin</Name>
+      <Name language="Hejazi_Arabic">Iyyuh</Name>
+      <Name language="Sicilian_Arabic">Iyyuh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71021,6 +71439,21 @@
       <GameId game="CK2HIP" parent="c_almansa" order="3">b_alcaladeljucar</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at as-Shuqr</Name>
+      <Name language="Arabic_Bedouin">Qal'at as-Shuqr</Name>
+      <Name language="Arabic_Egypt">Qal'at as-Shuqr</Name>
+      <Name language="Arabic_Levant">Qal'at as-Shuqr</Name>
+      <Name language="Arabic_Maghreb">Qal'at as-Shuqr</Name>
+      <Name language="Arabic_Yemen">Qal'at as-Shuqr</Name>
+      <Name language="Aragonese">Alcalá d'o Xúcar</Name>
+      <Name language="Basque">Alkala Xukar</Name>
+      <Name language="Catalan_Medieval">Alcalà del Xúquer</Name>
+      <Name language="French_Old">Alcala-sur-Xúquer</Name>
+      <Name language="Galician">Alcalá do Xúcar</Name>
+      <Name language="Hejazi_Arabic">Qal'at as-Shuqr</Name>
+      <Name language="Leonese">Alcalá del Xúcar</Name>
+      <Name language="Portuguese">Alcalá do Xúcar</Name>
+      <Name language="Sicilian_Arabic">Qal'at as-Shuqr</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71029,6 +71462,19 @@
       <GameId game="CK2HIP" parent="c_almansa" order="7">b_pozocanada</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qannad</Name>
+      <Name language="Arabic_Bedouin">Qannad</Name>
+      <Name language="Arabic_Egypt">Qannad</Name>
+      <Name language="Arabic_Levant">Qannad</Name>
+      <Name language="Arabic_Maghreb">Qannad</Name>
+      <Name language="Arabic_Yemen">Qannad</Name>
+      <Name language="Aragonese">Pozo Canyada</Name>
+      <Name language="Basque">Putzu Kañada</Name>
+      <Name language="Catalan_Medieval">Pou Canyada</Name>
+      <Name language="French_Old">Puits-Cagnée</Name>
+      <Name language="Hejazi_Arabic">Qannad</Name>
+      <Name language="Portuguese">Poço Canhada</Name>
+      <Name language="Sicilian_Arabic">Qannad</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74221,8 +74667,15 @@
     <Id>madain</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_baghdad" order="3">b_madain</GameId>
+      <GameId game="ImperatorRome">912</GameId> <!-- Ctesiphon -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Ktesiphon</Name>
+      <Name language="Greek_Medieval">Ktesiphon</Name>
+      <Name language="Latin_Ancient">Ctesiphon</Name>
+      <Name language="Latin_Medieval">Ctesiphon</Name>
+      <Name language="Persian_Middle">Tesifon</Name>
+      <Name language="Syriac_Classical">Seliq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74309,8 +74762,13 @@
     <Id>tagrit</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_druz" order="2">b_tagrit</GameId>
+      <GameId game="ImperatorRome">806</GameId> <!-- Birtha -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Birtha</Name>
+      <Name language="Latin_Medieval">Birtha</Name>
+      <Name language="Persian_Middle">Tagrit</Name>
+      <Name language="Syriac_Classical">Tagrit</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74328,6 +74786,8 @@
       <GameId game="CK2HIP" parent="c_kermanshah" order="7">b_kermanshah</GameId>
     </GameIds>
     <Names>
+      <Name language="Kurdish">Qarmîsin</Name>
+      <Name language="Persian_Middle">Kirmanshah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74336,6 +74796,7 @@
       <GameId game="CK2HIP" parent="c_kermanshah" order="2">b_hulwan</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Peroz Kavad</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74353,6 +74814,13 @@
       <GameId game="CK2HIP" parent="d_kurdistan" order="2">c_kirkuk</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Korkyra</Name>
+      <Name language="Kurdish">Kerkûk</Name>
+      <Name language="Latin_Medieval">Corcura</Name>
+      <Name language="Oghuz">Kerkük</Name>
+      <Name language="Syriac_Classical">Karka d-Beth Slokh</Name>
+      <Name language="Turkish_Old">Kerkük</Name>
+      <Name language="Turkmen_Medieval">Kerkük</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74361,6 +74829,9 @@
       <GameId game="CK2HIP" parent="c_kirkuk" order="1">b_daquq</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Dakuk</Name>
+      <Name language="Turkish_Old">Dakuk</Name>
+      <Name language="Turkmen_Medieval">Dakuk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74370,6 +74841,11 @@
       <GameId game="CK2HIP" parent="c_shahrazur" order="1">b_shahrazur</GameId>
     </GameIds>
     <Names>
+      <Name language="Kurdish">Sehrezûr</Name>
+      <Name language="Oghuz">Šehr-i Zor</Name>
+      <Name language="Persian_Middle">Syarzur</Name>
+      <Name language="Turkish_Old">Šehr-i Zor</Name>
+      <Name language="Turkmen_Medieval">Šehr-i Zor</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -90018,14 +90494,6 @@
     </GameIds>
     <Names>
       <Name language="Italian">Gallarate</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>bari</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_bari" order="3">b_bari</GameId>
-    </GameIds>
-    <Names>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -12198,21 +12198,9 @@
     <Id>hradec</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_bohemia" order="3">c_hradec</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Bosnian">Gradac</Name>
-      <Name language="Bulgarian">Gradec</Name>
-      <Name language="Croatian">Gradac</Name>
-      <Name language="Czech_Medieval">Hradecz</Name>
-      <Name language="Serbian">Gradac</Name>
-      <Name language="Slovak_Medieval">Hradecz</Name>
-      <Name language="Slovene">Gradec</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>hradeckralove</Id>
-    <GameIds>
       <GameId game="CK2HIP" parent="c_hradec" order="1">b_hradeckralove</GameId>
+      <GameId game="CK3">b_hradec</GameId>
+      <GameId game="CK3">c_hradec</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Grätz</Name>
@@ -12233,9 +12221,19 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>dvur-chvojno</Id>
+    <GameIds>
+      <GameId game="CK3">b_dvur-chvojno</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Dvůr-Chvojno</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>chrudim</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_hradec" order="2">b_chrudim</GameId>
+      <GameId game="CK3">b_chrudim</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Crudim</Name>
@@ -12243,6 +12241,7 @@
       <Name language="Bosnian">Hrudim</Name>
       <Name language="Bulgarian">Hrudim</Name>
       <Name language="Croatian">Hrudim</Name>
+      <Name language="Czech_Medieval">Chrudim</Name>
       <Name language="Frankish_Low">Crudim</Name>
       <Name language="Frankish">Crudim</Name>
       <Name language="German_Middle_High">Crudim</Name>
@@ -12258,6 +12257,7 @@
     <Id>jaromer</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_hradec" order="4">b_jaromer</GameId>
+      <GameId game="CK3">b_jaromer</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Jermer</Name>
@@ -12265,7 +12265,7 @@
       <Name language="Bosnian">Jaromjerž</Name>
       <Name language="Bulgarian">Jaromjerž</Name>
       <Name language="Croatian">Jaromjerž</Name>
-      <Name language="Czech_Medieval">Jaromierz</Name>
+      <Name language="Czech_Medieval">Jaroměř</Name>
       <Name language="Frankish_Low">Jermer</Name>
       <Name language="Frankish">Jermer</Name>
       <Name language="German_Middle_High">Jermer</Name>
@@ -12274,9 +12274,18 @@
       <Name language="Lithuanian">Jaromeržas</Name>
       <Name language="Polish_Old">Jaromierz</Name>
       <Name language="Serbian">Jaromjerž</Name>
-      <Name language="Slovak_Medieval">Jaromierz</Name>
+      <Name language="Slovak_Medieval">Jaroměř</Name>
       <Name language="Slovene">Jaromjerž</Name>
       <Name language="Thuringian">Jermer</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kladzko</Id>
+    <GameIds>
+      <GameId game="CK3">b_kladzko</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Kladzko</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12930,6 +12939,7 @@
     <Id>moravia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="k_bohemia" order="2">d_moravia</GameId>
+      <GameId game="CK3">d_moravia</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Mähre</Name>
@@ -12978,6 +12988,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_olomouc" order="1">b_olomouc</GameId>
       <GameId game="CK2HIP" parent="d_moravia" order="1">c_olomouc</GameId>
+      <GameId game="CK3">b_olomouc</GameId>
+      <GameId game="CK3">c_olomouc</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Olmütz</Name>
@@ -13033,6 +13045,7 @@
     <Id>unicov</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_olomouc" order="4">b_unicov</GameId>
+      <GameId game="CK3">b_unicov</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Neustadt</Name>
@@ -13040,7 +13053,7 @@
       <Name language="Bosnian">Unjicov</Name>
       <Name language="Bulgarian">Unjicov</Name>
       <Name language="Croatian">Unjicov</Name>
-      <Name language="Czech_Medieval">Uniczow</Name>
+      <Name language="Czech_Medieval">Uničov</Name>
       <Name language="Frankish_Low">Neustadt</Name>
       <Name language="Frankish">Neustadt</Name>
       <Name language="German_Middle_High">Neustadt</Name>
@@ -13049,7 +13062,7 @@
       <Name language="Latgalian">Unicova</Name>
       <Name language="Polish_Old">Uniczow</Name>
       <Name language="Serbian">Unjicov</Name>
-      <Name language="Slovak_Medieval">Uniczow</Name>
+      <Name language="Slovak_Medieval">Uničov</Name>
       <Name language="Slovene">Unjicov</Name>
       <Name language="Thuringian">Neustadt</Name>
     </Names>
@@ -13071,6 +13084,7 @@
     <Id>kromeriz</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_olomouc" order="6">b_kromeriz</GameId>
+      <GameId game="CK3">b_kromeriz</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Kremsier</Name>
@@ -13078,7 +13092,7 @@
       <Name language="Bosnian">Kromjeržiž</Name>
       <Name language="Bulgarian">Kromeržiž</Name>
       <Name language="Croatian">Kromjeržiž</Name>
-      <Name language="Czech_Medieval">Kromierziz</Name>
+      <Name language="Czech_Medieval">Kroměříž</Name>
       <Name language="Frankish_Low">Kremsier</Name>
       <Name language="Frankish">Kremsier</Name>
       <Name language="German_Middle_High">Kremsier</Name>
@@ -13088,7 +13102,7 @@
       <Name language="Lithuanian">Kromeržyžas</Name>
       <Name language="Polish_Old">Kromieryz</Name>
       <Name language="Serbian">Kromjeržiž</Name>
-      <Name language="Slovak_Medieval">Kromierziz</Name>
+      <Name language="Slovak_Medieval">Kroměříž</Name>
       <Name language="Slovene">Kromjeržiž</Name>
       <Name language="Szekely_Old">Kromerzsízs</Name>
       <Name language="Thuringian">Kremsier</Name>
@@ -13143,6 +13157,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_opava" order="1">b_opava</GameId>
       <GameId game="CK2HIP" parent="d_moravia" order="2">c_opava</GameId>
+      <GameId game="CK3">b_opava</GameId>
+      <GameId game="CK3">c_opava</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Troppau</Name>
@@ -13157,6 +13173,16 @@
       <Name language="Polish_Old">Opawa</Name>
       <Name language="Slovak_Medieval">Opawa</Name>
       <Name language="Thuringian">Troppau</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hradec_moravia</Id>
+    <GameIds>
+      <GameId game="CK3">b_hradec-nad-moravici</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Hradec nad Moravicí</Name>
+      <Name language="Slovak_Medieval">Hradec nad Moravicí</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -13295,6 +13321,8 @@
     <Id>jihlava</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_znojmo" order="2">b_jihlava</GameId>
+      <GameId game="CK3">b_jihlava</GameId>
+      <GameId game="CK3">c_jihlava</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Iglau</Name>
@@ -13315,6 +13343,18 @@
       <Name language="Slovene">Iglava</Name>
       <Name language="Szekely_Old">Igló</Name>
       <Name language="Thuringian">Iglau</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>telcz</Id>
+    <GameIds>
+      <GameId game="CK3">b_telcz</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Telcz</Name>
+      <Name language="Czech">Telč</Name>
+      <Name language="German">Teltsch</Name>
+      <Name language="Slovak_Medieval">Telcz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53887,19 +53927,30 @@
     <Id>caslav</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_hradec" order="5">b_caslav</GameId>
+      <GameId game="CK3">b_caslav</GameId>
+      <GameId game="CK3">c_caslav</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Tschaslau</Name>
       <Name language="Bavarian_Medieval">Tschaslau</Name>
-      <Name language="Czech_Medieval">Czáslaw</Name>
+      <Name language="Czech_Medieval">Čáslav</Name>
       <Name language="Frankish_Low">Tschaslau</Name>
       <Name language="Frankish">Tschaslau</Name>
       <Name language="German_Middle_High">Tschaslau</Name>
       <Name language="German_Middle_Low">Tschaslau</Name>
       <Name language="German_Old_Low">Tschaslau</Name>
       <Name language="Polish_Old">Czaslaw</Name>
-      <Name language="Slovak_Medieval">Czáslaw</Name>
+      <Name language="Slovak_Medieval">Čáslav</Name>
       <Name language="Thuringian">Tschaslau</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vraclav</Id>
+    <GameIds>
+      <GameId game="CK3">b_vraclav</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Vraclav</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -9033,10 +9033,12 @@
     <Names>
       <Name language="Bosnian">Sveti Hipolit</Name>
       <Name language="Bulgarian">Sveti Hipolit</Name>
-      <Name language="Slovene">Sveti Hipolit</Name>
       <Name language="Croatian">Sveti Hipolit</Name>
+      <Name language="Greek_Medieval">Cetium</Name>
+      <Name language="Latin_Medieval">Cetium</Name>
       <Name language="Lithuanian">Sankt Peltenas</Name>
       <Name language="Serbian">Sveti Hipolit</Name>
+      <Name language="Slovene">Sveti Hipolit</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -9273,12 +9275,13 @@
     <Names>
       <Name language="Bosnian">Linec</Name>
       <Name language="Bulgarian">Linec</Name>
-      <Name language="Slovene">Linec</Name>
       <Name language="Croatian">Linec</Name>
+      <Name language="Greek_Medieval">Lentia</Name>
+      <Name language="Latin_Medieval">Lentia</Name>
       <Name language="Lithuanian">Lincas</Name>
-      <Name language="Latin">Aguntum</Name>
       <Name language="Serbian">Linec</Name>
       <Name language="Slovak">Linec</Name>
+      <Name language="Slovene">Linec</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -9400,8 +9403,10 @@
       <Name language="Dutch_Middle">Trente</Name>
       <Name language="Estonian">Trento</Name>
       <Name language="French_Old">Trente</Name>
+      <Name language="Greek_Medieval">Tridente</Name>
       <Name language="Irish">Trionta</Name>
       <Name language="Italian">Trento</Name>
+      <Name language="Latin_Medieval">Tridentum</Name>
       <Name language="Lithuanian">Trentas</Name>
       <Name language="Norwegian">Trento</Name>
       <Name language="Polish">Trydent</Name>
@@ -12197,9 +12202,11 @@
     <Names>
       <Name language="Bosnian">Gradac</Name>
       <Name language="Bulgarian">Gradec</Name>
-      <Name language="Slovene">Gradec</Name>
       <Name language="Croatian">Gradac</Name>
+      <Name language="Czech_Medieval">Hradecz</Name>
       <Name language="Serbian">Gradac</Name>
+      <Name language="Slovak_Medieval">Hradecz</Name>
+      <Name language="Slovene">Gradec</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12346,15 +12353,23 @@
       <GameId game="CK2HIP" parent="c_boleslav" order="1">b_glatz</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Glatz</Name>
+      <Name language="Bavarian_Medieval">Glatz</Name>
       <Name language="Bosnian">Kladsko</Name>
       <Name language="Bulgarian">Kladsko</Name>
       <Name language="Croatian">Kladsko</Name>
       <Name language="Czech_Medieval">Kladsko</Name>
+      <Name language="Frankish_Low">Glatz</Name>
+      <Name language="Frankish">Glatz</Name>
+      <Name language="German_Middle_High">Glatz</Name>
+      <Name language="German_Middle_Low">Glatz</Name>
+      <Name language="German_Old_Low">Glatz</Name>
       <Name language="Latin">Glacio</Name>
       <Name language="Polish_Old">Klodsko</Name>
       <Name language="Serbian">Kladsko</Name>
       <Name language="Slovak_Medieval">Kladsko</Name>
       <Name language="Slovene">Kladsko</Name>
+      <Name language="Thuringian">Glatz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12541,11 +12556,19 @@
       <GameId game="CK2HIP" parent="c_litomerice" order="3">b_doksany</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Doxan</Name>
+      <Name language="Bavarian_Medieval">Doxan</Name>
       <Name language="Bosnian">Doksani</Name>
       <Name language="Bulgarian">Doksani</Name>
-      <Name language="Slovene">Doksani</Name>
       <Name language="Croatian">Doksani</Name>
+      <Name language="Frankish_Low">Doxan</Name>
+      <Name language="Frankish">Doxan</Name>
+      <Name language="German_Middle_High">Doxan</Name>
+      <Name language="German_Middle_Low">Doxan</Name>
+      <Name language="German_Old_Low">Doxan</Name>
       <Name language="Serbian">Doksani</Name>
+      <Name language="Slovene">Doksani</Name>
+      <Name language="Thuringian">Doxan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12554,11 +12577,23 @@
       <GameId game="CK2HIP" parent="c_litomerice" order="6">b_usti</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Aussig</Name>
+      <Name language="Bavarian_Medieval">Aussig</Name>
       <Name language="Bosnian">Ušce</Name>
       <Name language="Bulgarian">Ušce</Name>
-      <Name language="Slovene">Ušce</Name>
       <Name language="Croatian">Ušce</Name>
+      <Name language="Czech_Medieval">Ústie</Name>
+      <Name language="Frankish_Low">Aussig</Name>
+      <Name language="Frankish">Aussig</Name>
+      <Name language="German_Middle_High">Aussig</Name>
+      <Name language="German_Middle_Low">Aussig</Name>
+      <Name language="German_Old_Low">Aussig</Name>
+      <Name language="Polish_Old">Uscie</Name>
       <Name language="Serbian">Ušce</Name>
+      <Name language="Slovak_Medieval">Ústie</Name>
+      <Name language="Slovene">Ušce</Name>
+      <Name language="Sorbian">Wusce</Name>
+      <Name language="Thuringian">Aussig</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12632,11 +12667,19 @@
       <GameId game="CK2HIP" parent="c_zatec" order="5">b_egerberk</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Egerberg</Name>
+      <Name language="Bavarian_Medieval">Egerberg</Name>
       <Name language="Bosnian">Lestkov</Name>
       <Name language="Bulgarian">Lestkov</Name>
-      <Name language="Slovene">Lestkov</Name>
       <Name language="Croatian">Lestkov</Name>
+      <Name language="Frankish_Low">Egerberg</Name>
+      <Name language="Frankish">Egerberg</Name>
+      <Name language="German_Middle_High">Egerberg</Name>
+      <Name language="German_Middle_Low">Egerberg</Name>
+      <Name language="German_Old_Low">Egerberg</Name>
       <Name language="Serbian">Lestkov</Name>
+      <Name language="Slovene">Lestkov</Name>
+      <Name language="Thuringian">Egerberg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12645,11 +12688,19 @@
       <GameId game="CK2HIP" parent="c_zatec" order="6">b_sumberk</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Schönburg</Name>
+      <Name language="Bavarian_Medieval">Schönburg</Name>
       <Name language="Bosnian">Šumgrad</Name>
       <Name language="Bulgarian">Šumgrad</Name>
-      <Name language="Slovene">Šumgrad</Name>
       <Name language="Croatian">Šumgrad</Name>
+      <Name language="Frankish_Low">Schönburg</Name>
+      <Name language="Frankish">Schönburg</Name>
+      <Name language="German_Middle_High">Schönburg</Name>
+      <Name language="German_Middle_Low">Schönburg</Name>
+      <Name language="German_Old_Low">Schönburg</Name>
       <Name language="Serbian">Šumgrad</Name>
+      <Name language="Slovene">Šumgrad</Name>
+      <Name language="Thuringian">Schönburg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12727,11 +12778,19 @@
       <GameId game="CK2HIP" parent="c_plzen" order="2">b_kladruby</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Kladrau</Name>
+      <Name language="Bavarian_Medieval">Kladrau</Name>
       <Name language="Bosnian">Kladrubi</Name>
       <Name language="Bulgarian">Kladrubi</Name>
-      <Name language="Slovene">Kladrubi</Name>
       <Name language="Croatian">Kladrubi</Name>
+      <Name language="Frankish_Low">Kladrau</Name>
+      <Name language="Frankish">Kladrau</Name>
+      <Name language="German_Middle_High">Kladrau</Name>
+      <Name language="German_Middle_Low">Kladrau</Name>
+      <Name language="German_Old_Low">Kladrau</Name>
       <Name language="Serbian">Kladrubi</Name>
+      <Name language="Slovene">Kladrubi</Name>
+      <Name language="Thuringian">Kladrau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12764,11 +12823,19 @@
       <GameId game="CK2HIP" parent="c_plzen" order="5">b_plasy</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Plass</Name>
+      <Name language="Bavarian_Medieval">Plass</Name>
       <Name language="Bosnian">Plasi</Name>
       <Name language="Bulgarian">Plasi</Name>
-      <Name language="Slovene">Plasi</Name>
       <Name language="Croatian">Plasi</Name>
+      <Name language="Frankish_Low">Plass</Name>
+      <Name language="Frankish">Plass</Name>
+      <Name language="German_Middle_High">Plass</Name>
+      <Name language="German_Middle_Low">Plass</Name>
+      <Name language="German_Old_Low">Plass</Name>
       <Name language="Serbian">Plasi</Name>
+      <Name language="Slovene">Plasi</Name>
+      <Name language="Thuringian">Plass</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12777,11 +12844,22 @@
       <GameId game="CK2HIP" parent="c_plzen" order="7">b_susice</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Schüttenhofen</Name>
+      <Name language="Bavarian_Medieval">Schüttenhofen</Name>
       <Name language="Bosnian">Sušice</Name>
       <Name language="Bulgarian">Sušice</Name>
-      <Name language="Slovene">Sušice</Name>
       <Name language="Croatian">Sušice</Name>
+      <Name language="Czech_Medieval">Sussicze</Name>
+      <Name language="Frankish_Low">Schüttenhofen</Name>
+      <Name language="Frankish">Schüttenhofen</Name>
+      <Name language="German_Middle_High">Schüttenhofen</Name>
+      <Name language="German_Middle_Low">Schüttenhofen</Name>
+      <Name language="German_Old_Low">Schüttenhofen</Name>
+      <Name language="Polish_Old">Suszyca</Name>
       <Name language="Serbian">Sušice</Name>
+      <Name language="Slovak_Medieval">Sussicze</Name>
+      <Name language="Slovene">Sušice</Name>
+      <Name language="Thuringian">Schüttenhofen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12790,11 +12868,21 @@
       <GameId game="CK2HIP" parent="c_plzen" order="8">b_tepla</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Töpel</Name>
+      <Name language="Bavarian_Medieval">Töpel</Name>
       <Name language="Bosnian">Topla</Name>
       <Name language="Bulgarian">Topla</Name>
-      <Name language="Slovene">Topla</Name>
       <Name language="Croatian">Topla</Name>
+      <Name language="Czech_Medieval">Teplá</Name>
+      <Name language="Frankish_Low">Töpel</Name>
+      <Name language="Frankish">Töpel</Name>
+      <Name language="German_Middle_High">Töpel</Name>
+      <Name language="German_Middle_Low">Töpel</Name>
+      <Name language="German_Old_Low">Töpel</Name>
       <Name language="Serbian">Topla</Name>
+      <Name language="Slovak_Medieval">Teplá</Name>
+      <Name language="Slovene">Topla</Name>
+      <Name language="Thuringian">Töpel</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12803,12 +12891,20 @@
       <GameId game="CK2HIP" parent="c_plzen" order="9">b_klatovy</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Klattau</Name>
+      <Name language="Bavarian_Medieval">Klattau</Name>
       <Name language="Bosnian">Klatovi</Name>
       <Name language="Bulgarian">Klatovi</Name>
-      <Name language="Slovene">Klatovi</Name>
       <Name language="Croatian">Klatovi</Name>
+      <Name language="Frankish_Low">Klattau</Name>
+      <Name language="Frankish">Klattau</Name>
+      <Name language="German_Middle_High">Klattau </Name>
+      <Name language="German_Middle_Low">Klattau</Name>
+      <Name language="German_Old_Low">Klattau</Name>
       <Name language="Lithuanian">Klatovai</Name>
       <Name language="Serbian">Klatovi</Name>
+      <Name language="Slovene">Klatovi</Name>
+      <Name language="Thuringian">Klattau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12842,27 +12938,35 @@
       <Name language="Bulgarian">Moravija</Name>
       <Name language="Catalan">Moràvia</Name>
       <Name language="Croatian">Moravska</Name>
+      <Name language="Czech_Medieval">Morawa</Name>
       <Name language="Danish">Mähren</Name>
       <Name language="Dutch_Middle">Moravië</Name>
       <Name language="Estonian">Morava</Name>
       <Name language="Frankish_Low">Moravië</Name>
+      <Name language="Frankish">Mähren</Name>
       <Name language="French_Old">Moravie</Name>
       <Name language="Frisian_Old">Moraavje</Name>
+      <Name language="German_Middle_High">Mähren</Name>
       <Name language="German_Middle_Low">Mähren</Name>
       <Name language="German_Old_Low">Moravië</Name>
       <Name language="Gothic">Morawien</Name>
       <Name language="Greek_Medieval">Moravías</Name>
+      <Name language="Hungarian_Old_Early">Morva Uruzag</Name>
+      <Name language="Hungarian_Old">Morvaország</Name>
       <Name language="Icelandic">Maeri</Name>
       <Name language="Latgalian">Moravija</Name>
       <Name language="Lithuanian">Moravija</Name>
       <Name language="Norman">Moravie</Name>
       <Name language="Norwegian">Mähren</Name>
       <Name language="Occitan">Moràvia</Name>
+      <Name language="Polish_Old">Morawy</Name>
       <Name language="Portuguese">Morávia</Name>
       <Name language="Prussian_Old">Morawija</Name>
       <Name language="Romanian">Moravia</Name>
       <Name language="Russian">Moraviya</Name>
+      <Name language="Slovak_Medieval">Morawa</Name>
       <Name language="Swedish">Mähren</Name>
+      <Name language="Szekely_Old">Morvaország</Name>
       <Name language="Thuringian">Mähren</Name>
       <Name language="Turkish">Moravya</Name>
       <Name language="Welsh">Morafia</Name>
@@ -12876,13 +12980,27 @@
       <GameId game="CK2HIP" parent="d_moravia" order="1">c_olomouc</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Olmütz</Name>
+      <Name language="Bavarian_Medieval">Olmütz</Name>
       <Name language="Bosnian">Olomuc</Name>
       <Name language="Bulgarian">Olomuc</Name>
-      <Name language="Slovene">Olomuc</Name>
       <Name language="Croatian">Olomuc</Name>
-      <Name language="Lithuanian">Olomoucas</Name>
+      <Name language="Czech_Medieval">Olomúcz</Name>
+      <Name language="Frankish_Low">Olmütz</Name>
+      <Name language="Frankish">Olmütz</Name>
+      <Name language="German_Middle_High">Olmütz</Name>
+      <Name language="German_Middle_Low">Olmütz</Name>
+      <Name language="German_Old_Low">Olmütz</Name>
+      <Name language="Hungarian_Old">Alamóc</Name>
       <Name language="Latin">Olomucium</Name>
+      <Name language="Lithuanian">Olomoucas</Name>
+      <Name language="Polish_Old">Olomuniec</Name>
       <Name language="Serbian">Olomuc</Name>
+      <Name language="Slovak_Medieval">Olomúcz</Name>
+      <Name language="Slovene">Olomuc</Name>
+      <Name language="Szekely_Old">Alamóc</Name>
+      <Name language="Thuringian">Olmütz</Name>
+      <Name language="Yiddish">Olmits</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -13385,11 +13503,19 @@
       <GameId game="CK2HIP" parent="c_brno" order="2">b_pohansko</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Pohanska</Name>
+      <Name language="Bavarian_Medieval">Pohanska</Name>
       <Name language="Bosnian">Pogansko</Name>
       <Name language="Bulgarian">Pogansko</Name>
-      <Name language="Slovene">Pogansko</Name>
       <Name language="Croatian">Pogansko</Name>
+      <Name language="Frankish_Low">Pohanska</Name>
+      <Name language="Frankish">Pohanska</Name>
+      <Name language="German_Middle_High">Pohanska</Name>
+      <Name language="German_Middle_Low">Pohanska</Name>
+      <Name language="German_Old_Low">Pohanska</Name>
       <Name language="Serbian">Pogansko</Name>
+      <Name language="Slovene">Pogansko</Name>
+      <Name language="Thuringian">Pohanska</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -13398,11 +13524,21 @@
       <GameId game="CK2HIP" parent="c_brno" order="4">b_rejhrad</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Raigern</Name>
+      <Name language="Bavarian_Medieval">Raigern</Name>
       <Name language="Bosnian">Rajgrad</Name>
       <Name language="Bulgarian">Rajgrad</Name>
-      <Name language="Slovene">Rajgrad</Name>
       <Name language="Croatian">Rajgrad</Name>
+      <Name language="Czech_Medieval">Rayhrad</Name>
+      <Name language="Frankish_Low">Raigern</Name>
+      <Name language="Frankish">Raigern</Name>
+      <Name language="German_Middle_High">Raigern</Name>
+      <Name language="German_Middle_Low">Raigern</Name>
+      <Name language="German_Old_Low">Raigern</Name>
       <Name language="Serbian">Rajgrad</Name>
+      <Name language="Slovak_Medieval">Rayhrad</Name>
+      <Name language="Slovene">Rajgrad</Name>
+      <Name language="Thuringian">Raigern</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14077,9 +14213,13 @@
     <Names>
       <Name language="Bosnian">Silivrija</Name>
       <Name language="Bulgarian">Silivrija</Name>
-      <Name language="Slovene">Silivrija</Name>
       <Name language="Croatian">Silivrija</Name>
+      <Name language="Oghuz">Silivri</Name>
+      <Name language="Pecheneg">Silivri</Name>
       <Name language="Serbian">Silivrija</Name>
+      <Name language="Slovene">Silivrija</Name>
+      <Name language="Turkish_Old">Silivri</Name>
+      <Name language="Turkmen_Medieval">Silivri</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14090,9 +14230,26 @@
     <Names>
       <Name language="Bosnian">Rodosto</Name>
       <Name language="Bulgarian">Rodosto</Name>
-      <Name language="Slovene">Rodosto</Name>
       <Name language="Croatian">Rodosto</Name>
+      <Name language="Dalmatian_Medieval">Rodosto</Name>
+      <Name language="French_Old">Rodosto</Name>
+      <Name language="Italian_Central">Rodosto</Name>
+      <Name language="Italian_Medieval">Rodosto</Name>
+      <Name language="Langobardic">Rodosto</Name>
+      <Name language="Ligurian">Rodosto</Name>
+      <Name language="Neapolitan">Rodosto</Name>
+      <Name language="Norman">Rodosto</Name>
+      <Name language="Oghuz">Rodoscuk</Name>
+      <Name language="Pecheneg">Rodoscuk</Name>
+      <Name language="Sardinian">Rodosto</Name>
       <Name language="Serbian">Rodosto</Name>
+      <Name language="Sicilian">Rodosto</Name>
+      <Name language="Slovene">Rodosto</Name>
+      <Name language="Turkish_Old">Rodoscuk</Name>
+      <Name language="Turkmen_Medieval">Rodoscuk</Name>
+      <Name language="Tuscan_Medieval">Rodosto</Name>
+      <Name language="Umbrian_Medieval">Rodosto</Name>
+      <Name language="Venetian_Medieval">Rodosto</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14103,11 +14260,28 @@
     <Names>
       <Name language="Bosnian">Perint</Name>
       <Name language="Bulgarian">Perint</Name>
-      <Name language="Slovene">Perint</Name>
       <Name language="Catalan">Heracleia</Name>
       <Name language="Croatian">Perint</Name>
+      <Name language="Dalmatian_Medieval">Heraclea</Name>
       <Name language="Dutch_Middle">Heraclea</Name>
+      <Name language="French_Old">Héraclée</Name>
+      <Name language="Italian_Central">Heraclea</Name>
+      <Name language="Italian_Medieval">Heraclea</Name>
+      <Name language="Langobardic">Heraclea</Name>
+      <Name language="Ligurian">Heraclea</Name>
+      <Name language="Neapolitan">Heraclea</Name>
+      <Name language="Norman">Héraclée</Name>
+      <Name language="Oghuz">Eregli</Name>
+      <Name language="Pecheneg">Eregli</Name>
+      <Name language="Sardinian">Heraclea</Name>
       <Name language="Serbian">Perint</Name>
+      <Name language="Sicilian">Heraclea</Name>
+      <Name language="Slovene">Perint</Name>
+      <Name language="Turkish_Old">Eregli</Name>
+      <Name language="Turkmen_Medieval">Eregli</Name>
+      <Name language="Tuscan_Medieval">Heraclea</Name>
+      <Name language="Umbrian_Medieval">Heraclea</Name>
+      <Name language="Venetian_Medieval">Heraclea</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14118,9 +14292,13 @@
     <Names>
       <Name language="Bosnian">Jenez</Name>
       <Name language="Bulgarian">Jenez</Name>
-      <Name language="Slovene">Jenez</Name>
       <Name language="Croatian">Jenez</Name>
+      <Name language="Oghuz">Enez</Name>
+      <Name language="Pecheneg">Enez</Name>
       <Name language="Serbian">Jenez</Name>
+      <Name language="Slovene">Jenez</Name>
+      <Name language="Turkish_Old">Enez</Name>
+      <Name language="Turkmen_Medieval">Enez</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14131,9 +14309,13 @@
     <Names>
       <Name language="Bosnian">Corlu</Name>
       <Name language="Bulgarian">Corlu</Name>
-      <Name language="Slovene">Corlu</Name>
       <Name language="Croatian">Corlu</Name>
+      <Name language="Oghuz">Corlu</Name>
+      <Name language="Pecheneg">Corlu</Name>
       <Name language="Serbian">Corlu</Name>
+      <Name language="Slovene">Corlu</Name>
+      <Name language="Turkish_Old">Corlu</Name>
+      <Name language="Turkmen_Medieval">Corlu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14144,9 +14326,13 @@
     <Names>
       <Name language="Bosnian">Haripol</Name>
       <Name language="Bulgarian">Haripol</Name>
-      <Name language="Slovene">Haripol</Name>
       <Name language="Croatian">Haripol</Name>
+      <Name language="Oghuz">Hayrabolu</Name>
+      <Name language="Pecheneg">Hayrabolu</Name>
       <Name language="Serbian">Haripol</Name>
+      <Name language="Slovene">Haripol</Name>
+      <Name language="Turkish_Old">Hayrabolu</Name>
+      <Name language="Turkmen_Medieval">Hayrabolu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14157,9 +14343,13 @@
     <Names>
       <Name language="Bosnian">Kipsela</Name>
       <Name language="Bulgarian">Kipsela</Name>
-      <Name language="Slovene">Kipsela</Name>
       <Name language="Croatian">Kipsela</Name>
+      <Name language="Oghuz">Ipsala</Name>
+      <Name language="Pecheneg">Ipsala</Name>
       <Name language="Serbian">Kipsela</Name>
+      <Name language="Slovene">Kipsela</Name>
+      <Name language="Turkish_Old">Ipsala</Name>
+      <Name language="Turkmen_Medieval">Ipsala</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14191,6 +14381,7 @@
       <Name language="Frankish">Konstantinusesburg</Name>
       <Name language="German_Middle_Low">Byzanz</Name>
       <Name language="German_Old_Low">Byzanz</Name>
+      <Name language="Gothic">Miklagarðr</Name>
       <Name language="Greek_Ancient">Byzántion</Name>
       <Name language="Greek_Medieval">Konstantinoupolis</Name>
       <Name language="Hejazi_Arabic">al-Qustantíniyya</Name>
@@ -14432,11 +14623,13 @@
     </GameIds>
     <Names>
       <Name language="Bosnian">Struma</Name>
+      <Name language="Bulgarian_Old">Syar</Name>
       <Name language="Bulgarian">Struma</Name>
       <Name language="Croatian">Struma</Name>
       <Name language="Oghuz">Serez</Name>
       <Name language="Pecheneg">Serez</Name>
       <Name language="Romanian">Struma</Name>
+      <Name language="Serbian_Medieval">Ser</Name>
       <Name language="Serbian">Struma</Name>
       <Name language="Slovene">Struma</Name>
       <Name language="Turkish_Old">Serez</Name>
@@ -14711,9 +14904,13 @@
     <Names>
       <Name language="Bosnian">Jeriso</Name>
       <Name language="Bulgarian">Jeriso</Name>
-      <Name language="Slovene">Jeriso</Name>
       <Name language="Croatian">Jeriso</Name>
+      <Name language="Oghuz">Erse</Name>
+      <Name language="Pecheneg">Erse</Name>
       <Name language="Serbian">Jeriso</Name>
+      <Name language="Slovene">Jeriso</Name>
+      <Name language="Turkish_Old">Erse</Name>
+      <Name language="Turkmen_Medieval">Erse</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14724,9 +14921,13 @@
     <Names>
       <Name language="Bosnian">Sedmikulsko</Name>
       <Name language="Bulgarian">Sedmikulsko</Name>
-      <Name language="Slovene">Sedmikulsko</Name>
       <Name language="Croatian">Sedmikulsko</Name>
+      <Name language="Oghuz">Beyaz Kule</Name>
+      <Name language="Pecheneg">Beyaz Kule</Name>
       <Name language="Serbian">Sedmikulsko</Name>
+      <Name language="Slovene">Sedmikulsko</Name>
+      <Name language="Turkish_Old">Beyaz Kule</Name>
+      <Name language="Turkmen_Medieval">Beyaz Kule</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14776,9 +14977,13 @@
     <Names>
       <Name language="Bosnian">Lagadin</Name>
       <Name language="Bulgarian">Lagadin</Name>
-      <Name language="Slovene">Lagadin</Name>
       <Name language="Croatian">Lagadin</Name>
+      <Name language="Oghuz">Langaza</Name>
+      <Name language="Pecheneg">Langaza</Name>
       <Name language="Serbian">Lagadin</Name>
+      <Name language="Slovene">Lagadin</Name>
+      <Name language="Turkish_Old">Langaza</Name>
+      <Name language="Turkmen_Medieval">Langaza</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14920,9 +15125,13 @@
     <Names>
       <Name language="Bosnian">Larisa</Name>
       <Name language="Bulgarian">Larisa</Name>
-      <Name language="Slovene">Larisa</Name>
       <Name language="Croatian">Larisa</Name>
+      <Name language="Oghuz">Yenisehir i-Fenari</Name>
+      <Name language="Pecheneg">Yenisehir i-Fenari</Name>
       <Name language="Serbian">Larisa</Name>
+      <Name language="Slovene">Larisa</Name>
+      <Name language="Turkish_Old">Yenisehir i-Fenari</Name>
+      <Name language="Turkmen_Medieval">Yenisehir i-Fenari</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14933,9 +15142,13 @@
     <Names>
       <Name language="Bosnian">Elasona</Name>
       <Name language="Bulgarian">Elasona</Name>
-      <Name language="Slovene">Elasona</Name>
       <Name language="Croatian">Elasona</Name>
+      <Name language="Oghuz">Alasonya</Name>
+      <Name language="Pecheneg">Alasonya</Name>
       <Name language="Serbian">Elasona</Name>
+      <Name language="Slovene">Elasona</Name>
+      <Name language="Turkish_Old">Alasonya</Name>
+      <Name language="Turkmen_Medieval">Alasonya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14945,6 +15158,10 @@
     </GameIds>
     <Names>
       <Name language="French_Old">Platamonas</Name>
+      <Name language="Oghuz">Platamona</Name>
+      <Name language="Pecheneg">Platamona</Name>
+      <Name language="Turkish_Old">Platamona</Name>
+      <Name language="Turkmen_Medieval">Platamona</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14969,9 +15186,26 @@
     <Names>
       <Name language="Bosnian">Dimitrijas</Name>
       <Name language="Bulgarian">Dimitrijas</Name>
-      <Name language="Slovene">Dimitrijas</Name>
       <Name language="Croatian">Dimitrijas</Name>
+      <Name language="Dalmatian_Medieval">Dimitrias</Name>
+      <Name language="French_Old">Mitre</Name>
+      <Name language="Italian_Central">Dimitrias</Name>
+      <Name language="Italian_Medieval">Dimitrias</Name>
+      <Name language="Langobardic">Dimitrias</Name>
+      <Name language="Ligurian">Dimitrias</Name>
+      <Name language="Neapolitan">Dimitrias</Name>
+      <Name language="Norman">Mitre</Name>
+      <Name language="Oghuz">Golos</Name>
+      <Name language="Pecheneg">Golos</Name>
+      <Name language="Sardinian">Dimitrias</Name>
       <Name language="Serbian">Dimitrijas</Name>
+      <Name language="Sicilian">Dimitrias</Name>
+      <Name language="Slovene">Dimitrijas</Name>
+      <Name language="Turkish_Old">Golos</Name>
+      <Name language="Turkmen_Medieval">Golos</Name>
+      <Name language="Tuscan_Medieval">Dimitrias</Name>
+      <Name language="Umbrian_Medieval">Dimitrias</Name>
+      <Name language="Venetian_Medieval">Dimitrias</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14982,9 +15216,26 @@
     <Names>
       <Name language="Bosnian">Almiros</Name>
       <Name language="Bulgarian">Almiros</Name>
-      <Name language="Slovene">Almiros</Name>
       <Name language="Croatian">Almiros</Name>
+      <Name language="Dalmatian_Medieval">Almiró</Name>
+      <Name language="French_Old">L'Amiro</Name>
+      <Name language="Italian_Central">Almiró</Name>
+      <Name language="Italian_Medieval">Almiró</Name>
+      <Name language="Langobardic">Almiró</Name>
+      <Name language="Ligurian">Almiró</Name>
+      <Name language="Neapolitan">Almiró</Name>
+      <Name language="Norman">L'Amiro</Name>
+      <Name language="Oghuz">Ermiye</Name>
+      <Name language="Pecheneg">Ermiye</Name>
+      <Name language="Sardinian">Almiró</Name>
       <Name language="Serbian">Almiros</Name>
+      <Name language="Sicilian">Almiró</Name>
+      <Name language="Slovene">Almiros</Name>
+      <Name language="Turkish_Old">Ermiye</Name>
+      <Name language="Turkmen_Medieval">Ermiye</Name>
+      <Name language="Tuscan_Medieval">Almiró</Name>
+      <Name language="Umbrian_Medieval">Almiró</Name>
+      <Name language="Venetian_Medieval">Almiró</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -14995,9 +15246,22 @@
     <Names>
       <Name language="Bosnian">Lehonija</Name>
       <Name language="Bulgarian">Lehonija</Name>
-      <Name language="Slovene">Lehonija</Name>
       <Name language="Croatian">Lehonija</Name>
+      <Name language="Dalmatian_Medieval">Liconia</Name>
+      <Name language="French_Old">Liconie</Name>
+      <Name language="Italian_Central">Liconia</Name>
+      <Name language="Italian_Medieval">Liconia</Name>
+      <Name language="Langobardic">Liconia</Name>
+      <Name language="Ligurian">Liconia</Name>
+      <Name language="Neapolitan">Liconia</Name>
+      <Name language="Norman">Liconie</Name>
+      <Name language="Sardinian">Liconia</Name>
       <Name language="Serbian">Lehonija</Name>
+      <Name language="Sicilian">Liconia</Name>
+      <Name language="Slovene">Lehonija</Name>
+      <Name language="Tuscan_Medieval">Liconia</Name>
+      <Name language="Umbrian_Medieval">Liconia</Name>
+      <Name language="Venetian_Medieval">Liconia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15062,10 +15326,16 @@
     </GameIds>
     <Names>
       <Name language="Bosnian">Greben</Name>
+      <Name language="Bulgarian_Old">Grebena</Name>
       <Name language="Bulgarian">Greben</Name>
-      <Name language="Slovene">Greben</Name>
       <Name language="Croatian">Greben</Name>
+      <Name language="Oghuz">Gerebena</Name>
+      <Name language="Pecheneg">Gerebena</Name>
+      <Name language="Romanian_Old">Grebini</Name>
       <Name language="Serbian">Greben</Name>
+      <Name language="Slovene">Greben</Name>
+      <Name language="Turkish_Old">Gerebena</Name>
+      <Name language="Turkmen_Medieval">Gerebena</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15089,9 +15359,26 @@
     <Names>
       <Name language="Bosnian">Zituni</Name>
       <Name language="Bulgarian">Zituni</Name>
-      <Name language="Slovene">Zituni</Name>
       <Name language="Croatian">Zituni</Name>
+      <Name language="Dalmatian_Medieval">Citó</Name>
+      <Name language="French_Old">Girton</Name>
+      <Name language="Italian_Central">Citó</Name>
+      <Name language="Italian_Medieval">Citó</Name>
+      <Name language="Langobardic">Citó</Name>
+      <Name language="Ligurian">Citó</Name>
+      <Name language="Neapolitan">Citó</Name>
+      <Name language="Norman">Girton</Name>
+      <Name language="Oghuz">Izdin</Name>
+      <Name language="Pecheneg">Izdin</Name>
+      <Name language="Sardinian">Citó</Name>
       <Name language="Serbian">Zituni</Name>
+      <Name language="Sicilian">Citó</Name>
+      <Name language="Slovene">Zituni</Name>
+      <Name language="Turkish_Old">Izdin</Name>
+      <Name language="Turkmen_Medieval">Izdin</Name>
+      <Name language="Tuscan_Medieval">Citó</Name>
+      <Name language="Umbrian_Medieval">Citó</Name>
+      <Name language="Venetian_Medieval">Citó</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15102,9 +15389,15 @@
     <Names>
       <Name language="Bosnian">Farsal</Name>
       <Name language="Bulgarian">Farsal</Name>
-      <Name language="Slovene">Farsal</Name>
       <Name language="Croatian">Farsal</Name>
+      <Name language="French_Old">Ferselle</Name>
+      <Name language="Norman">Ferselle</Name>
+      <Name language="Oghuz">Catalca</Name>
+      <Name language="Pecheneg">Catalca</Name>
       <Name language="Serbian">Farsal</Name>
+      <Name language="Slovene">Farsal</Name>
+      <Name language="Turkish_Old">Catalca</Name>
+      <Name language="Turkmen_Medieval">Catalca</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15115,9 +15408,26 @@
     <Names>
       <Name language="Bosnian">Domok</Name>
       <Name language="Bulgarian">Domok</Name>
-      <Name language="Slovene">Domok</Name>
       <Name language="Croatian">Domok</Name>
+      <Name language="Dalmatian_Medieval">Domaco</Name>
+      <Name language="French_Old">Donchie</Name>
+      <Name language="Italian_Central">Domaco</Name>
+      <Name language="Italian_Medieval">Domaco</Name>
+      <Name language="Langobardic">Domaco</Name>
+      <Name language="Ligurian">Domaco</Name>
+      <Name language="Neapolitan">Domaco</Name>
+      <Name language="Norman">Donchie</Name>
+      <Name language="Oghuz">Dömeke</Name>
+      <Name language="Pecheneg">Dömeke</Name>
+      <Name language="Sardinian">Domaco</Name>
       <Name language="Serbian">Domok</Name>
+      <Name language="Sicilian">Domaco</Name>
+      <Name language="Slovene">Domok</Name>
+      <Name language="Turkish_Old">Dömeke</Name>
+      <Name language="Turkmen_Medieval">Dömeke</Name>
+      <Name language="Tuscan_Medieval">Domaco</Name>
+      <Name language="Umbrian_Medieval">Domaco</Name>
+      <Name language="Venetian_Medieval">Domaco</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15128,9 +15438,22 @@
     <Names>
       <Name language="Bosnian">Arakova</Name>
       <Name language="Bulgarian">Arakova</Name>
-      <Name language="Slovene">Arakova</Name>
       <Name language="Croatian">Arakova</Name>
+      <Name language="Dalmatian_Medieval">Siderocastro</Name>
+      <Name language="French_Old">Chastel-de-Fer</Name>
+      <Name language="Italian_Central">Siderocastro</Name>
+      <Name language="Italian_Medieval">Siderocastro</Name>
+      <Name language="Langobardic">Siderocastro</Name>
+      <Name language="Ligurian">Siderocastro</Name>
+      <Name language="Neapolitan">Siderocastro</Name>
+      <Name language="Norman">Chastel-de-Fer</Name>
+      <Name language="Sardinian">Siderocastro</Name>
       <Name language="Serbian">Arakova</Name>
+      <Name language="Sicilian">Siderocastro</Name>
+      <Name language="Slovene">Arakova</Name>
+      <Name language="Tuscan_Medieval">Siderocastro</Name>
+      <Name language="Umbrian_Medieval">Siderocastro</Name>
+      <Name language="Venetian_Medieval">Siderocastro</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15151,18 +15474,60 @@
       <GameId game="CK2HIP" parent="c_dyrrachion" order="1">b_durazzo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arberian">Durrës</Name>
       <Name language="Bosnian">Drac</Name>
-      <Name language="Slovene">Drac</Name>
+      <Name language="Bulgarian_Old">Drac</Name>
       <Name language="Croatian">Drac</Name>
+      <Name language="Dalmatian_Medieval">Durazzo</Name>
+      <Name language="Italian_Central">Durazzo</Name>
+      <Name language="Italian_Medieval">Durazzo</Name>
+      <Name language="Langobardic">Durazzo</Name>
+      <Name language="Ligurian">Durazzo</Name>
+      <Name language="Neapolitan">Durazzo</Name>
+      <Name language="Oghuz">Diraç</Name>
+      <Name language="Pecheneg">Diraç</Name>
+      <Name language="Sardinian">Durazzo</Name>
+      <Name language="Sicilian">Durazzu</Name>
+      <Name language="Slovene">Drac</Name>
+      <Name language="Turkish_Old">Diraç</Name>
+      <Name language="Turkmen_Medieval">Diraç</Name>
+      <Name language="Tuscan_Medieval">Durazzo</Name>
+      <Name language="Umbrian_Medieval">Durazzo</Name>
+      <Name language="Venetian_Medieval">Durazo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>lezhe</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_dyrrachion" order="2">b_lezhe</GameId>
+      <GameId game="ImperatorRome">2336</GameId> <!-- Lissus -->
     </GameIds>
     <Names>
+      <Name language="Alan">Lissòs</Name>
+      <Name language="Arberian">Lezhë</Name>
+      <Name language="Armenian_Middle">Lissòs</Name>
+      <Name language="Bosnian_Medieval">Lješ</Name>
+      <Name language="Bulgarian_Old">Lješ</Name>
+      <Name language="Croatian_Medieval">Lješ</Name>
+      <Name language="Dalmatian_Medieval">Alessio</Name>
+      <Name language="Georgian">Lissòs</Name>
+      <Name language="Greek_Ancient">Lissòs</Name>
+      <Name language="Greek_Medieval">Lissòs</Name>
+      <Name language="Italian_Central">Alessio</Name>
+      <Name language="Italian_Medieval">Alessio</Name>
+      <Name language="Langobardic">Alessio</Name>
+      <Name language="Latin_Ancient">Lissus</Name>
+      <Name language="Latin_Medieval">Lissus</Name>
+      <Name language="Ligurian">Alessio</Name>
+      <Name language="Neapolitan">Alessio</Name>
+      <Name language="Sardinian">Alessio</Name>
+      <Name language="Serbian_Medieval">Lješ</Name>
+      <Name language="Sicilian">Alessio</Name>
       <Name language="Slovene">Lješ</Name>
+      <Name language="Turkish_Old">Les</Name>
+      <Name language="Tuscan_Medieval">Alessio</Name>
+      <Name language="Umbrian_Medieval">Alessio</Name>
+      <Name language="Venetian_Medieval">Alessio</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15171,11 +15536,12 @@
       <GameId game="CK2HIP" parent="c_dyrrachion" order="3">b_chounavia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arberian">Thumanë</Name>
       <Name language="Bosnian">Conavija</Name> <!-- Historical? Translated -->
       <Name language="Bulgarian">Conavija</Name> <!-- Historical? Translated -->
-      <Name language="Slovene">Conavija</Name> <!-- Historical? Translated -->
       <Name language="Croatian">Conavija</Name> <!-- Historical? Translated -->
       <Name language="Serbian">Conavija</Name> <!-- Historical? Translated -->
+      <Name language="Slovene">Conavija</Name> <!-- Historical? Translated -->
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -39314,6 +39680,7 @@
       <Name language="Danish_Middle">Donceaster</Name>
       <Name language="English_Old_Norse">Donceaster</Name>
       <Name language="English_Old">Donceaster</Name>
+      <Name language="Gothic">Donceaster</Name>
       <Name language="Icelandic_Old">Donceaster</Name>
       <Name language="Irish_Middle_Norse">Donceaster</Name>
       <Name language="Latin">Denocestria</Name>
@@ -39345,6 +39712,7 @@
       <Name language="English_Middle">Whitby</Name>
       <Name language="English_Old_Norse">Hwitebi</Name>
       <Name language="English_Old">Streoneshalh</Name>
+      <Name language="Gothic">Hwitebi</Name>
       <Name language="Icelandic_Old">Hwitebi</Name>
       <Name language="Irish_Middle_Norse">Hwitebi</Name>
       <Name language="Lithuanian">Vitbis</Name>
@@ -39389,7 +39757,17 @@
       <GameId game="CK2HIP" parent="c_york_wolds" order="2">b_hull</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Vik</Name>
+      <Name language="English_Middle">Kingston</Name>
+      <Name language="English_Old_Norse">Vik</Name>
+      <Name language="English_Old">Wic</Name>
+      <Name language="Gothic">Vik</Name>
+      <Name language="Icelandic_Old">Vik</Name>
+      <Name language="Irish_Middle_Norse">Vik</Name>
       <Name language="Latin">Peturia</Name>
+      <Name language="Norse">Vik</Name>
+      <Name language="Norwegian_Old">Vik</Name>
+      <Name language="Swedish_Old">Vik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -39487,6 +39865,7 @@
       <Name language="Danish_Middle">Lonceaster</Name>
       <Name language="English_Old_Norse">Lonceaster</Name>
       <Name language="English_Old">Luneceaster</Name>
+      <Name language="Gothic">Lonceaster</Name>
       <Name language="Icelandic_Old">Lonceaster</Name>
       <Name language="Irish_Middle_Norse">Lonceaster</Name>
       <Name language="Irish_Middle">Gaerhirfryn</Name>
@@ -39519,7 +39898,17 @@
       <GameId game="CK2HIP" parent="c_lancaster" order="7">b_preston</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Prestestun</Name>
+      <Name language="English_Old_Norse">Prestestun</Name>
+      <Name language="English_Old">Prestestun</Name>
+      <Name language="Gothic">Prestestun</Name>
+      <Name language="Icelandic_Old">Prestestun</Name>
+      <Name language="Irish_Middle_Norse">Prestestun</Name>
       <Name language="Lithuanian">Prestonas</Name>
+      <Name language="Norman">Prestune</Name>
+      <Name language="Norse">Prestestun</Name>
+      <Name language="Norwegian_Old">Prestestun</Name>
+      <Name language="Swedish_Old">Prestestun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -39550,6 +39939,7 @@
       <Name language="English_Middle">Chester</Name>
       <Name language="English_Old_Norse">Legeceaster</Name>
       <Name language="English_Old">Legeceaster</Name>
+      <Name language="Gothic">Legeceaster</Name>
       <Name language="Greek_Medieval">Deva</Name>
       <Name language="Icelandic_Old">Legeceaster</Name>
       <Name language="Irish_Middle_Norse">Legeceaster</Name>
@@ -39695,6 +40085,7 @@
       <Name language="Danish_Middle">Norðhymbraland</Name>
       <Name language="English_Old_Norse">Northymbraland</Name>
       <Name language="English_Old">Northymbraland</Name>
+      <Name language="Gothic">Norðhymbraland</Name>
       <Name language="Icelandic_Old">Norðhymbraland</Name>
       <Name language="Irish_Middle_Norse">Norðhymbraland</Name>
       <Name language="Latin_Medieval">Northanhymbrorum</Name>
@@ -39730,6 +40121,7 @@
       <Name language="English_Old_Norse">Bebbanburh</Name>
       <Name language="English_Old">Bebbanburh</Name>
       <Name language="German_Old_Low">Bebbanburg</Name>
+      <Name language="Gothic">Bebbanborg</Name>
       <Name language="Icelandic_Old">Bebbanborg</Name>
       <Name language="Irish_Middle_Norse">Bebbanborg</Name>
       <Name language="Irish">Dún Guaire</Name>
@@ -39749,8 +40141,17 @@
       <GameId game="CK3">b_hexham</GameId> <!-- Hexham -->
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Hagustaldesee</Name>
       <Name language="English_Middle">Hexham</Name>
+      <Name language="English_Old_Norse">Hagustaldesee</Name>
+      <Name language="English_Old">Hagustaldesham</Name>
+      <Name language="Gothic">Hagustaldesee</Name>
+      <Name language="Icelandic_Old">Hagustaldesee</Name>
+      <Name language="Irish_Middle_Norse">Hagustaldesee</Name>
       <Name language="Latin">Hagastaldunum</Name>
+      <Name language="Norse">Hagustaldesee</Name>
+      <Name language="Norwegian_Old">Hagustaldesee</Name>
+      <Name language="Swedish_Old">Hagustaldesee</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -39766,6 +40167,7 @@
       <Name language="Danish_Middle">Lindisfarena</Name>
       <Name language="English_Old_Norse">Lindisfarena</Name>
       <Name language="English_Old">Lindisfarena</Name>
+      <Name language="Gothic">Lindisfarena</Name>
       <Name language="Icelandic_Old">Lindisfarena</Name>
       <Name language="Irish_Middle_Norse">Lindisfarena</Name>
       <Name language="Latin">Medicata Insula</Name>
@@ -39782,11 +40184,20 @@
       <GameId game="CK2HIP" parent="c_northumberland" order="5">b_newcastle</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Monkceaster</Name>
+      <Name language="English_Old_Norse">Monkceaster</Name>
+      <Name language="English_Old">Monkceaster</Name>
+      <Name language="Gothic">Monkceaster</Name>
+      <Name language="Icelandic_Old">Monkceaster</Name>
+      <Name language="Irish_Middle_Norse">Monkceaster</Name>
       <Name language="Irish">An Caisleán Nua</Name>
       <Name language="Latgalian">Nukãsla</Name>
-      <Name language="Lithuanian">Niukaslas</Name>
       <Name language="Latin">Pons Aelius</Name>
+      <Name language="Lithuanian">Niukaslas</Name>
+      <Name language="Norse">Monkceaster</Name>
+      <Name language="Norwegian_Old">Monkceaster</Name>
       <Name language="Scottish_Medieval">An Caisteal Nuadh</Name>
+      <Name language="Swedish_Old">Monkceaster</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -39839,7 +40250,16 @@
       <GameId game="CK2HIP" parent="c_durham" order="1">b_chester-le-street</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Cuneceastra</Name>
+      <Name language="English_Old_Norse">Cuneceastra</Name>
+      <Name language="English_Old">Cuneceaster</Name>
+      <Name language="Gothic">Cuneceastra</Name>
+      <Name language="Icelandic_Old">Cuneceastra</Name>
+      <Name language="Irish_Middle_Norse">Cuneceastra</Name>
       <Name language="Latin">Concangis</Name>
+      <Name language="Norse">Cuneceastra</Name>
+      <Name language="Norwegian_Old">Cuneceastra</Name>
+      <Name language="Swedish_Old">Cuneceastra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -39955,7 +40375,16 @@
       <GameId game="CK2HIP" parent="c_cumberland" order="7">b_dacre</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Dacore</Name>
+      <Name language="English_Old_Norse">Dacore</Name>
+      <Name language="English_Old">Dacore</Name>
+      <Name language="Gothic">Dacore</Name>
+      <Name language="Icelandic_Old">Dacore</Name>
+      <Name language="Irish_Middle_Norse">Dacore</Name>
       <Name language="Latin">Dacor</Name>
+      <Name language="Norse">Dacore</Name>
+      <Name language="Norwegian_Old">Dacore</Name>
+      <Name language="Swedish_Old">Dacore</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53097,6 +53526,7 @@
       <GameId game="CK2HIP" parent="c_lienz" order="2">b_innichen</GameId>
     </GameIds>
     <Names>
+      <Name language="Italian_Medieval">San Candido</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53348,6 +53778,16 @@
       <GameId game="CK2HIP" parent="c_litomerice" order="4">b_duba_hre</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Dauba</Name>
+      <Name language="Bavarian_Medieval">Dauba</Name>
+      <Name language="Czech_Medieval">Dubá</Name>
+      <Name language="Frankish_Low">Dauba</Name>
+      <Name language="Frankish">Dauba</Name>
+      <Name language="German_Middle_High">Dauba</Name>
+      <Name language="German_Middle_Low">Dauba</Name>
+      <Name language="German_Old_Low">Dauba</Name>
+      <Name language="Slovak_Medieval">Dubá</Name>
+      <Name language="Thuringian">Dauba</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53356,6 +53796,16 @@
       <GameId game="CK2HIP" parent="c_litomerice" order="5">b_lipa</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Leipa</Name>
+      <Name language="Bavarian_Medieval">Leipa</Name>
+      <Name language="Czech_Medieval">Lipá</Name>
+      <Name language="Frankish_Low">Leipa</Name>
+      <Name language="Frankish">Leipa</Name>
+      <Name language="German_Middle_High">Leipa</Name>
+      <Name language="German_Middle_Low">Leipa</Name>
+      <Name language="German_Old_Low">Leipa</Name>
+      <Name language="Slovak_Medieval">Lipá</Name>
+      <Name language="Thuringian">Leipa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53364,6 +53814,14 @@
       <GameId game="CK2HIP" parent="c_zatec" order="3">b_osek</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Ossegg</Name>
+      <Name language="Bavarian_Medieval">Ossegg</Name>
+      <Name language="Frankish_Low">Ossegg</Name>
+      <Name language="Frankish">Ossegg</Name>
+      <Name language="German_Middle_High">Ossegg</Name>
+      <Name language="German_Middle_Low">Ossegg</Name>
+      <Name language="German_Old_Low">Ossegg</Name>
+      <Name language="Thuringian">Ossegg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53409,6 +53867,16 @@
       <GameId game="CK2HIP" parent="c_plzen" order="6">b_velhartice</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Welhartitz</Name>
+      <Name language="Bavarian_Medieval">Welhartitz</Name>
+      <Name language="Czech_Medieval">Welharticze</Name>
+      <Name language="Frankish_Low">Welhartitz</Name>
+      <Name language="Frankish">Welhartitz</Name>
+      <Name language="German_Middle_High">Welhartitz</Name>
+      <Name language="German_Middle_Low">Welhartitz</Name>
+      <Name language="German_Old_Low">Welhartitz</Name>
+      <Name language="Slovak_Medieval">Welharticze</Name>
+      <Name language="Thuringian">Welhartitz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53495,6 +53963,10 @@
       <GameId game="CK2HIP" parent="d_abydos" order="1">c_kyzikos</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Aydincik</Name>
+      <Name language="Pecheneg">Aydincik</Name>
+      <Name language="Turkish_Old">Aydincik</Name>
+      <Name language="Turkmen_Medieval">Aydincik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53503,6 +53975,10 @@
       <GameId game="CK2HIP" parent="c_kyzikos" order="1">b_pegai</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Biga</Name>
+      <Name language="Pecheneg">Biga</Name>
+      <Name language="Turkish_Old">Biga</Name>
+      <Name language="Turkmen_Medieval">Biga</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53511,6 +53987,10 @@
       <GameId game="CK2HIP" parent="c_kyzikos" order="2">b_artake</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Erdek</Name>
+      <Name language="Pecheneg">Erdek</Name>
+      <Name language="Turkish_Old">Erdek</Name>
+      <Name language="Turkmen_Medieval">Erdek</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63490,6 +63970,16 @@
       <GameId game="CK2HIP" parent="c_nottingham" order="5">b_worksop</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Werchesope</Name>
+      <Name language="English_Old_Norse">Werchesope</Name>
+      <Name language="English_Old">Werchesope</Name>
+      <Name language="Gothic">Werchesope</Name>
+      <Name language="Icelandic_Old">Werchesope</Name>
+      <Name language="Irish_Middle_Norse">Werchesope</Name>
+      <Name language="Norman">Werchesope</Name>
+      <Name language="Norse">Werchesope</Name>
+      <Name language="Norwegian_Old">Werchesope</Name>
+      <Name language="Swedish_Old">Werchesope</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63501,6 +63991,8 @@
       <Name language="Danish_Middle">Cyningesburgh</Name>
       <Name language="English_Old_Norse">Cyningesburh</Name>
       <Name language="English_Old">Cyningesburh</Name>
+      <Name language="Gothic">Cyningesborg</Name>
+      <Name language="Gothic">Jorvík</Name>
       <Name language="Icelandic_Old">Cyningesborg</Name>
       <Name language="Irish_Middle_Norse">Cyningesborg</Name>
       <Name language="Norse">Cyningesborg</Name>
@@ -63514,6 +64006,16 @@
       <GameId game="CK2HIP" parent="c_york" order="4">b_pontefract</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Tateshale</Name>
+      <Name language="English_Old_Norse">Tateshalh</Name>
+      <Name language="English_Old">Tateshalh</Name>
+      <Name language="Gothic">Tateshale</Name>
+      <Name language="Icelandic_Old">Tateshale</Name>
+      <Name language="Irish_Middle_Norse">Tateshale</Name>
+      <Name language="Norman">Pontefracto</Name>
+      <Name language="Norse">Tateshale</Name>
+      <Name language="Norwegian_Old">Tateshale</Name>
+      <Name language="Swedish_Old">Tateshale</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63522,6 +64024,15 @@
       <GameId game="CK2HIP" parent="c_york" order="6">b_selby</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Seletun</Name>
+      <Name language="English_Old_Norse">Seletun</Name>
+      <Name language="English_Old">Seletun</Name>
+      <Name language="Gothic">Seletun</Name>
+      <Name language="Icelandic_Old">Seletun</Name>
+      <Name language="Irish_Middle_Norse">Seletun</Name>
+      <Name language="Norse">Seletun</Name>
+      <Name language="Norwegian_Old">Seletun</Name>
+      <Name language="Swedish_Old">Seletun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63535,6 +64046,7 @@
       <Name language="English_Middle">Scarborough</Name>
       <Name language="English_Old_Norse">Skarthaburh</Name>
       <Name language="English_Old">Sceardesburh</Name>
+      <Name language="Gothic">Skarðaborg</Name>
       <Name language="Icelandic_Old">Skarðaborg</Name>
       <Name language="Irish_Middle_Norse">Skarðaborg</Name>
       <Name language="Norse">Skarðaborg</Name>
@@ -63548,6 +64060,15 @@
       <GameId game="CK2HIP" parent="c_york_moors" order="3">b_malton</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Maltun</Name>
+      <Name language="English_Old_Norse">Maltun</Name>
+      <Name language="English_Old">Maltun</Name>
+      <Name language="Gothic">Maltun</Name>
+      <Name language="Icelandic_Old">Maltun</Name>
+      <Name language="Irish_Middle_Norse">Maltun</Name>
+      <Name language="Norse">Maltun</Name>
+      <Name language="Norwegian_Old">Maltun</Name>
+      <Name language="Swedish_Old">Maltun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63556,6 +64077,16 @@
       <GameId game="CK2HIP" parent="c_york_moors" order="7">b_helmsley</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Elmeslac</Name>
+      <Name language="English_Old_Norse">Elmeslac</Name>
+      <Name language="English_Old">Elmesley</Name>
+      <Name language="Gothic">Elmeslac</Name>
+      <Name language="Icelandic_Old">Elmeslac</Name>
+      <Name language="Irish_Middle_Norse">Elmeslac</Name>
+      <Name language="Norman">Hamlake</Name>
+      <Name language="Norse">Elmeslac</Name>
+      <Name language="Norwegian_Old">Elmeslac</Name>
+      <Name language="Swedish_Old">Elmeslac</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63564,6 +64095,16 @@
       <GameId game="CK2HIP" parent="c_richmond" order="1">b_gilling_west</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Ghellinges</Name>
+      <Name language="English_Old_Norse">Ghellinges</Name>
+      <Name language="English_Old">Gellinges</Name>
+      <Name language="Gothic">Ghellinges</Name>
+      <Name language="Icelandic_Old">Ghellinges</Name>
+      <Name language="Irish_Middle_Norse">Ghellinges</Name>
+      <Name language="Norman">Ghellinges</Name>
+      <Name language="Norse">Ghellinges</Name>
+      <Name language="Norwegian_Old">Ghellinges</Name>
+      <Name language="Swedish_Old">Ghellinges</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63572,6 +64113,16 @@
       <GameId game="CK2HIP" parent="c_richmond" order="2">b_middleham</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Medelai</Name>
+      <Name language="English_Old_Norse">Medeley</Name>
+      <Name language="English_Old">Medeley</Name>
+      <Name language="Gothic">Medelai</Name>
+      <Name language="Icelandic_Old">Medelai</Name>
+      <Name language="Irish_Middle_Norse">Medelai</Name>
+      <Name language="Norman">Medelai</Name>
+      <Name language="Norse">Medelai</Name>
+      <Name language="Norwegian_Old">Medelai</Name>
+      <Name language="Swedish_Old">Medelai</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63584,6 +64135,7 @@
       <Name language="Danish_Middle">Cotingeham</Name>
       <Name language="English_Old_Norse">Cotingeham</Name>
       <Name language="English_Old">Cotingesham</Name>
+      <Name language="Gothic">Cotingeham</Name>
       <Name language="Icelandic_Old">Cotingeham</Name>
       <Name language="Irish_Middle_Norse">Cotingeham</Name>
       <Name language="Norman">Cotingeham</Name>
@@ -63679,6 +64231,15 @@
       <GameId game="CK2HIP" parent="c_york_wolds" order="2">b_pocklington</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Poclintun</Name>
+      <Name language="English_Old_Norse">Poclintun</Name>
+      <Name language="English_Old">Pocelingastun</Name>
+      <Name language="Gothic">Poclintun</Name>
+      <Name language="Icelandic_Old">Poclintun</Name>
+      <Name language="Irish_Middle_Norse">Poclintun</Name>
+      <Name language="Norse">Poclintun</Name>
+      <Name language="Norwegian_Old">Poclintun</Name>
+      <Name language="Swedish_Old">Poclintun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63692,6 +64253,7 @@
       <Name language="English_Middle">Birdlington</Name>
       <Name language="English_Old_Norse">Berhtelingtun</Name>
       <Name language="English_Old">Berhtelingtun</Name>
+      <Name language="Gothic">Bretlintun</Name>
       <Name language="Icelandic_Old">Bretlintun</Name>
       <Name language="Irish_Middle_Norse">Bretlintun</Name>
       <Name language="Norman">Bretlinton</Name>
@@ -63711,6 +64273,7 @@
       <Name language="English_Middle">Furness</Name>
       <Name language="English_Old_Norse">Futhernessa</Name>
       <Name language="English_Old">Futhernæssa</Name>
+      <Name language="Gothic">Fuþþernessa</Name>
       <Name language="Icelandic_Old">Fuþþernessa</Name>
       <Name language="Irish_Middle_Norse">Fuþþernessa</Name>
       <Name language="Norse">Fuþþernessa</Name>
@@ -63744,6 +64307,16 @@
       <GameId game="CK2HIP" parent="c_lancaster" order="6">b_ulverston</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Ulfarrstun</Name>
+      <Name language="English_Old_Norse">Wulfestun</Name>
+      <Name language="English_Old">Wulfestun</Name>
+      <Name language="Gothic">Ulfarrstun</Name>
+      <Name language="Icelandic_Old">Ulfarrstun</Name>
+      <Name language="Irish_Middle_Norse">Ulfarrstun</Name>
+      <Name language="Norman">Ulurestun</Name>
+      <Name language="Norse">Ulfarrstun</Name>
+      <Name language="Norwegian_Old">Ulfarrstun</Name>
+      <Name language="Swedish_Old">Ulfarrstun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63752,6 +64325,15 @@
       <GameId game="CK2HIP" parent="c_chester" order="2">b_halton</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Haltun</Name>
+      <Name language="English_Old_Norse">Haltun</Name>
+      <Name language="English_Old">Halltun</Name>
+      <Name language="Gothic">Haltun</Name>
+      <Name language="Icelandic_Old">Haltun</Name>
+      <Name language="Irish_Middle_Norse">Haltun</Name>
+      <Name language="Norse">Haltun</Name>
+      <Name language="Norwegian_Old">Haltun</Name>
+      <Name language="Swedish_Old">Haltun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63768,6 +64350,16 @@
       <GameId game="CK2HIP" parent="c_chester" order="5">b_malpas</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Depenbæce</Name>
+      <Name language="English_Old_Norse">Depenbæce</Name>
+      <Name language="English_Old">Depenbæce</Name>
+      <Name language="Gothic">Depenbæce</Name>
+      <Name language="Icelandic_Old">Depenbæce</Name>
+      <Name language="Irish_Middle_Norse">Depenbæce</Name>
+      <Name language="Norman">Depenbech</Name>
+      <Name language="Norse">Depenbæce</Name>
+      <Name language="Norwegian_Old">Depenbæce</Name>
+      <Name language="Swedish_Old">Depenbæce</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -63776,6 +64368,16 @@
       <GameId game="CK2HIP" parent="c_chester" order="6">b_sandbach</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Sandbæce</Name>
+      <Name language="English_Old_Norse">Sandbæce</Name>
+      <Name language="English_Old">Sandbæce</Name>
+      <Name language="Gothic">Sandbæce</Name>
+      <Name language="Icelandic_Old">Sandbæce</Name>
+      <Name language="Irish_Middle_Norse">Sandbæce</Name>
+      <Name language="Norman">Sondebache</Name>
+      <Name language="Norse">Sandbæce</Name>
+      <Name language="Norwegian_Old">Sandbæce</Name>
+      <Name language="Swedish_Old">Sandbæce</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74334,6 +74936,46 @@
       <GameId game="CK2HIP" parent="k_pomerania" order="7">d_pommerania</GameId>
     </GameIds>
     <Names>
+      <Name language="Aragonese">Pomerania</Name>
+      <Name language="Arpitan">Poméranie</Name>
+      <Name language="Basque">Pomerania</Name>
+      <Name language="Bosnian_Medieval">Pomorze</Name>
+      <Name language="Breton_Middle">Pomerania</Name>
+      <Name language="Bulgarian_Old">Pomorze</Name>
+      <Name language="Catalan_Medieval">Pomerània</Name>
+      <Name language="Croatian_Medieval">Pomorze</Name>
+      <Name language="Czech_Medieval">Pomorzí</Name>
+      <Name language="Danish_Middle">Pommern</Name>
+      <Name language="English_Middle">Pomerania</Name>
+      <Name language="English_Old_Norse">Pommern</Name>
+      <Name language="English_Old">Pommern</Name>
+      <Name language="Estonian">Pommeri</Name>
+      <Name language="Finnish">Pommeri</Name>
+      <Name language="French_Old">Poméranie</Name>
+      <Name language="Galician">Pomerania</Name>
+      <Name language="German_Middle_High">Pommern</Name>
+      <Name language="Gothic">Pommern</Name>
+      <Name language="Icelandic_Old">Pommern</Name>
+      <Name language="Irish_Middle_Norse">Pommern</Name>
+      <Name language="Komi">Pommeri</Name>
+      <Name language="Latgalian">Pomeranija</Name>
+      <Name language="Leonese">Pomerania</Name>
+      <Name language="Lithuanian_Medieval">Pomeranija</Name>
+      <Name language="Livonian">Pommeri</Name>
+      <Name language="Norman">Poméranie</Name>
+      <Name language="Norse">Pommern</Name>
+      <Name language="Norwegian_Old">Pommern</Name>
+      <Name language="Occitan_Old">Pomerània</Name>
+      <Name language="Polish_Old">Pomorze</Name>
+      <Name language="Portuguese">Pomerania</Name>
+      <Name language="Prussian_Old">Pomeranija</Name>
+      <Name language="Russian_Medieval">Pomorze</Name>
+      <Name language="Sami">Pommeri</Name>
+      <Name language="Serbian_Medieval">Pomorze</Name>
+      <Name language="Slovak_Medieval">Pomorzí</Name>
+      <Name language="Slovene_Medieval">Pomorze</Name>
+      <Name language="Sorbian">Pòmòrsko</Name>
+      <Name language="Swedish_Old">Pommern</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74343,6 +74985,16 @@
       <GameId game="CK2HIP" parent="d_pommerania" order="1">c_stettin</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Szczecin</Name>
+      <Name language="Bulgarian_Old">Szczecin</Name>
+      <Name language="Croatian_Medieval">Szczecin</Name>
+      <Name language="Czech_Medieval">Štetín</Name>
+      <Name language="Polish_Old">Szczecin</Name>
+      <Name language="Russian_Medieval">Szczecin</Name>
+      <Name language="Serbian_Medieval">Szczecin</Name>
+      <Name language="Slovak_Medieval">Štetín</Name>
+      <Name language="Slovene_Medieval">Szczecin</Name>
+      <Name language="Sorbian">Szczëtno</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74351,6 +75003,22 @@
       <GameId game="CK2HIP" parent="c_stettin" order="1">b_dabie</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Dabie</Name>
+      <Name language="Bulgarian_Old">Dabie</Name>
+      <Name language="Croatian_Medieval">Dabie</Name>
+      <Name language="Czech_Medieval">Dabie</Name>
+      <Name language="Danish_Middle">Dam</Name>
+      <Name language="English_Old_Norse">Dam</Name>
+      <Name language="Gothic">Dam</Name>
+      <Name language="Irish_Middle_Norse">Dam</Name>
+      <Name language="Norwegian_Old">Dam</Name>
+      <Name language="Polish_Old">Dabie</Name>
+      <Name language="Russian_Medieval">Dabie</Name>
+      <Name language="Serbian_Medieval">Dabie</Name>
+      <Name language="Slovak_Medieval">Dabie</Name>
+      <Name language="Slovene_Medieval">Dabie</Name>
+      <Name language="Sorbian">Dambe</Name>
+      <Name language="Swedish_Old">Dam</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74359,6 +75027,16 @@
       <GameId game="CK2HIP" parent="c_stettin" order="2">b_kolbatz</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Kolbacz</Name>
+      <Name language="Bulgarian_Old">Kolbacz</Name>
+      <Name language="Croatian_Medieval">Kolbacz</Name>
+      <Name language="Czech_Medieval">Kolbacz</Name>
+      <Name language="Polish_Old">Kolbacz</Name>
+      <Name language="Russian_Medieval">Kolbacz</Name>
+      <Name language="Serbian_Medieval">Kolbacz</Name>
+      <Name language="Slovak_Medieval">Kolbacz</Name>
+      <Name language="Slovene_Medieval">Kolbacz</Name>
+      <Name language="Sorbian">Kolbacz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74367,6 +75045,25 @@
       <GameId game="CK2HIP" parent="c_stettin" order="4">b_groswin</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Grozswina</Name>
+      <Name language="Bulgarian_Old">Grozswina</Name>
+      <Name language="Croatian_Medieval">Grozswina</Name>
+      <Name language="Czech_Medieval">Grozswina</Name>
+      <Name language="Danish_Middle">Grotzuina</Name>
+      <Name language="English_Old_Norse">Grosum</Name>
+      <Name language="German_Old_Low">Brotwin</Name>
+      <Name language="Gothic">Grotzuina</Name>
+      <Name language="Icelandic_Old">Grosum</Name>
+      <Name language="Irish_Middle_Norse">Grosum</Name>
+      <Name language="Norse">Grosum</Name>
+      <Name language="Norwegian_Old">Grotzuina</Name>
+      <Name language="Polish_Old">Grozswina</Name>
+      <Name language="Russian_Medieval">Grozswina</Name>
+      <Name language="Serbian_Medieval">Grozswina</Name>
+      <Name language="Slovak_Medieval">Grozswina</Name>
+      <Name language="Slovene_Medieval">Grozswina</Name>
+      <Name language="Sorbian">Grozswina</Name>
+      <Name language="Swedish_Old">Grotzuina</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74375,6 +75072,16 @@
       <GameId game="CK2HIP" parent="c_stettin" order="5">b_anklam</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Tanchlim</Name>
+      <Name language="Bulgarian_Old">Tanchlim</Name>
+      <Name language="Croatian_Medieval">Tanchlim</Name>
+      <Name language="Czech_Medieval">Tanchlim</Name>
+      <Name language="Polish_Old">Tanchlim</Name>
+      <Name language="Russian_Medieval">Tanchlim</Name>
+      <Name language="Serbian_Medieval">Tanchlim</Name>
+      <Name language="Slovak_Medieval">Tanchlim</Name>
+      <Name language="Slovene_Medieval">Tanchlim</Name>
+      <Name language="Sorbian">Tanchlim</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74383,6 +75090,16 @@
       <GameId game="CK2HIP" parent="c_stettin" order="6">b_pyritz</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Pyrzyce</Name>
+      <Name language="Bulgarian_Old">Pyrzyce</Name>
+      <Name language="Croatian_Medieval">Pyrzyce</Name>
+      <Name language="Czech_Medieval">Pyrzice</Name>
+      <Name language="Polish_Old">Pyrzyce</Name>
+      <Name language="Russian_Medieval">Pyrzyce</Name>
+      <Name language="Serbian_Medieval">Pyrzyce</Name>
+      <Name language="Slovak_Medieval">Pyrzice</Name>
+      <Name language="Slovene_Medieval">Pyrzyce</Name>
+      <Name language="Sorbian">Pirzëce</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74391,6 +75108,16 @@
       <GameId game="CK2HIP" parent="c_stettin" order="7">b_pasewalk</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Pozdawilk</Name>
+      <Name language="Bulgarian_Old">Pozdawilk</Name>
+      <Name language="Croatian_Medieval">Pozdawilk</Name>
+      <Name language="Czech_Medieval">Pozdawilk</Name>
+      <Name language="Polish_Old">Pozdawilk</Name>
+      <Name language="Russian_Medieval">Pozdawilk</Name>
+      <Name language="Serbian_Medieval">Pozdawilk</Name>
+      <Name language="Slovak_Medieval">Pozdawilk</Name>
+      <Name language="Slovene_Medieval">Pozdawilk</Name>
+      <Name language="Sorbian">Pozwolc</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74399,6 +75126,16 @@
       <GameId game="CK2HIP" parent="c_stettin" order="8">b_stargard_pommern</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Starogród</Name>
+      <Name language="Bulgarian_Old">Starogród</Name>
+      <Name language="Croatian_Medieval">Starogród</Name>
+      <Name language="Czech_Medieval">Starograd</Name>
+      <Name language="Polish_Old">Starogród</Name>
+      <Name language="Russian_Medieval">Starogród</Name>
+      <Name language="Serbian_Medieval">Starogród</Name>
+      <Name language="Slovak_Medieval">Starograd</Name>
+      <Name language="Slovene_Medieval">Starogród</Name>
+      <Name language="Sorbian">Stôrgard</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74407,6 +75144,16 @@
       <GameId game="CK2HIP" parent="c_stettin" order="9">b_wussow</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Osowo</Name>
+      <Name language="Bulgarian_Old">Osowo</Name>
+      <Name language="Croatian_Medieval">Osowo</Name>
+      <Name language="Czech_Medieval">Osowo</Name>
+      <Name language="Polish_Old">Osowo</Name>
+      <Name language="Russian_Medieval">Osowo</Name>
+      <Name language="Serbian_Medieval">Osowo</Name>
+      <Name language="Slovak_Medieval">Osowo</Name>
+      <Name language="Slovene_Medieval">Osowo</Name>
+      <Name language="Sorbian">Osowo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74416,6 +75163,25 @@
       <GameId game="CK2HIP" parent="c_wolgast" order="1">b_wolgast</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Wologoszcz</Name>
+      <Name language="Bulgarian_Old">Wologoszcz</Name>
+      <Name language="Croatian_Medieval">Wologoszcz</Name>
+      <Name language="Czech_Medieval">Volgast</Name>
+      <Name language="Danish_Middle">Waløgost</Name>
+      <Name language="English_Old_Norse">Waløgost</Name>
+      <Name language="Gothic">Waløgost</Name>
+      <Name language="Icelandic_Old">Waløgost</Name>
+      <Name language="Irish_Middle_Norse">Waløgost</Name>
+      <Name language="Norse">Jómsborg</Name>
+      <Name language="Norse">Waløgost</Name>
+      <Name language="Norwegian_Old">Waløgost</Name>
+      <Name language="Polish_Old">Wologoszcz</Name>
+      <Name language="Russian_Medieval">Wologoszcz</Name>
+      <Name language="Serbian_Medieval">Wologoszcz</Name>
+      <Name language="Slovak_Medieval">Volgast</Name>
+      <Name language="Slovene_Medieval">Wologoszcz</Name>
+      <Name language="Sorbian">Hologost</Name>
+      <Name language="Swedish_Old">Waløgost</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -1686,7 +1686,7 @@
       <Name language="Castilian">Nápoles</Name>
       <Name language="Catalan">Nàpols</Name>
       <Name language="Croatian">Napulj</Name>
-      <Name language="Czech">Neapol</Name>                                                                                                                                                                                               
+      <Name language="Czech">Neapol</Name>
       <Name language="Dutch_Middle">Napels</Name>
       <Name language="Emilian_Romagnol">Nâpol</Name>
       <Name language="English">Naples</Name>
@@ -38578,21 +38578,50 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>norfolk</Id>
+    <Id>east_anglia</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_norfolk" order="1">c_norfolk</GameId>
       <GameId game="CK2HIP" parent="k_england" order="8">d_norfolk</GameId>
     </GameIds>
     <Names>
-      <Name language="Latin">Iceni</Name>
+      <Name language="Danish_Middle">Austængle</Name>
+      <Name language="English_Middle">East Anglia</Name>
+      <Name language="English_Old_Norse">Eastengle</Name>
+      <Name language="English_Old">Eastengle</Name>
+      <Name language="English">East Anglia</Name>
+      <Name language="Gothic">Austængle</Name>
+      <Name language="Icelandic_Old">Austængle</Name>
+      <Name language="Irish_Middle_Norse">Austængle</Name>
+      <Name language="Norse">Austængle</Name>
+      <Name language="Norwegian_Old">Austængle</Name>
+      <Name language="Swedish_Old">Austængle</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>norfolk</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_norfolk" order="1">c_norfolk</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Danish_Middle">Norðfolc</Name>
+      <Name language="English_Middle">Norfolk</Name>
+      <Name language="English_Old_Norse">Northfolc</Name>
+      <Name language="English">Norfolk</Name>
+      <Name language="Gothic">Norðfolc</Name>
+      <Name language="Icelandic_Old">Norðfolc</Name>
+      <Name language="Irish_Middle_Norse">Norðfolc</Name>
+      <Name language="Norse">Norðfolc</Name>
+      <Name language="Norwegian_Old">Norðfolc</Name>
+      <Name language="Swedish_Old">Norðfolc</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>thetford</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_norfolk" order="1">b_thetford</GameId>
+      <GameId game="CK3">b_thetford</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Middle">Thetford</Name>
       <Name language="English_Old_Norse">Theodforda</Name>
       <Name language="English_Old">Theodforda</Name>
       <Name language="Latin">Gariannonum</Name>
@@ -38603,8 +38632,10 @@
     <Id>norwich</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_norfolk" order="3">b_norwich</GameId>
+      <GameId game="CK3">b_norwich</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Middle">Northwich</Name>
       <Name language="English_Old_Norse">Northwic</Name>
       <Name language="English_Old">Northwic</Name>
       <Name language="Latin">Venta Icenorum</Name>
@@ -38613,12 +38644,31 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>walsingham</Id>
+    <GameIds>
+      <GameId game="CK3">b_walsingham</GameId>
+    </GameIds>
+    <Names>
+      <Name language="English_Middle">Walsingham</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>suffolk</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_norfolk" order="2">c_suffolk</GameId>
+      <GameId game="CK3">c_suffolk</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Suðfolc</Name>
+      <Name language="English_Old_Norse">Suthfolc</Name>
+      <Name language="English_Old">Suthfolc</Name>
+      <Name language="Gothic">Suðfolc</Name>
+      <Name language="Icelandic_Old">Suðfolc</Name>
+      <Name language="Irish_Middle_Norse">Suðfolc</Name>
       <Name language="Latin">Trinovantes</Name>
+      <Name language="Norse">Suðfolc</Name>
+      <Name language="Norwegian_Old">Suðfolc</Name>
+      <Name language="Swedish_Old">Suðfolc</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38627,8 +38677,46 @@
       <GameId game="CK2HIP" parent="c_suffolk" order="1">b_ipswich</GameId>
     </GameIds>
     <Names>
-      <Name language="Lithuanian">Ipsvicas</Name>
+      <Name language="Danish_Middle">Gipeswic</Name>
+      <Name language="English_Middle">Ipswich</Name>
+      <Name language="English_Old_Norse">Gipeswic</Name>
+      <Name language="English_Old">Gipeswic</Name>
+      <Name language="English">Ipswich</Name>
+      <Name language="Gothic">Gipeswic</Name>
+      <Name language="Icelandic_Old">Gipeswic</Name>
+      <Name language="Irish_Middle_Norse">Gipeswic</Name>
       <Name language="Latin">Gippevicum</Name>
+      <Name language="Lithuanian">Ipsvicas</Name>
+      <Name language="Norse">Gipeswic</Name>
+      <Name language="Norwegian_Old">Gipeswic</Name>
+      <Name language="Swedish_Old">Gipeswic</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sudbury</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_suffolk" order="1">b_sudbury</GameId>
+    </GameIds>
+    <Names>
+      <Name language="English_Middle">Sudbury</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>blything</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_suffolk" order="1">b_blything</GameId>
+    </GameIds>
+    <Names>
+      <Name language="English_Middle">Blything</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>beodericsworth</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_suffolk" order="1">b_beodericsworth</GameId>
+    </GameIds>
+    <Names>
+      <Name language="English_Middle">Beodericsworth</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38636,10 +38724,21 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_ely" order="1">b_ely</GameId>
       <GameId game="CK2HIP" parent="d_norfolk" order="3">c_ely</GameId>
+      <GameId game="CK3">b_ely</GameId>
     </GameIds>
     <Names>
-      <Name language="Lithuanian">Ilis</Name>
+      <Name language="Danish_Middle">Élig</Name>
+      <Name language="English_Middle">Ely</Name>
+      <Name language="English_Old_Norse">Elig</Name>
+      <Name language="English_Old">Elig</Name>
+      <Name language="Gothic">Élig</Name>
+      <Name language="Icelandic_Old">Élig</Name>
+      <Name language="Irish_Middle_Norse">Élig</Name>
       <Name language="Latin">Elia</Name>
+      <Name language="Lithuanian">Ilis</Name>
+      <Name language="Norse">Élig</Name>
+      <Name language="Norwegian_Old">Élig</Name>
+      <Name language="Swedish_Old">Élig</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38661,15 +38760,63 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>cambridgeshire</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_norfolk" order="4">c_cambridge</GameId>
+      <GameId game="CK3">c_cambridgeshire</GameId>
+    </GameIds>
+    <FallbackLocations>
+      <LocationId>cambridge</LocationId>
+    </FallbackLocations>
+    <Names>
+      <Name language="English_Middle">Cambridgeshire</Name>
+      <Name language="English">Cambridgeshire</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>cambridge</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_cambridge" order="1">b_cambridge</GameId>
-      <GameId game="CK2HIP" parent="d_norfolk" order="4">c_cambridge</GameId>
+      <GameId game="CK3">b_cambridge</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Caergrawnt</Name>
+      <Name language="Cornish_Middle">Caergrawnt</Name>
+      <Name language="Cumbric">Caergrawnt</Name>
+      <Name language="Danish_Middle">Grantabrycge</Name>
+      <Name language="English_Old_Norse">Grantabrycge</Name>
+      <Name language="English_Old">Grantabrycge</Name>
+      <Name language="Gothic">Grantabrycge</Name>
+      <Name language="Icelandic_Old">Grantabrycge</Name>
+      <Name language="Irish_Middle_Norse">Grantabrycge</Name>
+      <Name language="Irish_Middle">Caergrawnt</Name>
       <Name language="Latgalian">Kembridža</Name>
-      <Name language="Lithuanian">Kembridžas</Name>
       <Name language="Latin">Duroliponte</Name>
+      <Name language="Lithuanian">Kembridžas</Name>
+      <Name language="Norman">Grentebrige</Name>
+      <Name language="Norse">Grantabrycge</Name>
+      <Name language="Norwegian_Old">Grantabrycge</Name>
+      <Name language="Scottish_Medieval">Caergrawnt</Name>
+      <Name language="Swedish_Old">Grantabrycge</Name>
+      <Name language="Welsh_Middle">Caergrawnt</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>radfield</Id>
+    <GameIds>
+      <GameId game="CK3">b_radfield</GameId>
+    </GameIds>
+    <Names>
+      <Name language="English_Middle">Radfield</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>papworth</Id>
+    <GameIds>
+      <GameId game="CK3">b_papworth</GameId>
+    </GameIds>
+    <Names>
+      <Name language="English_Middle">Papworth</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62942,8 +63089,10 @@
     <Id>lynn</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_norfolk" order="2">b_lynn</GameId>
+      <GameId game="CK3">b_lynn</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Middle">Lynn</Name>
       <Name language="English_Old_Norse">Lean</Name>
       <Name language="English_Old">Lean</Name>
       <Name language="Norse">Lean</Name>

--- a/titles.xml
+++ b/titles.xml
@@ -11829,6 +11829,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="k_bohemia" order="1">d_bohemia</GameId>
       <GameId game="CK2HIP" parent="e_hre" order="12">k_bohemia</GameId>
+      <GameId game="CK3">d_bohemia</GameId>
+      <GameId game="CK3">k_bohemia</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Böhmen</Name>
@@ -11873,6 +11875,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_praha" order="2">b_praha</GameId>
       <GameId game="CK2HIP" parent="d_bohemia" order="1">c_praha</GameId>
+      <GameId game="CK3">b_praha</GameId>
+      <GameId game="CK3">c_praha</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Prag</Name>
@@ -11887,7 +11891,9 @@
       <Name language="Dutch_Middle">Prag</Name>
       <Name language="Franconian_Lorraine">Prag</Name>
       <Name language="Frankish_Low">Prag</Name>
+      <Name language="Frankish">Prag</Name>
       <Name language="French_Old">Prague</Name>
+      <Name language="French">Prague</Name>
       <Name language="Galician">Praga</Name>
       <Name language="German_Middle_High">Prag</Name>
       <Name language="German_Middle_Low">Prag</Name>
@@ -11912,6 +11918,34 @@
       <Name language="Turkish">Prag</Name>
       <Name language="Welsh">Prâg</Name>
       <Name language="Yiddish">Prag</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vysehrad</Id>
+    <GameIds>
+      <GameId game="CK3">b_vysehrad</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Vyšehrad</Name>
+      <Name language="German">Wyschehrad</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>beroun</Id>
+    <GameIds>
+      <GameId game="CK3">b_beroun</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Beroun</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>melnik_czechia</Id>
+    <GameIds>
+      <GameId game="CK3">b_melnik</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Mělník</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -11959,6 +11993,7 @@
     <Id>slany</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_praha" order="6">b_slany</GameId>
+      <GameId game="CK3">b_slany</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Slani</Name>
@@ -11996,22 +12031,30 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>domazlice</Id>
+    <Id>south_bohemia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_bohemia" order="2">c_domazlice</GameId>
     </GameIds>
     <Names>
-      <Name language="Bosnian">Duljebi</Name>
-      <Name language="Bulgarian">Dulebi</Name>
-      <Name language="Slovene">Duljebi</Name>
-      <Name language="Croatian">Duljebi</Name>
-      <Name language="Serbian">Duljebi</Name>
+      <Name language="Alemannic">Sudböhmen</Name>
+      <Name language="Bavarian_Medieval">Sudböhmen</Name>
+      <Name language="Czech_Medieval">Jižní Czechy</Name>
+      <Name language="Dutch_Middle">Sudböhmen</Name>
+      <Name language="Frankish_Low">Sudböhmen</Name>
+      <Name language="Frankish">Sudböhmen</Name>
+      <Name language="German_Middle_High">Sudböhmen</Name>
+      <Name language="German_Middle_Low">Sudböhmen</Name>
+      <Name language="German_Old_Low">Sudböhmen</Name>
+      <Name language="Slovak_Medieval">Jižní Czechy</Name>
+      <Name language="Thuringian">Sudböhmen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>doudleby</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_domazlice" order="1">b_doudleby</GameId>
+      <GameId game="CK3">b_doudleby</GameId>
+      <GameId game="CK3">c_doudleby</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Teindles</Name>
@@ -12033,11 +12076,40 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>prachen</Id>
+    <GameIds>
+      <GameId game="CK3">b_prachen</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Prácheň</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>domazlice</Id>
+    <GameIds>
+      <GameId game="CK3">b_domazlice</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Domažlice</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>netolice</Id>
+    <GameIds>
+      <GameId game="CK3">b_netolice</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Netolice</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>pisek</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_domazlice" order="2">b_pisek</GameId>
+      <GameId game="CK3">b_pisek</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Písek</Name>
       <Name language="Lithuanian">Pysekas</Name>
     </Names>
   </LocationEntity>
@@ -12070,18 +12142,19 @@
     <Id>rosenberg</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_domazlice" order="5">b_rosenberg</GameId>
+      <GameId game="CK3">b_rozmberk</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Ružova Gora</Name>
       <Name language="Bulgarian">Rozova Gora</Name>
       <Name language="Croatian">Ružova Gora</Name>
-      <Name language="Czech_Medieval">Rozmberk</Name>
+      <Name language="Czech_Medieval">Rožmberk</Name>
       <Name language="Czech">Ružová Hora</Name>
       <Name language="Latgalian">Ružomberoka</Name>
       <Name language="Lithuanian">Ružomberokas</Name>
       <Name language="Polish_Old">Rozemberk</Name>
       <Name language="Serbian">Ružova Gora</Name>
-      <Name language="Slovak_Medieval">Rozmberk</Name>
+      <Name language="Slovak_Medieval">Rožmberk</Name>
       <Name language="Slovak">Ružová Hora</Name>
       <Name language="Slovene">Rožova Gora</Name>
     </Names>
@@ -12238,6 +12311,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_praha" order="5">b_boleslav</GameId>
       <GameId game="CK2HIP" parent="d_bohemia" order="4">c_boleslav</GameId>
+      <GameId game="CK3">b_boleslav</GameId>
+      <GameId game="CK3">c_boleslav</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Bunzlau</Name>
@@ -12254,6 +12329,15 @@
       <Name language="Slovak_Medieval">Boleslaw</Name>
       <Name language="Thuringian">Bunzlau</Name>
       <Name language="Yiddish">Bumsla</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>bezdez</Id>
+    <GameIds>
+      <GameId game="CK3">b_bezdez</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Bezděz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12388,6 +12472,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_litomerice" order="1">b_litomerice</GameId>
       <GameId game="CK2HIP" parent="d_bohemia" order="5">c_litomerice</GameId>
+      <GameId game="CK3">b_litomerice</GameId>
+      <GameId game="CK3">c_litomerice</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Leitmeritz</Name>
@@ -12395,9 +12481,10 @@
       <Name language="Bosnian">Litomjeržice</Name>
       <Name language="Bulgarian">Litomeržice</Name>
       <Name language="Croatian">Litomjeržice</Name>
-      <Name language="Czech_Medieval">Litomierzicze</Name>
+      <Name language="Czech">Litoměřice</Name>
       <Name language="Frankish_Low">Leitmeritz</Name>
       <Name language="Frankish">Leitmeritz</Name>
+      <Name language="German">Leitmeritz</Name>
       <Name language="German_Middle_High">Leitmeritz</Name>
       <Name language="German_Middle_Low">Leitmeritz</Name>
       <Name language="German_Old_Low">Leitmeritz</Name>
@@ -12405,7 +12492,7 @@
       <Name language="Lithuanian">Litomeržices</Name>
       <Name language="Polish_Old">Litomierzyce</Name>
       <Name language="Serbian">Litomjeržice</Name>
-      <Name language="Slovak_Medieval">Litomierzicze</Name>
+      <Name language="Slovak">Litoměřice</Name>
       <Name language="Slovene">Litomjeržice</Name>
       <Name language="Thuringian">Leitmeritz</Name>
     </Names>
@@ -12414,6 +12501,7 @@
     <Id>bilina</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_litomerice" order="2">b_bilina</GameId>
+      <GameId game="CK3">b_bilina</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Pilsen</Name>
@@ -12427,6 +12515,24 @@
       <Name language="Romanian">Bilnița</Name>
       <Name language="Slovak_Medieval">Bielina</Name>
       <Name language="Thuringian">Pilsen</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>decin</Id>
+    <GameIds>
+      <GameId game="CK3">b_decin</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Děčín</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zitava</Id>
+    <GameIds>
+      <GameId game="CK3">b_zitava</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Žitava</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12478,13 +12584,25 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_zatec" order="1">b_zatec</GameId>
       <GameId game="CK2HIP" parent="d_bohemia" order="6">c_zatec</GameId>
+      <GameId game="CK3">b_zatec</GameId>
+      <GameId game="CK3">c_zatec</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Saaz</Name>
+      <Name language="Bavarian_Medieval">Saaz</Name>
       <Name language="Bosnian">Žatec</Name>
       <Name language="Bulgarian">Žatec</Name>
-      <Name language="Slovene">Žatec</Name>
       <Name language="Croatian">Žatec</Name>
+      <Name language="Czech_Medieval">Žatec</Name>
+      <Name language="Frankish_Low">Saaz</Name>
+      <Name language="Frankish">Saaz</Name>
+      <Name language="German_Middle_High">Saaz</Name>
+      <Name language="German_Middle_Low">Saaz</Name>
+      <Name language="German_Old_Low">Saaz</Name>
       <Name language="Serbian">Žatec</Name>
+      <Name language="Slovak_Medieval">Žatec</Name>
+      <Name language="Slovene">Žatec</Name>
+      <Name language="Thuringian">Saaz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12493,11 +12611,19 @@
       <GameId game="CK2HIP" parent="c_zatec" order="2">b_louny</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Laun</Name>
+      <Name language="Bavarian_Medieval">Laun</Name>
       <Name language="Bosnian">Luni</Name>
       <Name language="Bulgarian">Luni</Name>
-      <Name language="Slovene">Luni</Name>
       <Name language="Croatian">Luni</Name>
+      <Name language="Frankish_Low">Laun</Name>
+      <Name language="Frankish">Laun</Name>
+      <Name language="German_Middle_High">Laun</Name>
+      <Name language="German_Middle_Low">Laun</Name>
+      <Name language="German_Old_Low">Laun</Name>
       <Name language="Serbian">Luni</Name>
+      <Name language="Slovene">Luni</Name>
+      <Name language="Thuringian">Laun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12530,13 +12656,32 @@
     <Id>kadan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_zatec" order="7">b_kadan</GameId>
+      <GameId game="CK3">b_kadan</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Kaaden</Name>
+      <Name language="Bavarian_Medieval">Kaaden</Name>
       <Name language="Bosnian">Kadanj</Name>
       <Name language="Bulgarian">Kadanj</Name>
-      <Name language="Slovene">Kadanj</Name>
       <Name language="Croatian">Kadanj</Name>
+      <Name language="Czech_Medieval">Kadaň</Name>
+      <Name language="Frankish_Low">Kaaden</Name>
+      <Name language="Frankish">Kaaden</Name>
+      <Name language="German_Middle_High">Kaaden</Name>
+      <Name language="German_Middle_Low">Kaaden</Name>
+      <Name language="German_Old_Low">Kaaden</Name>
       <Name language="Serbian">Kadanj</Name>
+      <Name language="Slovene">Kadanj</Name>
+      <Name language="Thuringian">Kaaden</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sedlec</Id>
+    <GameIds>
+      <GameId game="CK3">b_sedlec</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Sedlec</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12544,22 +12689,36 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_plzen" order="1">b_plzen</GameId>
       <GameId game="CK2HIP" parent="d_bohemia" order="7">c_plzen</GameId>
+      <GameId game="CK3">b_plzen</GameId>
+      <GameId game="CK3">c_plzen</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Pilsen</Name>
       <Name language="Basque">Pilsen</Name>
+      <Name language="Bavarian_Medieval">Pilsen</Name>
       <Name language="Bosnian">Plzenj</Name>
       <Name language="Bulgarian">Plzenj</Name>
       <Name language="Castilian">Pilsen</Name>
       <Name language="Croatian">Plzenj</Name>
+      <Name language="Czech_Medieval">Plzeň</Name>
       <Name language="Dutch_Middle">Pilsen</Name>
+      <Name language="Frankish_Low">Pilsen</Name>
+      <Name language="Frankish">Pilsen</Name>
       <Name language="French_Old">Pilsen</Name>
       <Name language="Frisian_Old">Pilsen</Name>
+      <Name language="German_Middle_High">Pilsen</Name>
+      <Name language="German_Middle_Low">Pilsen</Name>
+      <Name language="German_Old_Low">Pilsen</Name>
       <Name language="Italian">Pilsen</Name>
       <Name language="Latgalian">Plzena</Name>
       <Name language="Latin">Pilsna</Name>
       <Name language="Lithuanian">Pilzenas</Name>
+      <Name language="Polish_Old">Pilzno</Name>
       <Name language="Serbian">Plzenj</Name>
       <Name language="Slovene">Plzenj</Name>
+      <Name language="Sorbian">Pilzen</Name>
+      <Name language="Thuringian">Pilsen</Name>
+      <Name language="Yiddish">Pilzen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12576,16 +12735,27 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>stribo</Id>
+    <Id>stribro</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_plzen" order="3">b_stribo</GameId>
+      <GameId game="CK3">b_stribro</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Mies</Name>
+      <Name language="Bavarian_Medieval">Mies</Name>
       <Name language="Bosnian">Stribro</Name>
       <Name language="Bulgarian">Stribro</Name>
-      <Name language="Slovene">Stribro</Name>
       <Name language="Croatian">Stribro</Name>
+      <Name language="Czech_Medieval">Stříbro</Name>
+      <Name language="Frankish_Low">Mies</Name>
+      <Name language="Frankish">Mies</Name>
+      <Name language="German_Middle_High">Mies</Name>
+      <Name language="German_Middle_Low">Mies</Name>
+      <Name language="German_Old_Low">Mies</Name>
       <Name language="Serbian">Stribro</Name>
+      <Name language="Slovak_Medieval">Stříbro</Name>
+      <Name language="Slovene">Stribro</Name>
+      <Name language="Thuringian">Mies</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -13126,18 +13296,40 @@
     <Id>moravsky_krumlov</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_znojmo" order="7">b_moravsky_krumlov</GameId>
+      <GameId game="CK3">b_krumlov</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Mährisch Kromau</Name>
       <Name language="Bavarian">Mährisch Kromau</Name>
+      <Name language="Czech_Medieval">Krumlov</Name>
+      <Name language="Czech">Český Krumlov</Name>
       <Name language="Frankish_Low">Mährisch Kromau</Name>
       <Name language="Frankish">Mährisch Kromau</Name>
       <Name language="German_Middle_High">Mährisch Kromau</Name>
       <Name language="German_Middle_Low">Mährisch Kromau</Name>
       <Name language="German_Old_Low">Mährisch Kromau</Name>
+      <Name language="German">Krummau</Name>
       <Name language="Latin">Crumlovia</Name>
       <Name language="Lithuanian">Krumlovas</Name>
       <Name language="Thuringian">Mährisch Kromau</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>chynov</Id>
+    <GameIds>
+      <GameId game="CK3">b_chynov</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Chýnov</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>bechyne</Id>
+    <GameIds>
+      <GameId game="CK3">b_bechyne</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Bechyně</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -53178,16 +53370,37 @@
     <Id>loket</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_zatec" order="4">b_loket</GameId>
+      <GameId game="CK3">b_loket</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Elbogen</Name>
+      <Name language="Bavarian_Medieval">Elbogen</Name>
+      <Name language="Czech_Medieval">Loket</Name>
+      <Name language="Frankish_Low">Elbogen</Name>
+      <Name language="Frankish">Elbogen</Name>
+      <Name language="German_Middle_High">Elbogen</Name>
+      <Name language="German_Middle_Low">Elbogen</Name>
+      <Name language="German_Old_Low">Elbogen</Name>
+      <Name language="Thuringian">Elbogen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>primda</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_plzen" order="4">b_primda</GameId>
+      <GameId game="CK3">b_primda</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Pfraumberg</Name>
+      <Name language="Bavarian_Medieval">Pfraumberg</Name>
+      <Name language="Czech_Medieval">Přimda</Name>
+      <Name language="Frankish_Low">Pfraumberg</Name>
+      <Name language="Frankish">Pfraumberg</Name>
+      <Name language="German_Middle_High">Pfraumberg</Name>
+      <Name language="German_Middle_Low">Pfraumberg</Name>
+      <Name language="German_Old_Low">Pfraumberg</Name>
+      <Name language="Slovak_Medieval">Přimda</Name>
+      <Name language="Thuringian">Pfraumberg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81510,6 +81723,7 @@
     <Id>milevsko</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_domazlice" order="4">b_milevsko</GameId>
+      <GameId game="CK3">b_milevsko</GameId>
     </GameIds>
     <Names>
     </Names>

--- a/titles.xml
+++ b/titles.xml
@@ -15217,6 +15217,7 @@
     <Id>thessalia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_neopatras" order="1">c_thessalia</GameId>
+      <GameId game="CK2HIP" parent="" order="11813">d_thessalia</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Tesalija</Name>
@@ -21616,6 +21617,7 @@
   <LocationEntity>
     <Id>sweden</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="" order="11781">d_sweden</GameId>
       <GameId game="CK2HIP" parent="e_scandinavia" order="3">k_sweden</GameId>
     </GameIds>
     <Names>
@@ -52634,6 +52636,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_sijilmasa" order="1">b_sijilmasa</GameId>
       <GameId game="CK2HIP" parent="d_sijilmasa" order="1">c_sijilmasa</GameId>
+      <GameId game="CK2HIP" parent="k_maghreb" order="6">d_sijilmasa</GameId>
     </GameIds>
     <Names>
       <Name language="German">Sidschilmasa</Name>
@@ -52646,6 +52649,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="k_mali" order="1">d_mali</GameId>
       <GameId game="CK2HIP" parent="e_mali" order="2">k_mali</GameId>
+      <GameId game="CK2HIP" parent="" order="8407">e_mali</GameId>
     </GameIds>
     <Names>
       <Name language="Prussian_Old">Malis</Name>
@@ -61818,6 +61822,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_dakhila" order="1">b_dakhila</GameId>
       <GameId game="CK2HIP" parent="d_alwahat" order="2">c_dakhila</GameId>
+      <GameId game="CK2HIP" parent="" order="11795">d_dakhila</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -63720,6 +63725,7 @@
     <Id>abyssinia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="e_abyssinia" order="2">k_abyssinia</GameId>
+      <GameId game="CK2HIP" parent="" order="4673">e_abyssinia</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -63935,6 +63941,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_aydhab" order="1">b_aydhab</GameId>
       <GameId game="CK2HIP" parent="d_aydhab" order="1">c_aydhab</GameId>
+      <GameId game="CK2HIP" parent="k_maikelebahr" order="1">d_aydhab</GameId>
     </GameIds>
     <Names>
       <Name language="Greek_Medieval">Berenike</Name>
@@ -67684,6 +67691,7 @@
     <Id>seprio</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_seprio" order="2">b_seprio</GameId>
+      <GameId game="CK2HIP" parent="d_lombardia" order="7">c_seprio</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -73723,6 +73731,7 @@
     <Id>masila</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tell_atlas" order="1">b_masila</GameId>
+      <GameId game="CK2HIP" parent="" order="11794">d_masila</GameId>
     </GameIds>
     <Names>
       <Name language="Greek_Medieval">Lambaesis</Name>
@@ -74147,8 +74156,9 @@
   <LocationEntity>
     <Id>rayy</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_rayy" order="1">c_rayy</GameId>
       <GameId game="CK2HIP" parent="c_rayy" order="1">b_rayy</GameId>
+      <GameId game="CK2HIP" parent="d_rayy" order="1">c_rayy</GameId>
+      <GameId game="CK2HIP" parent="k_persia" order="2">d_rayy</GameId>
       <GameId game="ImperatorRome">4991</GameId> <!-- Rhagai -->
     </GameIds>
     <Names>
@@ -74216,6 +74226,7 @@
     <Id>istakhr</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_istakhr" order="1">b_istakhr</GameId>
+      <GameId game="CK2HIP" parent="d_fars" order="2">c_istakhr</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -74262,6 +74273,7 @@
       <GameId game="CK2HIP" parent="c_kerman" order="7">b_kerman</GameId>
       <GameId game="CK2HIP" parent="d_kerman" order="1">c_kerman</GameId>
       <GameId game="CK2HIP" parent="k_persia" order="4">d_kerman</GameId>
+      <GameId game="CK2HIP" parent="" order="11850">k_kerman</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Bardsir</Name>
@@ -74348,6 +74360,7 @@
     <Id>shapurkhwast</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_shapurkhwast" order="1">b_shapurkhwast</GameId>
+      <GameId game="CK2HIP" parent="d_luristan" order="2">c_shapurkhwast</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -74438,6 +74451,7 @@
     <Id>kumis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_kumis" order="1">c_kumis</GameId>
+      <GameId game="CK2HIP" parent="k_daylam" order="5">d_kumis</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -77186,6 +77200,22 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>auxois</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_burgundy" order="1">c_auxois</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>bandava</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_courland" order="1">c_bandava</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>kuldiga</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_bandava" order="1">b_kuldiga</GameId>
@@ -78077,6 +78107,7 @@
   <LocationEntity>
     <Id>sarir</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="d_sarir" order="1">c_sarir</GameId>
       <GameId game="CK2HIP" parent="k_alania" order="3">d_sarir</GameId>
     </GameIds>
     <Names>
@@ -78101,8 +78132,9 @@
   <LocationEntity>
     <Id>kabul</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_kabul" order="1">c_kabul</GameId>
       <GameId game="CK2HIP" parent="c_kabul" order="1">b_kabul</GameId>
+      <GameId game="CK2HIP" parent="d_kabul" order="1">c_kabul</GameId>
+      <GameId game="CK2HIP" parent="k_kafarestan" order="2">d_kabul</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -78992,6 +79024,7 @@
     <Id>viipuri</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_viipuri" order="3">b_viipuri</GameId>
+      <GameId game="CK2HIP" parent="d_viipuri" order="1">c_viipuri</GameId>
       <GameId game="CK2HIP" parent="k_finland" order="2">d_viipuri</GameId>
     </GameIds>
     <Names>
@@ -79581,6 +79614,7 @@
   <LocationEntity>
     <Id>kartli</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="d_kartli" order="1">c_kartli</GameId>
       <GameId game="CK2HIP" parent="k_georgia" order="1">d_kartli</GameId>
     </GameIds>
     <Names>
@@ -79700,14 +79734,6 @@
       <Name language="Oghuz">Ardahan</Name>
       <Name language="Turkish_Old">Ardahan</Name>
       <Name language="Turkmen_Medieval">Ardahan</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>klarjeti</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_klarjeti" order="2">c_klarjeti</GameId>
-    </GameIds>
-    <Names>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80350,14 +80376,6 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_mzab" order="3">c_ghadames</GameId>
       <GameId game="CK2HIP" parent="c_ghadames" order="1">b_ghadames</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>fezzan</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="k_fezzan" order="1">d_fezzan</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -84780,6 +84798,7 @@
   <LocationEntity>
     <Id>halland</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="k_denmark" order="3">d_halland</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -85900,6 +85919,7 @@
     <Id>mora</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_dalarna" order="6">b_mora</GameId>
+      <GameId game="CK2HIP" parent="d_tedjoura" order="2">c_mora</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -89416,8 +89436,17 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>abivard</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_merv" order="3">c_abivard</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>asir</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="d_medina" order="6">c_asir</GameId>
       <GameId game="CK2HIP" parent="d_medina" order="6">c_asir</GameId>
     </GameIds>
     <Names>
@@ -90545,5 +90574,952 @@
     <Names>
     </Names>
   </LocationEntity>
-
+  <LocationEntity>
+    <Id>deccan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="9945">e_deccan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>null</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="10308">e_null</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>the_isles</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11776">d_the_isles</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>abbasid</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11777">d_abbasid</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>danes</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11778">d_danes</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>geats</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11779">d_geats</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hilal</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11785">d_hilal</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zughba</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11786">d_zughba</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>massufa</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11787">d_massufa</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>lamtuna</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11788">d_lamtuna</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>lamta</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11789">d_lamta</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>lamta_east</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11789">d_lamta_east</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>guddala</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11791">d_guddala</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gazzula</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11792">d_gazzula</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>lawata</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11793">d_lawata</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>musab</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11796">d_musab</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>azger</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11797">d_azger</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>mazata</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11798">d_mazata</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>naqis</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11799">d_naqis</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kanz</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11800">d_kanz</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>baqlin</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11801">d_baqlin</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>djarin</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11802">d_djarin</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>qataa</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11803">d_qataa</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>bazin</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11804">d_bazin</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>nagash</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11805">d_nagash</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>danakil</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11806">d_danakil</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>shewa</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11807">d_shewa</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>silesians</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11808">d_silesians</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>polans</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11809">d_polans</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>mazovians</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11811">d_mazovians</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>peloponnese</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11814">d_peloponnese</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>almohad</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11816">k_almohad</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>al-murabitids</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11817">k_al-murabitids</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>beni_helal</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11819">k_beni_helal</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>fatimids</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11822">k_fatimids</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hammadid</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11824">k_hammadid</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kafsid</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11825">k_kafsid</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>marinid</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11828">k_marinid</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>naples</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11831">k_naples</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>osmanli</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11832">d_osmanli</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ottoman</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11833">k_ottoman</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>rum</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11834">k_rum</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>seljuk_turks</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11836">e_seljuk_turks</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>trinacria</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11840">k_trinacria</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zenata</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11841">k_zenata</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zirid</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11842">k_zirid</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ziyanids</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11843">k_ziyanids</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>israel</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11847">k_israel</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ifat</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11848">k_ifat</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kimek</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11849">k_kimek</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>india</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11853">e_india</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>russian_empire</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="" order="11854">e_russian_empire</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>layzan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_shirvan" order="4">c_albania</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>bigorre</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_foix" order="4">c_bigorre</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>brega</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_meath" order="2">c_brega</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vaga</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_bjarmia" order="3">c_chud</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>darum</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_jerusalem" order="4">c_darum</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>duvzare</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_courland" order="2">c_duvzare</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>eilat</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_sinai" order="2">c_eilat</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ferghana</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_ferghana" order="4">c_ferghana</GameId>
+      <GameId game="CK2HIP" parent="k_mavarannahr" order="3">d_ferghana</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gatinas</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_orleans" order="2">c_gatinas</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gleiberg</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_hessen" order="1">c_gleiberg</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>dembiya</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_gondar" order="1">c_gondar</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gruyere</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_zahringen" order="3">c_gruyere</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>guria</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_imeretia" order="1">c_guria</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>harer</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_ifat" order="1">c_harer</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hereti</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_hereti" order="1">c_hereti</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>jand</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_jand" order="1">c_jand</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>jeriska</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_lettigale" order="1">c_jeriska</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>jiqeti</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_zichia" order="2">c_jiqeti</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kiel</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_wagria" order="2">c_kiel</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>komi</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_perm" order="3">c_komi</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kuma</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_itil" order="2">c_kuma</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>maragheh</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_azerbaijan" order="2">c_maragheh</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>marsan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_gascogne" order="4">c_marsan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>marsi</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_atri" order="1">c_marsi</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>matamma</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_damot" order="2">c_matamma</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>metsepole</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_livonia" order="2">c_metsepole</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>molise</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_capua" order="2">c_molise</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>muqan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_azerbaijan" order="5">c_muqan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>nafzawa</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_qamuda" order="3">c_nafzawa</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ouadane</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_adrar" order="1">c_ouadane</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>perche</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_alencon" order="2">c_perche</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>quercy</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_toulouse" order="2">c_quercy</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>rethel</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_rethel" order="1">c_rethel</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>rogliano</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_corsica" order="1">c_rogliano</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sabionetta</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_mantua" order="2">c_sabionetta</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sancerre</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_berry" order="2">c_sancerre</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>semna</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_nubia" order="2">c_semna</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>soba</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_alodia" order="1">c_soba</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>tonnerre</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_nevers" order="2">c_tonnerre</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>trans-portage</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_karelia" order="3">c_trans-portage</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>tsaparang</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_ladakh" order="1">c_tsaparang</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vaiga</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_dorpat" order="2">c_vaiga</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vaud</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_zahringen" order="4">c_vaud</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vertus</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_champagne" order="3">c_vertus</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>yegorlyk</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_saray" order="4">c_yegorlyk</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zawila</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_fezzan" order="3">c_zawila</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>adrar</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_mauretania" order="2">d_adrar</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>anartta</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_gujarat" order="2">d_anartta</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>berbera</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_berbera" order="2">c_berbera</GameId>
+      <GameId game="CK2HIP" parent="k_adal" order="1">d_berbera</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>chera_nadu</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_tamilakam" order="2">d_chera_nadu</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>dadhipadra</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_malwa" order="1">d_dadhipadra</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>gandhara</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_punjab" order="2">d_gandhara</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kakheti</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_georgia" order="4">d_kakheti</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kalyani</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_karnata" order="1">d_kalyani</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>klarjeti</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_klarjeti" order="2">c_klarjeti</GameId>
+      <GameId game="CK2HIP" parent="k_georgia" order="3">d_klarjeti</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kuru</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_delhi" order="1">d_kuru</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sauvira</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_sindh" order="1">d_sauvira</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>walishtan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_sistan" order="3">d_walishtan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zhetysu</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_turkestan_east" order="1">d_zhetysu</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>fezzan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_fezzan" order="1">d_fezzan</GameId>
+      <GameId game="CK2HIP" parent="e_null" order="21">k_fezzan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ghana</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_mali" order="1">k_ghana</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>tarim</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_null" order="11">k_khotan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>khwarezmia</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_persia" order="5">k_khwarezmia</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>maghreb</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_africa" order="2">k_maghreb</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>maharastra</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_deccan" order="1">k_maharastra</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sahara</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_null" order="20">k_sahara</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
 </ArrayOfLocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -11936,6 +11936,51 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>prerov</Id>
+    <GameIds>
+      <GameId game="CK3">b_prerov</GameId>
+      <GameId game="CK3">c_prerov</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Přerov</Name>
+      <Name language="German">Prerau</Name>
+      <Name language="Polish">Przerów</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>spytihnev</Id>
+    <GameIds>
+      <GameId game="CK3">b_spytihnev</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Spytihněv</Name>
+      <Name language="German">Spitinau</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hodonin</Id>
+    <GameIds>
+      <GameId game="CK3">b_hodonin</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Hodonín</Name>
+      <Name language="German">Göding</Name>
+      <Name language="Latvian">Hodonīna</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>veseli</Id>
+    <GameIds>
+      <GameId game="CK3">b_veseli</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Veselí</Name>
+      <Name language="Czech">Veselí nad Lužnicí</Name>
+      <Name language="German_Middle_High">Wesseli</Name>
+      <Name language="German">Wesseli an der Lainsitz</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>beroun</Id>
     <GameIds>
       <GameId game="CK3">b_beroun</GameId>
@@ -13300,6 +13345,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_znojmo" order="1">b_znojmo</GameId>
       <GameId game="CK2HIP" parent="d_moravia" order="3">c_znojmo</GameId>
+      <GameId game="CK3">b_znojmo</GameId>
+      <GameId game="CK3">c_znojmo</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Znaym</Name>
@@ -13385,12 +13432,14 @@
     <Id>bitov</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_znojmo" order="4">b_bitov</GameId>
+      <GameId game="CK3">b_bitov</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Bittau</Name>
       <Name language="Bavarian">Bittau</Name>
       <Name language="Castilian">Bytów</Name>
-      <Name language="Czech_Medieval">Bietow</Name>
+      <Name language="Czech_Medieval">Bítow</Name>
+      <Name language="Czech">Bítov</Name>
       <Name language="Dutch_Middle">Bytów</Name>
       <Name language="Frankish_Low">Bittau</Name>
       <Name language="Frankish">Bittau</Name>
@@ -13400,7 +13449,8 @@
       <Name language="Latgalian">Bitova</Name>
       <Name language="Polish">Bytów</Name>
       <Name language="Romanian">Bytów</Name>
-      <Name language="Slovak_Medieval">Bietow</Name>
+      <Name language="Slovak_Medieval">Bítow</Name>
+      <Name language="Slovak">Bítov</Name>
       <Name language="Thuringian">Bittau</Name>
     </Names>
   </LocationEntity>
@@ -13430,6 +13480,7 @@
     <Id>breclav</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_znojmo" order="6">b_breclav</GameId>
+      <GameId game="CK3">b_breclav</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Lundenburg</Name>
@@ -13437,6 +13488,7 @@
       <Name language="Bosnian">Braslav</Name>
       <Name language="Bulgarian">Braslav</Name>
       <Name language="Croatian">Braslav</Name>
+      <Name language="Czech_Medieval">Břeclav</Name>
       <Name language="Frankish_Low">Lundenburg</Name>
       <Name language="Frankish">Lundenburg</Name>
       <Name language="German_Middle_High">Lundenburg</Name>
@@ -13491,27 +13543,51 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>brno</Id>
+    <Id>brno_county</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="c_brno" order="3">b_brno</GameId>
       <GameId game="CK2HIP" parent="d_moravia" order="4">c_brno</GameId>
+      <GameId game="CK3">c_brno</GameId>
     </GameIds>
+    <FallbackLocations>
+      <LocationId>brno</LocationId>
+    </FallbackLocations>
     <Names>
       <Name language="Alemannic">Brünn</Name>
       <Name language="Bavarian">Brünn</Name>
       <Name language="Frankish_Low">Brünn</Name>
       <Name language="Frankish">Brünn</Name>
+      <Name language="Czech_Medieval">Brno</Name>
+      <Name language="Czech">Brno</Name>
       <Name language="German_Middle_High">Brünn</Name>
       <Name language="German_Middle_Low">Brünn</Name>
       <Name language="German_Old_Low">Brünn</Name>
-      <Name language="Hungarian_Old">Börénvásár</Name>
       <Name language="Hungarian_Old">Börön</Name>
       <Name language="Latin">Bruna</Name>
       <Name language="Polish_Old">Berno</Name>
-      <Name language="Szekely_Old">Börénvásár</Name>
       <Name language="Szekely_Old">Börön</Name>
       <Name language="Thuringian">Brünn</Name>
       <Name language="Yiddish">Brin</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>brno</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_brno" order="3">b_brno</GameId>
+      <GameId game="CK3">b_brno</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Hungarian_Old">Börénvásár</Name>
+      <Name language="Szekely_Old">Börénvásár</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ivancice</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_brno" order="1">b_ivancice</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Czech_Medieval">Ivančice</Name>
+      <Name language="German">Eibenschütz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -13585,6 +13661,7 @@
     <Id>zdar</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_brno" order="5">b_zdar</GameId>
+      <GameId game="CK3">b_zdar</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Saar</Name>
@@ -13592,7 +13669,7 @@
       <Name language="Bosnian">Ždjar</Name>
       <Name language="Bulgarian">Ždjar</Name>
       <Name language="Croatian">Ždjar</Name>
-      <Name language="Czech_Medieval">Zdár</Name>
+      <Name language="Czech_Medieval">Žďár</Name>
       <Name language="Frankish_Low">Saar</Name>
       <Name language="Frankish">Saar</Name>
       <Name language="German_Middle_High">Saar</Name>
@@ -13612,6 +13689,7 @@
     <Id>mikulov</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_brno" order="6">b_mikulov</GameId>
+      <GameId game="CK3">b_mikulov</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Nikolsburg</Name>
@@ -13621,6 +13699,7 @@
       <Name language="Castilian">Míkulov</Name>
       <Name language="Croatian">Nikolov</Name>
       <Name language="Czech_Medieval">Mikulow</Name>
+      <Name language="Czech">Mikulov</Name>
       <Name language="Frankish_Low">Nikolsburg</Name>
       <Name language="Frankish">Nikolsburg</Name>
       <Name language="German_Middle_High">Nikolsburg</Name>
@@ -13631,6 +13710,7 @@
       <Name language="Romanian">Miclăuș</Name> <!-- Translated -->
       <Name language="Serbian">Nikolov</Name>
       <Name language="Slovak_Medieval">Mikulow</Name>
+      <Name language="Slovak">Mikulov</Name>
       <Name language="Slovene">Nikolov</Name>
       <Name language="Szekely_Old">Miklósvár</Name>
       <Name language="Thuringian">Nikolsburg</Name>

--- a/titles.xml
+++ b/titles.xml
@@ -12474,10 +12474,12 @@
     <Id>great_moravia</Id>
     <GameIds>
       <GameId game="CK2HIP" order="11815">k_moravia</GameId>
+      <GameId game="CK3">k_moravia</GameId>
     </GameIds>
     <Names>
       <Name language="Bulgarian">Velikomoravija</Name>
       <Name language="Croatian">Velika Moravska</Name>
+      <Name language="English">Great Moravia</Name>
       <Name language="French_Old">Grande Moravie</Name>
       <Name language="German">Großmähren</Name>
       <Name language="Hungarian">Morvaország</Name>
@@ -23416,6 +23418,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_poznanskie" order="1">b_poznan</GameId>
       <GameId game="CK2HIP" parent="d_greater_poland" order="1">c_poznanskie</GameId>
+      <GameId game="CK3">b_poznan</GameId>
+      <GameId game="CK3">c_poznanska</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Posen</Name>
@@ -23434,6 +23438,7 @@
       <Name language="Latin">Posnania</Name>
       <Name language="Lithuanian">Poznane</Name>
       <Name language="Lombard">Posen</Name>
+      <Name language="Polish">Poznań</Name>
       <Name language="Romanian">Posnania</Name>
       <Name language="Serbian">Poznanj</Name>
       <Name language="Slovene">Poznanj</Name>
@@ -23490,9 +23495,11 @@
     <Id>miedzyrzecz</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_poznanskie" order="5">b_miedzyrzecz</GameId>
+      <GameId game="CK3">b_miedzyrzecz</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Meseritz</Name>
+      <Name language="Bavarian_Medieval">Meseritz</Name>
       <Name language="Bavarian">Meseritz</Name>
       <Name language="Bosnian">Mjendzižec</Name>
       <Name language="Bulgarian">Mendzižec</Name>
@@ -23506,9 +23513,41 @@
       <Name language="German_Old_Low">Meseritz</Name>
       <Name language="Latgalian">Mendzižeca</Name>
       <Name language="Lithuanian">Mendzyžecas</Name>
+      <Name language="Polish_Old">Międzyrzecz</Name>
       <Name language="Serbian">Mjendzižec</Name>
       <Name language="Slovene">Mjendzižec</Name>
       <Name language="Thuringian">Meseritz</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>czarnkow</Id>
+    <GameIds>
+      <GameId game="CK3">b_czarnkow</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Czarnków</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>wronki</Id>
+    <GameIds>
+      <GameId game="CK3">b_wronki</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Alemannic">Wronke</Name>
+      <Name language="Bavarian_Medieval">Wronke</Name>
+      <Name language="Polish_Old">Wronki</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>wolsztyn</Id>
+    <GameIds>
+      <GameId game="CK3">b_wolsztyn</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Alemannic">Wollstein</Name>
+      <Name language="Bavarian_Medieval">Wollstein</Name>
+      <Name language="Polish_Old">Wolsztyn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25270,10 +25309,41 @@
     <Id>radom</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_sandomierskie" order="2">b_radom</GameId>
+      <GameId game="CK3">b_radom</GameId>
+      <GameId game="CK3">c_radomska</GameId>
     </GameIds>
     <Names>
       <Name language="Latgalian">Radoma</Name>
       <Name language="Lithuanian">Radomas</Name>
+      <Name language="Polish_Old">Radom</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>opoczno</Id>
+    <GameIds>
+      <GameId game="CK3">b_opoczno</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Lithuanian">Opočnas</Name>
+      <Name language="Polish_Old">Opoczno</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>szydlowiec</Id>
+    <GameIds>
+      <GameId game="CK3">b_szydlowiec</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Szydłowiec</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>ilza</Id>
+    <GameIds>
+      <GameId game="CK3">b_ilza</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Iłża</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25308,15 +25378,45 @@
     <Id>lublin</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_sandomierskie" order="5">b_lublin</GameId>
+      <GameId game="CK3">b_lublin</GameId>
+      <GameId game="CK3">c_lubelska</GameId>
     </GameIds>
     <Names>
-      <Name language="Castilian">Campo de concentración</Name>
       <Name language="Italian">Lublino</Name>
       <Name language="Latgalian">Lublina</Name>
+      <Name language="Latin">Lublinum</Name>
       <Name language="Lithuanian">Liublinas</Name>
       <Name language="Neapolitan">Lublino</Name>
-      <Name language="Latin">Lublinum</Name>
+      <Name language="Polish_Old">Lublin</Name>
+      <Name language="Polish">Lublin</Name>
       <Name language="Sicilian">Lubblinu</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>parczew</Id>
+    <GameIds>
+      <GameId game="CK3">b_parczew</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Parczew</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>goraj</Id>
+    <GameIds>
+      <GameId game="CK3">b_goraj</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Goraj</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>urzedow</Id>
+    <GameIds>
+      <GameId game="CK3">b_urzedow</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Urzędów</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25427,16 +25527,38 @@
     <Id>tarnow</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_wislica" order="3">b_tarnow</GameId>
+      <GameId game="CK3">b_tarnow</GameId>
+      <GameId game="CK3">c_tarnowska</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Trnov</Name>
       <Name language="Bulgarian">Tarnov</Name>
-      <Name language="Slovene">Trnov</Name>
       <Name language="Croatian">Trnov</Name>
       <Name language="Latgalian">Tarnova</Name>
       <Name language="Lithuanian">Tarnuvas</Name>
+      <Name language="Polish">Tarnów</Name>
       <Name language="Romanian">Tarnovia</Name>
       <Name language="Serbian">Trnov</Name>
+      <Name language="Slovene">Trnov</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>mielec</Id>
+    <GameIds>
+      <GameId game="CK3">b_mielec</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish">Mielec</Name>
+      <Name language="Yiddish">Melitz‎</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>baranow</Id>
+    <GameIds>
+      <GameId game="CK3">b_baranow</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish_Old">Baranów</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52302,23 +52424,23 @@
       <GameId game="CK2HIP" order="11784">d_wielkopolska</GameId>
     </GameIds>
     <Names>
-      <Name language="Bavarian">Grosspolen</Name>
+      <Name language="Alemannic">Großpolen</Name>
+      <Name language="Bavarian_Medieval">Großpolen</Name>
+      <Name language="Bavarian">Großpolen</Name>
       <Name language="Czech">Velkopolsko</Name>
-      <Name language="Dutch_Middle">Grosspolen</Name>
-      <Name language="French_Old">Grosspolen</Name>
+      <Name language="Dutch_Middle">Großpolen</Name>
+      <Name language="English_Old">Polonia Maior</Name>
+      <Name language="Frankish_Low">Großpolen</Name>
+      <Name language="German_Middle_Low">Großpolen</Name>
+      <Name language="German_Old_Low">Großpolen</Name>
       <Name language="German">Großpolen</Name>
+      <Name language="Latin">Polonia Maior</Name>
       <Name language="Lombard">Polonia Maior</Name>
-      <Name language="Frankish_Low">Grosspolen</Name>
-      <Name language="German_Middle_Low">Grosspolen</Name>
-      <Name language="German_Old_Low">Grosspolen</Name>
+      <Name language="Prussian_Old">Polanie</Name>
+      <Name language="Romanian">Polonia Mare</Name>
       <Name language="Slovak">Velkopolsko</Name>
       <Name language="Sorbian">Polanie</Name>
-      <Name language="Prussian_Old">Polanie</Name>
-      <Name language="Latin">Polonia Maior</Name>
-      <Name language="Romanian">Polonia Mare</Name>
-      <Name language="English_Old">Polonia Maior</Name>
-      <Name language="Alemannic">Grosspolen</Name>
-      <Name language="Thuringian">Grosspolen</Name>
+      <Name language="Thuringian">Großpolen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -90961,6 +90961,7 @@
   <LocationEntity>
     <Id>ifat</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="k_adal" order="2">d_ifat</GameId>
       <GameId game="CK2HIP" parent="" order="11848">k_ifat</GameId>
     </GameIds>
     <Names>
@@ -91104,22 +91105,6 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>hereti</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_hereti" order="1">c_hereti</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>jand</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_jand" order="1">c_jand</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>jeriska</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_lettigale" order="1">c_jeriska</GameId>
@@ -91251,6 +91236,7 @@
     <Id>rethel</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_rethel" order="1">c_rethel</GameId>
+      <GameId game="CK2HIP" parent="k_france" order="14">d_rethel</GameId>
     </GameIds>
     <Names>
     </Names>
@@ -91518,6 +91504,73 @@
     <Id>sahara</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="e_null" order="20">k_sahara</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>damot</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_abyssinia" order="2">d_damot</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>hereti</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_hereti" order="1">c_hereti</GameId>
+      <GameId game="CK2HIP" parent="k_georgia" order="8">d_hereti</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>jand</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_jand" order="1">b_jand</GameId>
+      <GameId game="CK2HIP" parent="d_jand" order="1">c_jand</GameId>
+      <GameId game="CK2HIP" parent="k_turkestan_west" order="4">d_jand</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>luristan</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_persia" order="6">d_luristan</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>karnata</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_deccan" order="2">k_karnata</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sindh</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_rajastan" order="1">k_sindh</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>tamilakam</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_deccan" order="3">k_tamilakam</GameId>
+    </GameIds>
+    <Names>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>turkestan_east</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="e_null" order="10">k_turkestan_east</GameId>
     </GameIds>
     <Names>
     </Names>

--- a/titles.xml
+++ b/titles.xml
@@ -10292,6 +10292,7 @@
       <Name language="Dutch_Middle">Meranien</Name>
       <Name language="Franconian_Lorraine">Meranien</Name>
       <Name language="Frankish_Low">Meranien</Name>
+      <Name language="Frankish">Meranien</Name>
       <Name language="German_Middle_High">Meranien</Name>
       <Name language="German_Middle_Low">Meranien</Name>
       <Name language="German_Old_Low">Meranien</Name>
@@ -10895,6 +10896,7 @@
       <Name language="German">Cormòns</Name>
       <Name language="Italian_Central">Cormòns</Name>
       <Name language="Italian_Medieval">Cormòns</Name>
+      <Name language="Italian_Medieval">Cormòns</Name>
       <Name language="Langobardic">Cormòns</Name>
       <Name language="Latin">Cormonum</Name>
       <Name language="Ligurian">Cormòns</Name>
@@ -10939,6 +10941,7 @@
       <Name language="Sardinian">Monfalcone</Name>
       <Name language="Serbian">Tržic</Name>
       <Name language="Sicilian">Monfalcone</Name>
+      <Name language="Slovene_Medieval">Tržic</Name>
       <Name language="Slovene_Medieval">Tržic</Name>
       <Name language="Tuscan">Monfalcone</Name>
       <Name language="Umbrian_Medieval">Monfalcone</Name>
@@ -11517,13 +11520,15 @@
     </GameIds>
     <Names>
       <Name language="Aragonese">Mülhausen</Name>
-      <Name language="Czech">Mylhúzy</Name>
       <Name language="Breton_Middle">Mülhausen</Name>
       <Name language="Catalan">Mülhausen</Name>
+      <Name language="Czech">Mylhúzy</Name>
+      <Name language="Dutch_Middle">Mulhuizen</Name>
+      <Name language="German_Middle_High">Mülhausen</Name>
+      <Name language="Latin">Mulhusia</Name>
       <Name language="Lithuanian">Miuluzas</Name>
       <Name language="Occitan">Mülhausen</Name>
       <Name language="Polish">Miluza</Name>
-      <Name language="Latin">Mulhusia</Name>
       <Name language="Vepsian">Müluz</Name>
     </Names>
   </LocationEntity>
@@ -11837,6 +11842,7 @@
       <Name language="Estonian">Cechy</Name>
       <Name language="Franconian_Lorraine">Böhmen</Name>
       <Name language="Frankish_Low">Bohemen</Name>
+      <Name language="Frankish">Böhmen</Name>
       <Name language="Frisian_Old">Bohemen</Name>
       <Name language="German_Middle_High">Böhmen</Name>
       <Name language="German_Middle_Low">Böhmen</Name>
@@ -11859,7 +11865,6 @@
       <Name language="Sorbian">Czechy</Name>
       <Name language="Thuringian">Böhmen</Name>
       <Name language="Turkish">Bohemya</Name>
-      <Name language="Yiddish">Behmen</Name>
       <Name language="Yiddish">Pihm</Name>
     </Names>
   </LocationEntity>
@@ -11931,11 +11936,23 @@
       <GameId game="CK2HIP" parent="c_praha" order="3">b_stare_mesto</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Altstadt</Name>
+      <Name language="Bavarian_Medieval">Altstadt</Name>
       <Name language="Bosnian">Staro Misto</Name>
       <Name language="Bulgarian">Staro Mesto</Name>
-      <Name language="Slovene">Staro Mesto</Name>
       <Name language="Croatian">Staro Misto</Name>
+      <Name language="Czech_Medieval">Staré Miesto</Name>
+      <Name language="Frankish_Low">Altstadt</Name>
+      <Name language="Frankish">Altstadt</Name>
+      <Name language="German_Middle_High">Altstadt</Name>
+      <Name language="German_Middle_Low">Altstadt</Name>
+      <Name language="German_Old_Low">Altstadt</Name>
+      <Name language="Polish_Old">Stare Miasto</Name>
       <Name language="Serbian">Staro Mesto</Name>
+      <Name language="Slovak_Medieval">Staré Mesto</Name>
+      <Name language="Slovene">Staro Mesto</Name>
+      <Name language="Thuringian">Altstadt</Name>
+      <Name language="Yiddish">Alt Shtot</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -11946,9 +11963,12 @@
     <Names>
       <Name language="Bosnian">Slani</Name>
       <Name language="Bulgarian">Slani</Name>
-      <Name language="Slovene">Slani</Name>
       <Name language="Croatian">Slani</Name>
+      <Name language="Czech_Medieval">Slaný</Name>
+      <Name language="German_Middle_High">Schlan</Name>
       <Name language="Serbian">Slani</Name>
+      <Name language="Slovak_Medieval">Slaný</Name>
+      <Name language="Slovene">Slani</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -11957,11 +11977,22 @@
       <GameId game="CK2HIP" parent="c_praha" order="7">b_sternbergprague</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Sternberg</Name>
+      <Name language="Bavarian_Medieval">Sternberg</Name>
       <Name language="Bosnian">Šternberk</Name>
       <Name language="Bulgarian">Šternberk</Name>
-      <Name language="Slovene">Šternberk</Name>
       <Name language="Croatian">Šternberk</Name>
+      <Name language="Czech_Medieval">Ssternberk</Name>
+      <Name language="Frankish_Low">Sternberg</Name>
+      <Name language="Frankish">Sternberg</Name>
+      <Name language="German_Middle_High">Sternberg</Name>
+      <Name language="German_Middle_Low">Sternberg</Name>
+      <Name language="German_Old_Low">Sternberg</Name>
+      <Name language="Polish_Old">Szternberk</Name>
       <Name language="Serbian">Šternberk</Name>
+      <Name language="Slovak_Medieval">Ssternberk</Name>
+      <Name language="Slovene">Šternberk</Name>
+      <Name language="Thuringian">Sternberg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -11983,11 +12014,22 @@
       <GameId game="CK2HIP" parent="c_domazlice" order="1">b_doudleby</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Teindles</Name>
+      <Name language="Bavarian_Medieval">Teindles</Name>
       <Name language="Bosnian">Duljebi</Name>
       <Name language="Bulgarian">Dulebi</Name>
-      <Name language="Slovene">Duljebi</Name>
       <Name language="Croatian">Duljebi</Name>
+      <Name language="Czech_Medieval">Dúdleby</Name>
+      <Name language="Frankish_Low">Teindles</Name>
+      <Name language="Frankish">Teindles</Name>
+      <Name language="German_Middle_High">Teindles</Name>
+      <Name language="German_Middle_Low">Teindles</Name>
+      <Name language="German_Old_Low">Teindles</Name>
+      <Name language="Polish_Old">Dudleby</Name>
       <Name language="Serbian">Duljebi</Name>
+      <Name language="Slovak_Medieval">Dúdleby</Name>
+      <Name language="Slovene">Duljebi</Name>
+      <Name language="Thuringian">Teindles</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12005,12 +12047,23 @@
       <GameId game="CK2HIP" parent="c_domazlice" order="3">b_vyssi_brod</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Hohenfurth</Name>
+      <Name language="Bavarian_Medieval">Hohenfurth</Name>
       <Name language="Bosnian">Viši Brod</Name>
       <Name language="Bulgarian">Viši Brod</Name>
-      <Name language="Slovene">Viši Brod</Name>
       <Name language="Croatian">Viši Brod</Name>
+      <Name language="Czech_Medieval">Wyssebrod</Name>
+      <Name language="Frankish_Low">Hohenfurth</Name>
+      <Name language="Frankish">Hohenfurth</Name>
+      <Name language="German_Middle_High">Hohenfurth</Name>
+      <Name language="German_Middle_Low">Hohenfurth</Name>
+      <Name language="German_Old_Low">Hohenfurth</Name>
       <Name language="Latin">Altum Vodum</Name>
+      <Name language="Polish_Old">Wyzszy Bród</Name>
       <Name language="Serbian">Viši Brod</Name>
+      <Name language="Slovak_Medieval">Wyssebrod</Name>
+      <Name language="Slovene">Viši Brod</Name>
+      <Name language="Thuringian">Hohenfurth</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12019,15 +12072,18 @@
       <GameId game="CK2HIP" parent="c_domazlice" order="5">b_rosenberg</GameId>
     </GameIds>
     <Names>
-      <Name language="Czech">Ružová Hora</Name>
       <Name language="Bosnian">Ružova Gora</Name>
       <Name language="Bulgarian">Rozova Gora</Name>
-      <Name language="Slovene">Rožova Gora</Name>
       <Name language="Croatian">Ružova Gora</Name>
+      <Name language="Czech_Medieval">Rozmberk</Name>
+      <Name language="Czech">Ružová Hora</Name>
       <Name language="Latgalian">Ružomberoka</Name>
       <Name language="Lithuanian">Ružomberokas</Name>
+      <Name language="Polish_Old">Rozemberk</Name>
       <Name language="Serbian">Ružova Gora</Name>
+      <Name language="Slovak_Medieval">Rozmberk</Name>
       <Name language="Slovak">Ružová Hora</Name>
+      <Name language="Slovene">Rožova Gora</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12038,9 +12094,13 @@
     <Names>
       <Name language="Bosnian">Budjejovice</Name>
       <Name language="Bulgarian">Budejovice</Name>
-      <Name language="Slovene">Budjejovice</Name>
       <Name language="Croatian">Budjejovice</Name>
+      <Name language="Czech_Medieval">Budiegowicze</Name>
+      <Name language="Polish_Old">Budziejowice</Name>
       <Name language="Serbian">Budjejovice</Name>
+      <Name language="Slovak_Medieval">Budiegowicze</Name>
+      <Name language="Slovene">Budjejovice</Name>
+      <Name language="Sorbian">Budzejowicy</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12075,11 +12135,21 @@
       <GameId game="CK2HIP" parent="c_hradec" order="1">b_hradeckralove</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Grätz</Name>
+      <Name language="Bavarian_Medieval">Grätz</Name>
       <Name language="Bosnian">Gradac</Name>
       <Name language="Bulgarian">Gradec</Name>
-      <Name language="Slovene">Gradec</Name>
       <Name language="Croatian">Gradac</Name>
+      <Name language="Czech_Medieval">Hradecz</Name>
+      <Name language="Frankish_Low">Grätz</Name>
+      <Name language="Frankish">Grätz</Name>
+      <Name language="German_Middle_High">Grätz</Name>
+      <Name language="German_Middle_Low">Grätz</Name>
+      <Name language="German_Old_Low">Grätz</Name>
       <Name language="Serbian">Gradac</Name>
+      <Name language="Slovak_Medieval">Hradecz</Name>
+      <Name language="Slovene">Gradec</Name>
+      <Name language="Thuringian">Grätz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12088,12 +12158,20 @@
       <GameId game="CK2HIP" parent="c_hradec" order="2">b_chrudim</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Crudim</Name>
+      <Name language="Bavarian_Medieval">Crudim</Name>
       <Name language="Bosnian">Hrudim</Name>
       <Name language="Bulgarian">Hrudim</Name>
-      <Name language="Slovene">Hrudim</Name>
       <Name language="Croatian">Hrudim</Name>
+      <Name language="Frankish_Low">Crudim</Name>
+      <Name language="Frankish">Crudim</Name>
+      <Name language="German_Middle_High">Crudim</Name>
+      <Name language="German_Middle_Low">Crudim</Name>
+      <Name language="German_Old_Low">Crudim</Name>
       <Name language="Lithuanian">Chrudimas</Name>
       <Name language="Serbian">Hrudim</Name>
+      <Name language="Slovene">Hrudim</Name>
+      <Name language="Thuringian">Crudim</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12102,12 +12180,23 @@
       <GameId game="CK2HIP" parent="c_hradec" order="4">b_jaromer</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Jermer</Name>
+      <Name language="Bavarian_Medieval">Jermer</Name>
       <Name language="Bosnian">Jaromjerž</Name>
       <Name language="Bulgarian">Jaromjerž</Name>
-      <Name language="Slovene">Jaromjerž</Name>
       <Name language="Croatian">Jaromjerž</Name>
+      <Name language="Czech_Medieval">Jaromierz</Name>
+      <Name language="Frankish_Low">Jermer</Name>
+      <Name language="Frankish">Jermer</Name>
+      <Name language="German_Middle_High">Jermer</Name>
+      <Name language="German_Middle_Low">Jermer</Name>
+      <Name language="German_Old_Low">Jermer</Name>
       <Name language="Lithuanian">Jaromeržas</Name>
+      <Name language="Polish_Old">Jaromierz</Name>
       <Name language="Serbian">Jaromjerž</Name>
+      <Name language="Slovak_Medieval">Jaromierz</Name>
+      <Name language="Slovene">Jaromjerž</Name>
+      <Name language="Thuringian">Jermer</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12129,11 +12218,19 @@
       <GameId game="CK2HIP" parent="c_hradec" order="7">b_vartemberka</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Wartenberg</Name>
+      <Name language="Bavarian_Medieval">Wartenberg</Name>
       <Name language="Bosnian">Vartemberk</Name>
       <Name language="Bulgarian">Vartemberk</Name>
-      <Name language="Slovene">Vartemberk</Name>
       <Name language="Croatian">Vartemberk</Name>
+      <Name language="Frankish_Low">Wartenberg</Name>
+      <Name language="Frankish">Wartenberg</Name>
+      <Name language="German_Middle_High">Wartenberg</Name>
+      <Name language="German_Middle_Low">Wartenberg</Name>
+      <Name language="German_Old_Low">Wartenberg</Name>
       <Name language="Serbian">Vartemberk</Name>
+      <Name language="Slovene">Vartemberk</Name>
+      <Name language="Thuringian">Wartenberg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12143,8 +12240,20 @@
       <GameId game="CK2HIP" parent="d_bohemia" order="4">c_boleslav</GameId>
     </GameIds>
     <Names>
-      <Name language="Lithuanian">Klodzkas</Name>
+      <Name language="Alemannic">Bunzlau</Name>
+      <Name language="Bavarian_Medieval">Bunzlau</Name>
+      <Name language="Czech_Medieval">Boleslaw</Name>
+      <Name language="Frankish_Low">Bunzlau</Name>
+      <Name language="Frankish">Bunzlau</Name>
+      <Name language="German_Middle_High">Bunzlau</Name>
+      <Name language="German_Middle_Low">Bunzlau</Name>
+      <Name language="German_Old_Low">Bunzlau</Name>
       <Name language="Latin">Glacio</Name>
+      <Name language="Lithuanian">Klodzkas</Name>
+      <Name language="Polish_Old">Boleslaw</Name>
+      <Name language="Slovak_Medieval">Boleslaw</Name>
+      <Name language="Thuringian">Bunzlau</Name>
+      <Name language="Yiddish">Bumsla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12155,10 +12264,13 @@
     <Names>
       <Name language="Bosnian">Kladsko</Name>
       <Name language="Bulgarian">Kladsko</Name>
-      <Name language="Slovene">Kladsko</Name>
       <Name language="Croatian">Kladsko</Name>
+      <Name language="Czech_Medieval">Kladsko</Name>
       <Name language="Latin">Glacio</Name>
+      <Name language="Polish_Old">Klodsko</Name>
       <Name language="Serbian">Kladsko</Name>
+      <Name language="Slovak_Medieval">Kladsko</Name>
+      <Name language="Slovene">Kladsko</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12167,8 +12279,19 @@
       <GameId game="CK2HIP" parent="c_boleslav" order="2">b_jicin</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Jitschin</Name>
+      <Name language="Bavarian_Medieval">Jitschin</Name>
+      <Name language="Czech_Medieval">Jiczín</Name>
+      <Name language="Frankish_Low">Jitschin</Name>
+      <Name language="Frankish">Jitschin</Name>
       <Name language="Galician">Jicín</Name>
+      <Name language="German_Middle_High">Jitschin</Name>
+      <Name language="German_Middle_Low">Jitschin</Name>
+      <Name language="German_Old_Low">Jitschin</Name>
       <Name language="Latin">Gitzinum</Name>
+      <Name language="Polish_Old">Jiczyn</Name>
+      <Name language="Slovak_Medieval">Jiczín</Name>
+      <Name language="Thuringian">Jitschin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12177,8 +12300,19 @@
       <GameId game="CK2HIP" parent="c_boleslav" order="3">b_broumovkladsko</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Braunau</Name>
+      <Name language="Bavarian_Medieval">Braunau</Name>
+      <Name language="Czech_Medieval">Brumow</Name>
+      <Name language="Frankish_Low">Braunau</Name>
+      <Name language="Frankish">Braunau</Name>
+      <Name language="German_Middle_High">Braunau</Name>
+      <Name language="German_Middle_Low">Braunau</Name>
+      <Name language="German_Old_Low">Braunau</Name>
       <Name language="Latin">Brunoviensis</Name>
+      <Name language="Polish_Old">Brumow</Name>
       <Name language="Romanian">Brumă</Name>
+      <Name language="Slovak_Medieval">Brumow</Name>
+      <Name language="Thuringian">Braunau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12213,11 +12347,19 @@
       <GameId game="CK2HIP" parent="c_boleslav" order="6">b_karpien</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Karpenstein</Name>
+      <Name language="Bavarian_Medieval">Karpenstein</Name>
       <Name language="Bosnian">Karpno</Name>
       <Name language="Bulgarian">Karpno</Name>
-      <Name language="Slovene">Karpno</Name>
       <Name language="Croatian">Karpno</Name>
+      <Name language="Frankish_Low">Karpenstein</Name>
+      <Name language="Frankish">Karpenstein</Name>
+      <Name language="German_Middle_High">Karpenstein</Name>
+      <Name language="German_Middle_Low">Karpenstein</Name>
+      <Name language="German_Old_Low">Karpenstein</Name>
       <Name language="Serbian">Karpno</Name>
+      <Name language="Slovene">Karpno</Name>
+      <Name language="Thuringian">Karpenstein</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12226,11 +12368,19 @@
       <GameId game="CK2HIP" parent="c_boleslav" order="7">b_habelschwerdt</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Habelschwerdt</Name>
+      <Name language="Bavarian_Medieval">Habelschwerdt</Name>
       <Name language="Bosnian">Kladska Bistrica</Name>
       <Name language="Bulgarian">Kladska Bistrica</Name>
-      <Name language="Slovene">Kladska Bistrica</Name>
       <Name language="Croatian">Kladska Bistrica</Name>
+      <Name language="Frankish_Low">Habelschwerdt</Name>
+      <Name language="Frankish">Habelschwerdt</Name>
+      <Name language="German_Middle_High">Habelschwerdt</Name>
+      <Name language="German_Middle_Low">Habelschwerdt</Name>
+      <Name language="German_Old_Low">Habelschwerdt</Name>
       <Name language="Serbian">Kladska Bistrica</Name>
+      <Name language="Slovene">Kladska Bistrica</Name>
+      <Name language="Thuringian">Habelschwerdt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12240,13 +12390,24 @@
       <GameId game="CK2HIP" parent="d_bohemia" order="5">c_litomerice</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Leitmeritz</Name>
+      <Name language="Bavarian_Medieval">Leitmeritz</Name>
       <Name language="Bosnian">Litomjeržice</Name>
       <Name language="Bulgarian">Litomeržice</Name>
-      <Name language="Slovene">Litomjeržice</Name>
       <Name language="Croatian">Litomjeržice</Name>
-      <Name language="Lithuanian">Litomeržices</Name>
+      <Name language="Czech_Medieval">Litomierzicze</Name>
+      <Name language="Frankish_Low">Leitmeritz</Name>
+      <Name language="Frankish">Leitmeritz</Name>
+      <Name language="German_Middle_High">Leitmeritz</Name>
+      <Name language="German_Middle_Low">Leitmeritz</Name>
+      <Name language="German_Old_Low">Leitmeritz</Name>
       <Name language="Latin">Litomericium</Name>
+      <Name language="Lithuanian">Litomeržices</Name>
+      <Name language="Polish_Old">Litomierzyce</Name>
       <Name language="Serbian">Litomjeržice</Name>
+      <Name language="Slovak_Medieval">Litomierzicze</Name>
+      <Name language="Slovene">Litomjeržice</Name>
+      <Name language="Thuringian">Leitmeritz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -12255,7 +12416,17 @@
       <GameId game="CK2HIP" parent="c_litomerice" order="2">b_bilina</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Pilsen</Name>
+      <Name language="Bavarian_Medieval">Pilsen</Name>
+      <Name language="Czech_Medieval">Bielina</Name>
+      <Name language="Frankish_Low">Pilsen</Name>
+      <Name language="Frankish">Pilsen</Name>
+      <Name language="German_Middle_High">Pilsen</Name>
+      <Name language="German_Middle_Low">Pilsen</Name>
+      <Name language="German_Old_Low">Pilsen</Name>
       <Name language="Romanian">Bilnița</Name>
+      <Name language="Slovak_Medieval">Bielina</Name>
+      <Name language="Thuringian">Pilsen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -23525,6 +23696,8 @@
       <GameId game="CK3">b_czarnkow</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Scharnikau</Name>
+      <Name language="Bavarian_Medieval">Scharnikau</Name>
       <Name language="Polish_Old">Czarnków</Name>
     </Names>
   </LocationEntity>
@@ -52495,6 +52668,7 @@
       <GameId game="CK2HIP" parent="c_salm" order="3">b_malmedy</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Malmünde</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52503,6 +52677,7 @@
       <GameId game="CK2HIP" parent="c_luxembourg" order="6">b_bourscheid</GameId>
     </GameIds>
     <Names>
+      <Name language="German_Middle_High">Burscheid</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52511,6 +52686,7 @@
       <GameId game="CK2HIP" parent="c_vianden" order="6">b_clerf</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Clervaux</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52519,6 +52695,14 @@
       <GameId game="CK2HIP" parent="c_holstein" order="5">b_bornhoved</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Bornhøved</Name>
+      <Name language="English_Old_Norse">Bornhøved</Name>
+      <Name language="Gothic">Bornhøved</Name>
+      <Name language="Icelandic_Old">Bornhofuð</Name>
+      <Name language="Irish_Middle_Norse">Bornhøved</Name>
+      <Name language="Norse">Bornhofuð</Name>
+      <Name language="Norwegian_Old">Bornhofuð</Name>
+      <Name language="Swedish_Old">Bornhøved</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52527,6 +52711,12 @@
       <GameId game="CK2HIP" parent="c_ratzeburg" order="2">b_molln</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Mølln</Name>
+      <Name language="English_Old_Norse">Mølln</Name>
+      <Name language="Gothic">Mølln</Name>
+      <Name language="Irish_Middle_Norse">Mølln</Name>
+      <Name language="Norwegian_Old">Mølln</Name>
+      <Name language="Swedish_Old">Mølln</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52576,6 +52766,16 @@
       <GameId game="CK2HIP" parent="c_karnten" order="1">b_karnburg</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Krnskigrad</Name>
+      <Name language="Bulgarian_Old">Krnskigrad</Name>
+      <Name language="Croatian_Medieval">Krnskigrad</Name>
+      <Name language="Czech_Medieval">Kranj</Name>
+      <Name language="Polish_Old">Krnskigrad</Name>
+      <Name language="Russian_Medieval">Krnskigrad</Name>
+      <Name language="Serbian_Medieval">Krnskigrad</Name>
+      <Name language="Slovak_Medieval">Kranj</Name>
+      <Name language="Slovene_Medieval">Krnskigrad</Name>
+      <Name language="Sorbian">Krnskigrad</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52584,6 +52784,16 @@
       <GameId game="CK2HIP" parent="c_windische_mark" order="4">b_weichselberg</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Višnja Gora</Name>
+      <Name language="Bulgarian_Old">Višnja Gora</Name>
+      <Name language="Croatian_Medieval">Višnja Gora</Name>
+      <Name language="Czech_Medieval">Višnja Gora</Name>
+      <Name language="Polish_Old">Višnja Gora</Name>
+      <Name language="Russian_Medieval">Višnja Gora</Name>
+      <Name language="Serbian_Medieval">Višnja Gora</Name>
+      <Name language="Slovak_Medieval">Višnja Gora</Name>
+      <Name language="Slovene_Medieval">Višnja Gora</Name>
+      <Name language="Sorbian">Višnja Gora</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52690,14 +52900,29 @@
       <GameId game="CK2HIP" parent="c_gorz" order="2">b_kanal</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Canale</Name>
+      <Name language="Italian_Central">Canale</Name>
+      <Name language="Italian_Medieval">Canale</Name>
+      <Name language="Langobardic">Canale</Name>
+      <Name language="Ligurian">Canale</Name>
+      <Name language="Neapolitan">Canale</Name>
+      <Name language="Sardinian">Canale</Name>
+      <Name language="Sicilian">Canale</Name>
+      <Name language="Slovene_Medieval">Kanale</Name>
+      <Name language="Tuscan_Medieval">Canale</Name>
+      <Name language="Umbrian_Medieval">Canale</Name>
+      <Name language="Venetian_Medieval">Canale</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>kempten</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_waldburg" order="2">b_kempten</GameId>
+      <GameId game="ImperatorRome">3638</GameId> <!-- Cambodunum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Kambodunum</Name>
+      <Name language="Latin_Medieval">Cambodunum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52706,6 +52931,8 @@
       <GameId game="CK2HIP" parent="c_sundgau" order="1">b_ferette</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Ferrette</Name>
+      <Name language="German_Middle_High">Pfirt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52714,6 +52941,17 @@
       <GameId game="CK2HIP" parent="c_praha" order="4">b_brevnov</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Breunau</Name>
+      <Name language="Bavarian_Medieval">Breunau</Name>
+      <Name language="Czech_Medieval">Brzewnow</Name>
+      <Name language="Frankish_Low">Breunau</Name>
+      <Name language="Frankish">Breunau</Name>
+      <Name language="German_Middle_High">Breunau</Name>
+      <Name language="German_Middle_Low">Breunau</Name>
+      <Name language="German_Old_Low">Breunau</Name>
+      <Name language="Polish_Old">Brzewnow</Name>
+      <Name language="Slovak_Medieval">Brzewnow</Name>
+      <Name language="Thuringian">Breunau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52722,6 +52960,9 @@
       <GameId game="CK2HIP" parent="c_praha" order="8">b_sazava</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Sázava</Name>
+      <Name language="German_Middle_High">Sazawa</Name>
+      <Name language="Slovak_Medieval">Sázava</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52730,6 +52971,17 @@
       <GameId game="CK2HIP" parent="c_hradec" order="3">b_opatovice</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Opatowitz</Name>
+      <Name language="Bavarian_Medieval">Opatowitz</Name>
+      <Name language="Czech_Medieval">Opatowicze</Name>
+      <Name language="Frankish_Low">Opatowitz</Name>
+      <Name language="Frankish">Opatowitz</Name>
+      <Name language="German_Middle_High">Opatowitz</Name>
+      <Name language="German_Middle_Low">Opatowitz</Name>
+      <Name language="German_Old_Low">Opatowitz</Name>
+      <Name language="Polish_Old">Opatowice</Name>
+      <Name language="Slovak_Medieval">Opatowicze</Name>
+      <Name language="Thuringian">Opatowitz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -52738,6 +52990,17 @@
       <GameId game="CK2HIP" parent="c_hradec" order="5">b_caslav</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Tschaslau</Name>
+      <Name language="Bavarian_Medieval">Tschaslau</Name>
+      <Name language="Czech_Medieval">Czáslaw</Name>
+      <Name language="Frankish_Low">Tschaslau</Name>
+      <Name language="Frankish">Tschaslau</Name>
+      <Name language="German_Middle_High">Tschaslau</Name>
+      <Name language="German_Middle_Low">Tschaslau</Name>
+      <Name language="German_Old_Low">Tschaslau</Name>
+      <Name language="Polish_Old">Czaslaw</Name>
+      <Name language="Slovak_Medieval">Czáslaw</Name>
+      <Name language="Thuringian">Tschaslau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -37155,14 +37155,21 @@
       <GameId game="CK2HIP" parent="c_acre" order="3">b_tyrus</GameId>
     </GameIds>
     <Names>
-      <Name language="Czech">Týros</Name>
+      <Name language="Arabic_Andalusia">Sur</Name>
+      <Name language="Arabic_Bedouin">Sur</Name>
+      <Name language="Arabic_Egypt">Sur</Name>
+      <Name language="Arabic_Levant">Sur</Name>
+      <Name language="Arabic_Maghreb">Sur</Name>
+      <Name language="Arabic_Yemen">Sur</Name>
       <Name language="Breton_Middle">Tir</Name>
-      <Name language="Slovene">Tir</Name>
       <Name language="Castilian">Tiro</Name>
       <Name language="Catalan">Tir</Name>
+      <Name language="Czech">Týros</Name>
       <Name language="Finnish">Tyros</Name>
       <Name language="French_Old">Tyr</Name>
       <Name language="German">Tyros</Name>
+      <Name language="Greek_Medieval">Tyros</Name>
+      <Name language="Hejazi_Arabic">Sur</Name>
       <Name language="Icelandic">Týros</Name>
       <Name language="Italian">Tiro</Name>
       <Name language="Lithuanian">Tyras</Name>
@@ -37170,8 +37177,12 @@
       <Name language="Polish">Tyr</Name>
       <Name language="Portuguese">Tiro</Name>
       <Name language="Romanian">Tir</Name>
+      <Name language="Sanhaja">Sur</Name>
+      <Name language="Sicilian_Arabic">Sur</Name>
       <Name language="Slovak">Tyros</Name>
+      <Name language="Slovene">Tir</Name>
       <Name language="Swedish">Tyros</Name>
+      <Name language="Tuareg">Sur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37180,6 +37191,8 @@
       <GameId game="CK2HIP" parent="c_acre" order="4">b_haifa</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Hepha</Name>
+      <Name language="Latin_Medieval">Hepha</Name>
       <Name language="Occitan">Aifa</Name>
       <Name language="Polish">Hajfa</Name>
       <Name language="Slovak">Hajfa</Name>
@@ -37194,14 +37207,27 @@
       <GameId game="ImperatorRome">747</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Saydá</Name>
+      <Name language="Arabic_Bedouin">Saydá</Name>
+      <Name language="Arabic_Egypt">Saydá</Name>
+      <Name language="Arabic_Levant">Saydá</Name>
+      <Name language="Arabic_Maghreb">Saydá</Name>
+      <Name language="Arabic_Yemen">Saydá</Name>
       <Name language="Catalan">Sidó</Name>
+      <Name language="Estonian">Saydã</Name>
+      <Name language="Hejazi_Arabic">Saydá</Name>
       <Name language="Hungarian">Szidón</Name>
       <Name language="Italian">Sidone</Name>
       <Name language="Lithuanian">Sidonas</Name>
       <Name language="Lombard">Sidun</Name>
+      <Name language="Oghuz">Saydá</Name>
       <Name language="Polish">Sydon</Name>
+      <Name language="Sanhaja">Saydá</Name>
+      <Name language="Sicilian_Arabic">Saydá</Name>
       <Name language="Swedish">Sayda</Name>
-      <Name language="Estonian">Saydã</Name>
+      <Name language="Tuareg">Saydá</Name>
+      <Name language="Turkish_Old">Saydá</Name>
+      <Name language="Turkmen_Medieval">Saydá</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37237,8 +37263,18 @@
       <GameId game="CK2HIP" parent="d_oultrejourdain" order="1">c_monreal</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shawbak</Name>
+      <Name language="Arabic_Bedouin">Shawbak</Name>
+      <Name language="Arabic_Egypt">Shawbak</Name>
+      <Name language="Arabic_Levant">Shawbak</Name>
+      <Name language="Arabic_Maghreb">Shawbak</Name>
+      <Name language="Arabic_Yemen">Shawbak</Name>
       <Name language="Aragonese">Mont-reyal</Name>
+      <Name language="Hejazi_Arabic">Shawbak</Name>
+      <Name language="Sanhaja">Shawbak</Name>
+      <Name language="Sicilian_Arabic">Shawbak</Name>
       <Name language="Sicilian">Murriali</Name>
+      <Name language="Tuareg">Shawbak</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -49799,15 +49835,27 @@
       <GameId game="CK2HIP" parent="e_spain" order="3">k_leon</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Liyún</Name>
+      <Name language="Arabic_Bedouin">Liyún</Name>
+      <Name language="Arabic_Egypt">Liyún</Name>
+      <Name language="Arabic_Levant">Liyún</Name>
+      <Name language="Arabic_Maghreb">Liyún</Name>
+      <Name language="Arabic_Yemen">Liyún</Name>
+      <Name language="Aragonese">Leyón</Name>
       <Name language="Basque">Leongo</Name>
+      <Name language="Catalan_Medieval">Lleó</Name>
       <Name language="Georgian">Leoni</Name>
       <Name language="Gothic">Legionis</Name>
+      <Name language="Hejazi_Arabic">Liyún</Name>
       <Name language="Latin">Legionis</Name>
+      <Name language="Leonese">Llión</Name>
       <Name language="Lombard">Legionis</Name>
       <Name language="Polish">Leon</Name>
+      <Name language="Portuguese">Leão</Name>
       <Name language="Romanian">Leon</Name>
       <Name language="Russian">Leon</Name>
       <Name language="Serbian">Leon</Name>
+      <Name language="Sicilian_Arabic">Liyún</Name>
       <Name language="Swedish">Leon</Name>
       <Name language="Yiddish">Lean</Name>
     </Names>
@@ -49819,13 +49867,27 @@
       <GameId game="CK2HIP" parent="e_spain" order="4">k_aragon</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Araghún</Name>
+      <Name language="Arabic_Bedouin">Araghún</Name>
+      <Name language="Arabic_Egypt">Araghún</Name>
+      <Name language="Arabic_Levant">Araghún</Name>
+      <Name language="Arabic_Maghreb">Araghún</Name>
+      <Name language="Arabic_Yemen">Araghún</Name>
+      <Name language="Basque">Aragoi</Name>
+      <Name language="Catalan_Medieval">Aragó</Name>
+      <Name language="English_Old">Aragonia</Name>
+      <Name language="French_Old">Aragon</Name>
       <Name language="German">Aragonien</Name>
       <Name language="Gothic">Aragonia</Name>
+      <Name language="Greek_Medieval">Tarrakonesia</Name>
+      <Name language="Hejazi_Arabic">Araghún</Name>
+      <Name language="Latin_Medieval">Tarraconensis</Name>
+      <Name language="Latin">Aragonia</Name>
       <Name language="Lombard">Aragonia</Name>
       <Name language="Occitan">Argon</Name>
-      <Name language="Latin">Aragonia</Name>
+      <Name language="Portuguese">Aragão</Name>
       <Name language="Romanian">Aragon</Name>
-      <Name language="English_Old">Aragonia</Name>
+      <Name language="Sicilian_Arabic">Araghún</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -50017,8 +50079,17 @@
       <GameId game="CK2HIP" parent="d_teruel" order="3">c_caspe</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qashb</Name>
+      <Name language="Arabic_Bedouin">Qashb</Name>
+      <Name language="Arabic_Egypt">Qashb</Name>
+      <Name language="Arabic_Levant">Qashb</Name>
+      <Name language="Arabic_Maghreb">Qashb</Name>
+      <Name language="Arabic_Yemen">Qashb</Name>
       <Name language="Aragonese">Casp</Name>
+      <Name language="Catalan_Medieval">Casp</Name>
+      <Name language="Hejazi_Arabic">Qashb</Name>
       <Name language="Occitan">Casp</Name>
+      <Name language="Sicilian_Arabic">Qashb</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -50027,7 +50098,19 @@
       <GameId game="CK2HIP" parent="c_caspe" order="4">b_alcanyiz</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qannísh</Name>
+      <Name language="Arabic_Bedouin">al-Qannísh</Name>
+      <Name language="Arabic_Egypt">al-Qannísh</Name>
+      <Name language="Arabic_Levant">al-Qannísh</Name>
+      <Name language="Arabic_Maghreb">al-Qannísh</Name>
+      <Name language="Arabic_Yemen">al-Qannísh</Name>
+      <Name language="Aragonese">Alcanyiz</Name>
+      <Name language="Catalan_Medieval">Alcanyís</Name>
+      <Name language="French_Old">Alcagniz</Name>
+      <Name language="Hejazi_Arabic">al-Qannísh</Name>
       <Name language="Occitan">Alcanyiz</Name>
+      <Name language="Portuguese">Alcanhiz</Name>
+      <Name language="Sicilian_Arabic">al-Qannísh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -50037,7 +50120,17 @@
       <GameId game="CK2HIP" parent="k_aragon" order="5">d_gandia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qandiyya</Name>
+      <Name language="Arabic_Bedouin">Qandiyya</Name>
+      <Name language="Arabic_Egypt">Qandiyya</Name>
+      <Name language="Arabic_Levant">Qandiyya</Name>
+      <Name language="Arabic_Maghreb">Qandiyya</Name>
+      <Name language="Arabic_Yemen">Qandiyya</Name>
+      <Name language="Basque">Gandia</Name>
+      <Name language="Catalan_Medieval">Gandia</Name>
       <Name language="French_Old">Gandie</Name>
+      <Name language="Hejazi_Arabic">Qandiyya</Name>
+      <Name language="Sicilian_Arabic">Qandiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -50046,11 +50139,21 @@
       <GameId game="CK2HIP" parent="e_spain" order="5">k_portugal</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Burtuqál</Name>
+      <Name language="Arabic_Bedouin">Burtuqál</Name>
+      <Name language="Arabic_Egypt">Burtuqál</Name>
+      <Name language="Arabic_Levant">Burtuqál</Name>
+      <Name language="Arabic_Maghreb">Burtuqál</Name>
+      <Name language="Arabic_Yemen">Burtuqál</Name>
+      <Name language="English_Old">Portucale</Name>
       <Name language="Gothic">Portucale</Name>
+      <Name language="Greek_Medieval">Lysitania</Name>
+      <Name language="Hejazi_Arabic">Burtuqál</Name>
+      <Name language="Latin_Medieval">Lusitania</Name>
       <Name language="Lombard">Portucale</Name>
       <Name language="Prussian_Old">Portugalin</Name>
       <Name language="Romanian">Portugalia</Name>
-      <Name language="English_Old">Portucale</Name>
+      <Name language="Sicilian_Arabic">Burtuqál</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -51126,24 +51229,38 @@
       <GameId game="CK2HIP" parent="d_valencia" order="3">c_valencia</GameId>
       <GameId game="CK2HIP" parent="k_valencia" order="1">d_valencia</GameId>
       <GameId game="CK2HIP" parent="e_spain" order="9">k_valencia</GameId>
+      <GameId game="ImperatorRome">1030</GameId> <!-- Valentia -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Balansiya</Name>
+      <Name language="Arabic_Bedouin">Balansiya</Name>
+      <Name language="Arabic_Egypt">Balansiya</Name>
+      <Name language="Arabic_Levant">Balansiya</Name>
+      <Name language="Arabic_Maghreb">Balansiya</Name>
+      <Name language="Arabic_Yemen">Balansiya</Name>
       <Name language="Aragonese">Balenzia</Name>
+      <Name language="Basque">Balentzia</Name>
       <Name language="Bulgarian">Valensija</Name>
+      <Name language="Catalan_Medieval">València</Name>
       <Name language="Croatian">Valensija</Name>
       <Name language="Czech">Valencie</Name>
       <Name language="English_Old">Valentia</Name>
+      <Name language="French_Old">Valence</Name>
       <Name language="German">Valentz</Name>
       <Name language="Gothic">Valentia</Name>
-      <Name language="Greek_Medieval">Valentia</Name>
+      <Name language="Greek_Medieval">Oualentia</Name>
+      <Name language="Hejazi_Arabic">Balansiya</Name>
       <Name language="Italian">Valenza</Name>
+      <Name language="Ladino">Valensia</Name>
       <Name language="Latgalian">Valensija</Name>
+      <Name language="Latin_Medieval">Valentia</Name>
       <Name language="Lithuanian">Valensija</Name>
       <Name language="Lombard">Valentia</Name>
       <Name language="Polish">Walencja</Name>
+      <Name language="Portuguese">Valência</Name>
       <Name language="Russian">Valensiya</Name>
-      <Name language="Ladino">Valensia</Name>
       <Name language="Serbian">Valensija</Name>
+      <Name language="Sicilian_Arabic">Balansiya</Name>
       <Name language="Slovene">Valencija</Name>
       <Name language="Turkish">Valensiya</Name>
       <Name language="Venetian">Valénsia</Name>
@@ -51156,12 +51273,25 @@
       <GameId game="CK2HIP" parent="c_valencia" order="7">b_chiva</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shiba</Name>
+      <Name language="Arabic_Bedouin">Shiba</Name>
+      <Name language="Arabic_Egypt">Shiba</Name>
+      <Name language="Arabic_Levant">Shiba</Name>
+      <Name language="Arabic_Maghreb">Shiba</Name>
+      <Name language="Arabic_Yemen">Shiba</Name>
+      <Name language="Aragonese">Chiba</Name>
+      <Name language="Basque">Xiba</Name>
       <Name language="Castilian">Jiva</Name>
+      <Name language="Catalan_Medieval">Xiva</Name>
       <Name language="Dutch_Middle">Xiva</Name>
-      <Name language="Finnish">Hiva</Name>
-      <Name language="German">Xiva</Name>
-      <Name language="Polish">Xiva</Name>
       <Name language="Estonian">Hiiva</Name>
+      <Name language="Finnish">Hiva</Name>
+      <Name language="French_Old">Xive</Name>
+      <Name language="Galician">Xiva</Name>
+      <Name language="German">Xiva</Name>
+      <Name language="Hejazi_Arabic">Shiba</Name>
+      <Name language="Polish">Xiva</Name>
+      <Name language="Sicilian_Arabic">Shiba</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61777,6 +61907,16 @@
       <GameId game="CK2HIP" parent="c_acre" order="4">b_castellumregis</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at Qurein</Name>
+      <Name language="Arabic_Bedouin">Qal'at Qurein</Name>
+      <Name language="Arabic_Egypt">Qal'at Qurein</Name>
+      <Name language="Arabic_Levant">Qal'at Qurein</Name>
+      <Name language="Arabic_Maghreb">Qal'at Qurein</Name>
+      <Name language="Arabic_Yemen">Qal'at Qurein</Name>
+      <Name language="German_Middle_High">Starkenberg</Name>
+      <Name language="Greek_Medieval">Kastro Basileios</Name>
+      <Name language="Hejazi_Arabic">Qal'at Qurein</Name>
+      <Name language="Sicilian_Arabic">Qal'at Qurein</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61785,6 +61925,14 @@
       <GameId game="CK2HIP" parent="c_acre" order="6">b_adelon</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ad'loun</Name>
+      <Name language="Arabic_Bedouin">Ad'loun</Name>
+      <Name language="Arabic_Egypt">Ad'loun</Name>
+      <Name language="Arabic_Levant">Ad'loun</Name>
+      <Name language="Arabic_Maghreb">Ad'loun</Name>
+      <Name language="Arabic_Yemen">Ad'loun</Name>
+      <Name language="Hejazi_Arabic">Ad'loun</Name>
+      <Name language="Sicilian_Arabic">Ad'loun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61793,6 +61941,14 @@
       <GameId game="CK2HIP" parent="c_tyrus" order="4">b_schuf</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shúf</Name>
+      <Name language="Arabic_Bedouin">Shúf</Name>
+      <Name language="Arabic_Egypt">Shúf</Name>
+      <Name language="Arabic_Levant">Shúf</Name>
+      <Name language="Arabic_Maghreb">Shúf</Name>
+      <Name language="Arabic_Yemen">Shúf</Name>
+      <Name language="Hejazi_Arabic">Shúf</Name>
+      <Name language="Sicilian_Arabic">Shúf</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61801,6 +61957,8 @@
       <GameId game="CK2HIP" parent="c_caesarea" order="1">b_caymont</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Cammona</Name>
+      <Name language="Latin_Medieval">Cammona</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61809,6 +61967,8 @@
       <GameId game="CK2HIP" parent="c_caesarea" order="2">b_arsuf</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Apollonia</Name>
+      <Name language="Latin_Medieval">Apollonia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61841,6 +62001,16 @@
       <GameId game="CK2HIP" parent="c_petra" order="2">b_jordanaqba</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Aqabah</Name>
+      <Name language="Arabic_Bedouin">Aqabah</Name>
+      <Name language="Arabic_Egypt">Aqabah</Name>
+      <Name language="Arabic_Levant">Aqabah</Name>
+      <Name language="Arabic_Maghreb">Aqabah</Name>
+      <Name language="Arabic_Yemen">Aqabah</Name>
+      <Name language="Greek_Medieval">Aila</Name>
+      <Name language="Hejazi_Arabic">Aqabah</Name>
+      <Name language="Latin_Medieval">Aila</Name>
+      <Name language="Sicilian_Arabic">Aqabah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69204,6 +69374,18 @@
       <GameId game="CK2HIP" parent="c_caspe" order="2">b_chiprana</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shibran</Name>
+      <Name language="Arabic_Bedouin">Shibran</Name>
+      <Name language="Arabic_Egypt">Shibran</Name>
+      <Name language="Arabic_Levant">Shibran</Name>
+      <Name language="Arabic_Maghreb">Shibran</Name>
+      <Name language="Arabic_Yemen">Shibran</Name>
+      <Name language="Basque">Txiprana</Name>
+      <Name language="French_Old">Chiprane</Name>
+      <Name language="Galician">Xiprana</Name>
+      <Name language="Hejazi_Arabic">Shibran</Name>
+      <Name language="Portuguese">Xiprana</Name>
+      <Name language="Sicilian_Arabic">Shibran</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69212,6 +69394,17 @@
       <GameId game="CK2HIP" parent="c_caspe" order="3">b_fabara</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hawara</Name>
+      <Name language="Arabic_Bedouin">Hawara</Name>
+      <Name language="Arabic_Egypt">Hawara</Name>
+      <Name language="Arabic_Levant">Hawara</Name>
+      <Name language="Arabic_Maghreb">Hawara</Name>
+      <Name language="Arabic_Yemen">Hawara</Name>
+      <Name language="Aragonese">Favara</Name>
+      <Name language="Catalan_Medieval">Favara de Matarranya</Name>
+      <Name language="French_Old">Fabare</Name>
+      <Name language="Hejazi_Arabic">Hawara</Name>
+      <Name language="Sicilian_Arabic">Hawara</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -69220,6 +69413,15 @@
       <GameId game="CK2HIP" parent="c_caspe" order="5">b_calanda</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qalanna</Name>
+      <Name language="Arabic_Bedouin">Qalanna</Name>
+      <Name language="Arabic_Egypt">Qalanna</Name>
+      <Name language="Arabic_Levant">Qalanna</Name>
+      <Name language="Arabic_Maghreb">Qalanna</Name>
+      <Name language="Arabic_Yemen">Qalanna</Name>
+      <Name language="Basque">Kalanda</Name>
+      <Name language="Hejazi_Arabic">Qalanna</Name>
+      <Name language="Sicilian_Arabic">Qalanna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70914,6 +71116,15 @@
       <GameId game="CK2HIP" parent="d_beira" order="2">c_viseu</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Buza</Name>
+      <Name language="Arabic_Bedouin">Buza</Name>
+      <Name language="Arabic_Egypt">Buza</Name>
+      <Name language="Arabic_Levant">Buza</Name>
+      <Name language="Arabic_Maghreb">Buza</Name>
+      <Name language="Arabic_Yemen">Buza</Name>
+      <Name language="Basque">Biseu</Name>
+      <Name language="Hejazi_Arabic">Buza</Name>
+      <Name language="Sicilian_Arabic">Buza</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70930,6 +71141,16 @@
       <GameId game="CK2HIP" parent="c_viseu" order="3">b_lamego</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Lamiq</Name>
+      <Name language="Arabic_Bedouin">Lamiq</Name>
+      <Name language="Arabic_Egypt">Lamiq</Name>
+      <Name language="Arabic_Levant">Lamiq</Name>
+      <Name language="Arabic_Maghreb">Lamiq</Name>
+      <Name language="Arabic_Yemen">Lamiq</Name>
+      <Name language="French_Old">Lamegge</Name>
+      <Name language="Hejazi_Arabic">Lamiq</Name>
+      <Name language="Leonese">Lamiegu</Name>
+      <Name language="Sicilian_Arabic">Lamiq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70938,6 +71159,20 @@
       <GameId game="CK2HIP" parent="c_viseu" order="4">b_castro_daire</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at al-Hawaa</Name>
+      <Name language="Arabic_Bedouin">Qal'at al-Hawaa</Name>
+      <Name language="Arabic_Egypt">Qal'at al-Hawaa</Name>
+      <Name language="Arabic_Levant">Qal'at al-Hawaa</Name>
+      <Name language="Arabic_Maghreb">Qal'at al-Hawaa</Name>
+      <Name language="Arabic_Yemen">Qal'at al-Hawaa</Name>
+      <Name language="Aragonese">Castiello d'Aire</Name>
+      <Name language="Basque">Aireko Gaztelua</Name>
+      <Name language="Castilian">Castillo de Aire</Name>
+      <Name language="Catalan_Medieval">Castell d'Aire</Name>
+      <Name language="French_Old">Chateau d'Air</Name>
+      <Name language="Hejazi_Arabic">Qal'at al-Hawaa</Name>
+      <Name language="Leonese">Castiellu de Aire</Name>
+      <Name language="Sicilian_Arabic">Qal'at al-Hawaa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70946,6 +71181,16 @@
       <GameId game="CK2HIP" parent="c_viseu" order="5">b_penedono</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bindun</Name>
+      <Name language="Arabic_Bedouin">Bindun</Name>
+      <Name language="Arabic_Egypt">Bindun</Name>
+      <Name language="Arabic_Levant">Bindun</Name>
+      <Name language="Arabic_Maghreb">Bindun</Name>
+      <Name language="Arabic_Yemen">Bindun</Name>
+      <Name language="French_Old">Penedone</Name>
+      <Name language="Hejazi_Arabic">Bindun</Name>
+      <Name language="Leonese">Penedonu</Name>
+      <Name language="Sicilian_Arabic">Bindun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70954,6 +71199,14 @@
       <GameId game="CK2HIP" parent="c_viseu" order="6">b_mangualde</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Azurara</Name>
+      <Name language="Arabic_Bedouin">Azurara</Name>
+      <Name language="Arabic_Egypt">Azurara</Name>
+      <Name language="Arabic_Levant">Azurara</Name>
+      <Name language="Arabic_Maghreb">Azurara</Name>
+      <Name language="Arabic_Yemen">Azurara</Name>
+      <Name language="Hejazi_Arabic">Azurara</Name>
+      <Name language="Sicilian_Arabic">Azurara</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70962,6 +71215,20 @@
       <GameId game="CK2HIP" parent="c_viseu" order="7">b_moimenta_da_beira</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mumminda</Name>
+      <Name language="Arabic_Bedouin">Mumminda</Name>
+      <Name language="Arabic_Egypt">Mumminda</Name>
+      <Name language="Arabic_Levant">Mumminda</Name>
+      <Name language="Arabic_Maghreb">Mumminda</Name>
+      <Name language="Arabic_Yemen">Mumminda</Name>
+      <Name language="Aragonese">Moimenta d'a Beira</Name>
+      <Name language="Basque">Moimenta Beira</Name>
+      <Name language="Castilian">Moimenta de la Beira</Name>
+      <Name language="Catalan_Medieval">Moimenta de la Beira</Name>
+      <Name language="French_Old">Moimente de la Beire</Name>
+      <Name language="Hejazi_Arabic">Mumminda</Name>
+      <Name language="Leonese">Moimenta de la Beira</Name>
+      <Name language="Sicilian_Arabic">Mumminda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70971,6 +71238,17 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="1">b_trancoso</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tranqusu</Name>
+      <Name language="Arabic_Bedouin">Tranqusu</Name>
+      <Name language="Arabic_Egypt">Tranqusu</Name>
+      <Name language="Arabic_Levant">Tranqusu</Name>
+      <Name language="Arabic_Maghreb">Tranqusu</Name>
+      <Name language="Arabic_Yemen">Tranqusu</Name>
+      <Name language="Basque">Trankoso</Name>
+      <Name language="French_Old">Trancose</Name>
+      <Name language="Hejazi_Arabic">Tranqusu</Name>
+      <Name language="Leonese">Trancosu</Name>
+      <Name language="Sicilian_Arabic">Tranqusu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70979,6 +71257,15 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="2">b_guarda</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Warda</Name>
+      <Name language="Arabic_Bedouin">Warda</Name>
+      <Name language="Arabic_Egypt">Warda</Name>
+      <Name language="Arabic_Levant">Warda</Name>
+      <Name language="Arabic_Maghreb">Warda</Name>
+      <Name language="Arabic_Yemen">Warda</Name>
+      <Name language="French_Old">Guarde</Name>
+      <Name language="Hejazi_Arabic">Warda</Name>
+      <Name language="Sicilian_Arabic">Warda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70987,6 +71274,15 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="3">b_seia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Siyya</Name>
+      <Name language="Arabic_Bedouin">Siyya</Name>
+      <Name language="Arabic_Egypt">Siyya</Name>
+      <Name language="Arabic_Levant">Siyya</Name>
+      <Name language="Arabic_Maghreb">Siyya</Name>
+      <Name language="Arabic_Yemen">Siyya</Name>
+      <Name language="French_Old">Seye</Name>
+      <Name language="Hejazi_Arabic">Siyya</Name>
+      <Name language="Sicilian_Arabic">Siyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70995,6 +71291,20 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="4">b_manteigas</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mindeqa</Name>
+      <Name language="Arabic_Bedouin">Mindeqa</Name>
+      <Name language="Arabic_Egypt">Mindeqa</Name>
+      <Name language="Arabic_Levant">Mindeqa</Name>
+      <Name language="Arabic_Maghreb">Mindeqa</Name>
+      <Name language="Arabic_Yemen">Mindeqa</Name>
+      <Name language="Aragonese">Mantegas</Name>
+      <Name language="Basque">Mantegas</Name>
+      <Name language="Castilian">Mantegas</Name>
+      <Name language="Catalan_Medieval">Mantegues</Name>
+      <Name language="French_Old">Mantégues</Name>
+      <Name language="Hejazi_Arabic">Mindeqa</Name>
+      <Name language="Leonese">Mantiegues</Name>
+      <Name language="Sicilian_Arabic">Mindeqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71003,6 +71313,20 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="5">b_celorico_da_beira</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sihlriq</Name>
+      <Name language="Arabic_Bedouin">Sihlriq</Name>
+      <Name language="Arabic_Egypt">Sihlriq</Name>
+      <Name language="Arabic_Levant">Sihlriq</Name>
+      <Name language="Arabic_Maghreb">Sihlriq</Name>
+      <Name language="Arabic_Yemen">Sihlriq</Name>
+      <Name language="Aragonese">Celorico d'a Beira</Name>
+      <Name language="Basque">Zeloriko Beira</Name>
+      <Name language="Castilian">Celorico de la Beira</Name>
+      <Name language="Catalan_Medieval">Celoric de la Beira</Name>
+      <Name language="French_Old">Celric de la Beire</Name>
+      <Name language="Hejazi_Arabic">Sihlriq</Name>
+      <Name language="Leonese">Celoricu de la Beira</Name>
+      <Name language="Sicilian_Arabic">Sihlriq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71011,6 +71335,20 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="6">b_aguiar_da_beira</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Nasr al-Bira</Name>
+      <Name language="Arabic_Bedouin">Nasr al-Bira</Name>
+      <Name language="Arabic_Egypt">Nasr al-Bira</Name>
+      <Name language="Arabic_Levant">Nasr al-Bira</Name>
+      <Name language="Arabic_Maghreb">Nasr al-Bira</Name>
+      <Name language="Arabic_Yemen">Nasr al-Bira</Name>
+      <Name language="Aragonese">Aguilar d'a Beira</Name>
+      <Name language="Basque">Aguilar Beira</Name>
+      <Name language="Castilian">Aguilar de la Beira</Name>
+      <Name language="Catalan_Medieval">Àguilar de la Beira</Name>
+      <Name language="French_Old">Aiglère de la Beira</Name>
+      <Name language="Hejazi_Arabic">Nasr al-Bira</Name>
+      <Name language="Leonese">Aguilar de la Beira</Name>
+      <Name language="Sicilian_Arabic">Nasr al-Bira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71019,6 +71357,20 @@
       <GameId game="CK2HIP" parent="c_trancoso" order="7">b_gouveia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Gubbiyya</Name>
+      <Name language="Arabic_Bedouin">Gubbiyya</Name>
+      <Name language="Arabic_Egypt">Gubbiyya</Name>
+      <Name language="Arabic_Levant">Gubbiyya</Name>
+      <Name language="Arabic_Maghreb">Gubbiyya</Name>
+      <Name language="Arabic_Yemen">Gubbiyya</Name>
+      <Name language="Aragonese">Goveya</Name>
+      <Name language="Basque">Gobeia</Name>
+      <Name language="Castilian">Goveya</Name>
+      <Name language="Catalan_Medieval">Goveia</Name>
+      <Name language="French_Old">Gouveille</Name>
+      <Name language="Hejazi_Arabic">Gubbiyya</Name>
+      <Name language="Leonese">Goveya</Name>
+      <Name language="Sicilian_Arabic">Gubbiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71125,6 +71477,23 @@
       <GameId game="CK2HIP" parent="c_valencia" order="3">b_jativa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Madína Shátiba</Name>
+      <Name language="Arabic_Bedouin">Madína Shátiba</Name>
+      <Name language="Arabic_Egypt">Madína Shátiba</Name>
+      <Name language="Arabic_Levant">Madína Shátiba</Name>
+      <Name language="Arabic_Maghreb">Madína Shátiba</Name>
+      <Name language="Arabic_Yemen">Madína Shátiba</Name>
+      <Name language="Aragonese">Exativa</Name>
+      <Name language="Basque">Xatiba</Name>
+      <Name language="Catalan_Medieval">Xàtiva</Name>
+      <Name language="French_Old">Xàtiva</Name>
+      <Name language="Galician">Xátiva</Name>
+      <Name language="Greek_Medieval">Saitabis</Name>
+      <Name language="Hejazi_Arabic">Madína Shátiba</Name>
+      <Name language="Latin_Medieval">Saetabis</Name>
+      <Name language="Leonese">Xátiva</Name>
+      <Name language="Portuguese">Xátiva</Name>
+      <Name language="Sicilian_Arabic">Madína Shátiba</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71133,6 +71502,17 @@
       <GameId game="CK2HIP" parent="c_valencia" order="4">b_alacuas</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Aqwás</Name>
+      <Name language="Arabic_Bedouin">al-Aqwás</Name>
+      <Name language="Arabic_Egypt">al-Aqwás</Name>
+      <Name language="Arabic_Levant">al-Aqwás</Name>
+      <Name language="Arabic_Maghreb">al-Aqwás</Name>
+      <Name language="Arabic_Yemen">al-Aqwás</Name>
+      <Name language="Basque">Alakuas</Name>
+      <Name language="Catalan_Medieval">Alaquàs</Name>
+      <Name language="French_Old">Alacuas</Name>
+      <Name language="Hejazi_Arabic">al-Aqwás</Name>
+      <Name language="Sicilian_Arabic">al-Aqwás</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71141,6 +71521,17 @@
       <GameId game="CK2HIP" parent="c_valencia" order="5">b_cuartdepoblet</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qwart</Name>
+      <Name language="Arabic_Bedouin">Qwart</Name>
+      <Name language="Arabic_Egypt">Qwart</Name>
+      <Name language="Arabic_Levant">Qwart</Name>
+      <Name language="Arabic_Maghreb">Qwart</Name>
+      <Name language="Arabic_Yemen">Qwart</Name>
+      <Name language="Basque">Kuart Poblet</Name>
+      <Name language="Catalan_Medieval">Quart de Poblet</Name>
+      <Name language="French_Old">Quart de Poblet</Name>
+      <Name language="Hejazi_Arabic">Qwart</Name>
+      <Name language="Sicilian_Arabic">Qwart</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -71149,6 +71540,18 @@
       <GameId game="CK2HIP" parent="c_valencia" order="3">b_alberique</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Barid</Name>
+      <Name language="Arabic_Bedouin">al-Barid</Name>
+      <Name language="Arabic_Egypt">al-Barid</Name>
+      <Name language="Arabic_Levant">al-Barid</Name>
+      <Name language="Arabic_Maghreb">al-Barid</Name>
+      <Name language="Arabic_Yemen">al-Barid</Name>
+      <Name language="Aragonese">Alberic</Name>
+      <Name language="Basque">Alberik</Name>
+      <Name language="Catalan_Medieval">Alberic</Name>
+      <Name language="French_Old">Albéric</Name>
+      <Name language="Hejazi_Arabic">al-Barid</Name>
+      <Name language="Sicilian_Arabic">al-Barid</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74912,6 +75315,17 @@
       <GameId game="CK2HIP" parent="c_neumark" order="4">b_soldin</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Myslibórz</Name>
+      <Name language="Bulgarian_Old">Myslibórz</Name>
+      <Name language="Croatian_Medieval">Myslibórz</Name>
+      <Name language="Czech_Medieval">Mysliborz</Name>
+      <Name language="German_Middle_High">Soldin</Name>
+      <Name language="Polish_Old">Myslibórz</Name>
+      <Name language="Russian_Medieval">Myslibórz</Name>
+      <Name language="Serbian_Medieval">Myslibórz</Name>
+      <Name language="Slovak_Medieval">Mysliborz</Name>
+      <Name language="Slovene_Medieval">Myslibórz</Name>
+      <Name language="Sorbian">Zôldzëno</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74920,6 +75334,17 @@
       <GameId game="CK2HIP" parent="c_neumark" order="5">b_arnswalde</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Choszczno</Name>
+      <Name language="Bulgarian_Old">Choszczno</Name>
+      <Name language="Croatian_Medieval">Choszczno</Name>
+      <Name language="Czech_Medieval">Chošczno</Name>
+      <Name language="German_Middle_High">Arnswalde</Name>
+      <Name language="Polish_Old">Choszczno</Name>
+      <Name language="Russian_Medieval">Choszczno</Name>
+      <Name language="Serbian_Medieval">Choszczno</Name>
+      <Name language="Slovak_Medieval">Chošczno</Name>
+      <Name language="Slovene_Medieval">Choszczno</Name>
+      <Name language="Sorbian">Chòsczno</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74928,6 +75353,17 @@
       <GameId game="CK2HIP" parent="c_neumark" order="7">b_dramburg</GameId>
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Drawsko</Name>
+      <Name language="Bulgarian_Old">Drawsko</Name>
+      <Name language="Croatian_Medieval">Drawsko</Name>
+      <Name language="Czech_Medieval">Dravsko</Name>
+      <Name language="German_Middle_High">Dramburg</Name>
+      <Name language="Polish_Old">Drawsko</Name>
+      <Name language="Russian_Medieval">Drawsko</Name>
+      <Name language="Serbian_Medieval">Drawsko</Name>
+      <Name language="Slovak_Medieval">Dravsko</Name>
+      <Name language="Slovene_Medieval">Drawsko</Name>
+      <Name language="Sorbian">Drawno</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>


### PR DESCRIPTION
 - Added all titles in `CK3`'s Bohemia
 - Added all titles in `CK3`'s Serbia
 - Added more titles in `CK3`'s England
 - Added more titles in `CK3`'s Poland
 - Added more names to existing titles
 - Added more names and links to `Imperator: Rome` titles
 - Updated the readme and the Steam Workshop description
 - Fixed some names missing from the CK2HIP mod