### PR TITLE
More names

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supported games:
  - `Crusader Kings 3`
  - `Imperator: Rome`
 
-The common database currently has over **40 thousand** names for over **370** languages, settings and time periods.
+The common database currently has over **45 thousand** names for over **380** languages, settings and time periods.
 
 # Installation
 

--- a/assets/steam-workshop-description.txt
+++ b/assets/steam-workshop-description.txt
@@ -12,7 +12,7 @@ Supported games:
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2217534250]Crusader Kings 3[/url]
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2219177532]Imperator: Rome[/url]
 
-The common database currently has over [b]40 thousand[/b] names for over [b]370[/b] languages, settings and time periods.
+The common database currently has over [b]45 thousand[/b] names for over [b]380[/b] languages, settings and time periods.
 
 [img=https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/banner_useful_links.png][/img]
 

--- a/languages.xml
+++ b/languages.xml
@@ -262,6 +262,7 @@
       <LanguageId>Romanian_Before1974</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
@@ -2631,6 +2632,7 @@
       <LanguageId>Romanian_Before1974</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
@@ -2643,6 +2645,7 @@
       <LanguageId>Romanian_Before1974</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian</LanguageId>
@@ -2655,6 +2658,7 @@
     <FallbackLanguages>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Before1993</LanguageId>
@@ -2667,6 +2671,7 @@
     <Id>Romanian_Before1964</Id>
     <FallbackLanguages>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
@@ -2679,9 +2684,24 @@
   <Language>
     <Id>Romanian_BeforeWW2</Id>
     <FallbackLanguages>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
+      <LanguageId>Romanian_Before1964</LanguageId>
+      <LanguageId>Romanian_Before1974</LanguageId>
+      <LanguageId>Romanian_Before1993</LanguageId>
+      <LanguageId>Romanian</LanguageId>
+      <LanguageId>Aromanian</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Romanian_Before1930</Id>
+    <FallbackLanguages>
+      <LanguageId>Romanian_BeforeWW1</LanguageId>
+      <LanguageId>Romanian_Before19Century</LanguageId>
+      <LanguageId>Romanian_Old</LanguageId>
+      <LanguageId>Romanian_BeforeWW2</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_Before1974</LanguageId>
       <LanguageId>Romanian_Before1993</LanguageId>
@@ -2694,6 +2714,7 @@
     <FallbackLanguages>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_Before1974</LanguageId>
@@ -2707,6 +2728,7 @@
     <FallbackLanguages>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_Before1974</LanguageId>
@@ -2725,6 +2747,7 @@
     <FallbackLanguages>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_BeforeWW1</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
       <LanguageId>Romanian_BeforeWW2</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
       <LanguageId>Romanian_Before1974</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -1754,6 +1754,16 @@
     </GameIds>
   </Language>
   <Language>
+    <Id>Karluk</Id>
+    <GameIds>
+      <GameId game="CK2HIP">karluk</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Uyghur</LanguageId>
+      <LanguageId>Uzbek</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
     <Id>Kashubian</Id>
     <Code iso-639-3="csb" />
   </Language>
@@ -3391,10 +3401,18 @@
       <GameId game="CK2HIP">uyghur</GameId>
       <GameId game="CK3">uyghur</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Karluk</LanguageId>
+      <LanguageId>Uzbek</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Uzbek</Id>
     <Code iso-639-1="uz" iso-639-2="uzb" iso-639-3="uzb" />
+    <FallbackLanguages>
+      <LanguageId>Karluk</LanguageId>
+      <LanguageId>Uyghur</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Venetian</Id>

--- a/languages.xml
+++ b/languages.xml
@@ -2787,7 +2787,10 @@
     <Id>Scots</Id>
     <Code iso-639-3="sco" />
     <FallbackLanguages>
+      <LanguageId>English_Before1974</LanguageId>
+      <LanguageId>English_Before1926</LanguageId>
       <LanguageId>Scots_Medieval</LanguageId>
+      <LanguageId>English_Middle</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2796,7 +2799,12 @@
       <GameId game="CK3">scottish</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>English_Middle</LanguageId>
+      <LanguageId>English_Before1926</LanguageId>
+      <LanguageId>English_Before1974</LanguageId>
       <LanguageId>Scots</LanguageId>
+      <LanguageId>English</LanguageId>
+      <LanguageId>English_Old</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -54,6 +54,13 @@
     </FallbackLanguages>
   </Language>
   <Language>
+    <Id>Amharic</Id>
+    <Code iso-639-1="am" iso-639-2="amh" iso-639-3="amh" />
+    <GameIds>
+      <GameId game="CK2HIP">ethiopian</GameId>
+    </GameIds>
+  </Language>
+  <Language>
     <Id>Arabic</Id>
     <Code iso-639-1="ar" iso-639-3="ara" />
     <FallbackLanguages>
@@ -1737,8 +1744,10 @@
     <FallbackLanguages>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Zenati</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
       <LanguageId>Zenaga</LanguageId>
       <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2144,6 +2153,20 @@
     <GameIds>
       <GameId game="CK2HIP">mari</GameId>
     </GameIds>
+  </Language>
+  <Language>
+    <Id>Masmuda</Id>
+    <GameIds>
+      <GameId game="CK2HIP">masmuda</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Sanhaja</LanguageId>
+      <LanguageId>Kabyle</LanguageId>
+      <LanguageId>Zenati</LanguageId>
+      <LanguageId>Zenaga</LanguageId>
+      <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Massylian</Id>
@@ -2769,8 +2792,10 @@
     <FallbackLanguages>
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Zenati</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
       <LanguageId>Zenaga</LanguageId>
       <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
     </FallbackLanguages>
     <GameIds>
       <GameId game="CK2HIP">sanhaja</GameId>
@@ -3030,6 +3055,37 @@
     </GameIds>
   </Language>
   <Language>
+    <Id>Soninke</Id>
+    <Code iso-639-2="snk" iso-639-3="snk" />
+    <GameIds>
+      <GameId game="CK2HIP">soninke</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Soninke_Bozo</LanguageId>
+      <LanguageId>Soninke_Bobo</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Soninke_Bobo</Id>
+    <Code iso-639-3="bbo" />
+    <GameIds>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Soninke_Bozo</LanguageId>
+      <LanguageId>Soninke</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Soninke_Bozo</Id>
+    <Code iso-639-3="boz" />
+    <GameIds>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Soninke_Bobo</LanguageId>
+      <LanguageId>Soninke</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
     <Id>Sorbian</Id>
     <Code iso-639-2="wen" />
     <GameIds>
@@ -3225,9 +3281,25 @@
       <GameId game="CK2HIP">tuareg</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
       <LanguageId>Zenati</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Kabyle</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
+      <LanguageId>Zenaga</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Tuareg_Tagelmust</Id>
+    <GameIds>
+      <GameId game="CK2HIP">tagelmust</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Zenati</LanguageId>
+      <LanguageId>Sanhaja</LanguageId>
+      <LanguageId>Kabyle</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
       <LanguageId>Zenaga</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -3553,9 +3625,11 @@
     <Code iso-639-2="zen" iso-639-3="zen" />
     <FallbackLanguages>
       <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
       <LanguageId>Zenati</LanguageId>
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
     </FallbackLanguages>
     <GameIds>
       <GameId game="CK2HIP">berber</GameId>
@@ -3567,7 +3641,9 @@
     <FallbackLanguages>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Kabyle</LanguageId>
-      <LanguageId>Kabyle</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
+      <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
       <LanguageId>Zenaga</LanguageId>
     </FallbackLanguages>
     <GameIds>

--- a/languages.xml
+++ b/languages.xml
@@ -58,6 +58,7 @@
     <Code iso-639-1="am" iso-639-2="amh" iso-639-3="amh" />
     <GameIds>
       <GameId game="CK2HIP">ethiopian</GameId>
+      <GameId game="CK3">ethiopian</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -387,6 +388,22 @@
     </FallbackLanguages>
   </Language>
   <Language>
+    <Id>Berber</Id>
+    <GameIds>
+      <GameId game="CK2HIP">berber</GameId>
+      <GameId game="CK3">berber</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Zenaga</LanguageId>
+      <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Tuareg_Tagelmust</LanguageId>
+      <LanguageId>Zenati</LanguageId>
+      <LanguageId>Kabyle</LanguageId>
+      <LanguageId>Sanhaja</LanguageId>
+      <LanguageId>Masmuda</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
     <Id>Bikol_Central</Id>
     <Code iso-639-3="bcl" />
   </Language>
@@ -515,7 +532,7 @@
     <Id>Castilian</Id>
     <GameIds>
       <GameId game="CK2HIP">castillan</GameId>
-      <GameId game="CK3">castillan</GameId>
+      <GameId game="CK3">castilian</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Spanish_Medieval</LanguageId>
@@ -1742,6 +1759,7 @@
     <Id>Kabyle</Id>
     <Code iso-639-3="kab" />
     <FallbackLanguages>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Zenati</LanguageId>
       <LanguageId>Masmuda</LanguageId>
@@ -1766,6 +1784,7 @@
     <Id>Karluk</Id>
     <GameIds>
       <GameId game="CK2HIP">karluk</GameId>
+      <GameId game="CK3">karluk</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Uyghur</LanguageId>
@@ -1796,7 +1815,7 @@
     <Id>Khazar_Kabar</Id>
     <Code iso-639-3="zkz" />
     <GameIds>
-      <GameId game="CK2HIP">khazar</GameId>
+      <GameId game="CK2HIP">khavar</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Khazar</LanguageId>
@@ -1813,6 +1832,7 @@
     <Code iso-639-3="kca" />
     <GameIds>
       <GameId game="CK2HIP">khanty</GameId>
+      <GameId game="CK3">khanty</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -1820,6 +1840,7 @@
     <Code iso-639-3="zkt" />
     <GameIds>
       <GameId game="CK2HIP">khitan</GameId>
+      <GameId game="CK3">khitan</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -1831,6 +1852,7 @@
     <Code iso-639-3="kpv" />
     <GameIds>
       <GameId game="CK2HIP">komi</GameId>
+      <GameId game="CK3">komi</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -2152,6 +2174,7 @@
     <Code iso-639-2="chm" iso-639-3="chm" />
     <GameIds>
       <GameId game="CK2HIP">mari</GameId>
+      <GameId game="CK3">mari</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -2160,6 +2183,7 @@
       <GameId game="CK2HIP">masmuda</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Zenati</LanguageId>
@@ -2694,6 +2718,7 @@
   <Language>
     <Id>Romanian_Old</Id>
     <GameIds>
+      <GameId game="CK2">vlach</GameId>
       <GameId game="CK2HIP">romanian</GameId>
       <GameId game="CK3">vlach</GameId>
     </GameIds>
@@ -2784,12 +2809,14 @@
     <Code iso-639-5="syd" />
     <GameIds>
       <GameId game="CK2HIP">samoyed</GameId>
+      <GameId game="CK3">samoyed</GameId>
     </GameIds>
   </Language>
   <Language>
     <Id>Sanhaja</Id>
     <Code iso-639-3="sjs" />
     <FallbackLanguages>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Zenati</LanguageId>
       <LanguageId>Masmuda</LanguageId>
@@ -3005,6 +3032,7 @@
     <Code iso-639-3="scn" />
     <GameIds>
       <GameId game="CK2HIP">sicilian</GameId>
+      <GameId game="CK3">sicilian</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -3044,6 +3072,7 @@
     <Code iso-639-2="sog" iso-639-3="sog" />
     <GameIds>
       <GameId game="CK2HIP">sogdian</GameId>
+      <GameId game="CK3">sogdian</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -3059,6 +3088,7 @@
     <Code iso-639-2="snk" iso-639-3="snk" />
     <GameIds>
       <GameId game="CK2HIP">soninke</GameId>
+      <GameId game="CK3">soninke</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Soninke_Bozo</LanguageId>
@@ -3069,6 +3099,7 @@
     <Id>Soninke_Bobo</Id>
     <Code iso-639-3="bbo" />
     <GameIds>
+      <GameId game="CK3">bobo</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Soninke_Bozo</LanguageId>
@@ -3079,6 +3110,7 @@
     <Id>Soninke_Bozo</Id>
     <Code iso-639-3="boz" />
     <GameIds>
+      <GameId game="CK3">bozo</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Soninke_Bobo</LanguageId>
@@ -3212,6 +3244,7 @@
     <Code iso-639-1="tg" iso-639-2="tgk" iso-639-3="tgk" />
     <GameIds>
       <GameId game="CK2HIP">tajik</GameId>
+      <GameId game="CK3">tajik</GameId>
     </GameIds>
   </Language>
   <Language>
@@ -3282,6 +3315,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Tuareg_Tagelmust</LanguageId>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Zenati</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Kabyle</LanguageId>
@@ -3296,6 +3330,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Tuareg</LanguageId>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Zenati</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Kabyle</LanguageId>
@@ -3624,6 +3659,7 @@
     <Id>Zenaga</Id>
     <Code iso-639-2="zen" iso-639-3="zen" />
     <FallbackLanguages>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Tuareg</LanguageId>
       <LanguageId>Tuareg_Tagelmust</LanguageId>
       <LanguageId>Zenati</LanguageId>
@@ -3631,14 +3667,11 @@
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Masmuda</LanguageId>
     </FallbackLanguages>
-    <GameIds>
-      <GameId game="CK2HIP">berber</GameId>
-      <GameId game="CK3">berber</GameId>
-    </GameIds>
   </Language>
   <Language>
     <Id>Zenati</Id>
     <FallbackLanguages>
+      <LanguageId>Berber</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Masmuda</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -2789,12 +2789,12 @@
     <FallbackLanguages>
       <LanguageId>English_Before1974</LanguageId>
       <LanguageId>English_Before1926</LanguageId>
-      <LanguageId>Scots_Medieval</LanguageId>
+      <LanguageId>Scots_Early</LanguageId>
       <LanguageId>English_Middle</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
-    <Id>Scots_Medieval</Id>
+    <Id>Scots_Early</Id>
     <GameIds>
       <GameId game="CK3">scottish</GameId>
     </GameIds>

--- a/titles.xml
+++ b/titles.xml
@@ -825,6 +825,7 @@
       <Name language="French_Old">Dobrogée</Name>
       <Name language="Galician">Dobruia</Name>
       <Name language="German">Dobrudscha</Name>
+      <Name language="Gothic_Crimean">Mikrá Skythia</Name>
       <Name language="Greek">Mikrá Skythia</Name>
       <Name language="Hungarian">Dobrudzsa</Name>
       <Name language="Italian">Dobrugia</Name>
@@ -1091,6 +1092,8 @@
       <Name language="Hungarian_Old">Fekete Gyergyó</Name> <!-- Or Szent-György -->
       <Name language="Hungarian">Gyurgyevó</Name>
       <Name language="Italian">Giurgevo</Name>
+      <Name language="Karluk">Yergögü</Name>
+      <Name language="Khazar_Kabar">Yergögü</Name>
       <Name language="Khazar">Yergöğü</Name>
       <Name language="Kyrgyz">Yergöğü</Name>
       <Name language="Latin_Medieval">Theodorapolis</Name>
@@ -1468,13 +1471,18 @@
       <Name language="Greek_Ancient">Byzone</Name>
       <Name language="Greek_Ancient">Krounoi</Name>
       <Name language="Greek_Medieval">Krounoi</Name>
-      <Name language="Latin_Old">Dionysopolis</Name>
       <Name language="Latin_Medieval">Krounoi</Name>
+      <Name language="Latin_Old">Dionysopolis</Name>
       <Name language="Latin">Cavarna</Name>
+      <Name language="Oghuz">Balçik</Name>
+      <Name language="Pecheneg">Balçik</Name>
       <Name language="Polish">Karwuna</Name>
-      <Name language="Romanian">Cărvuna</Name>
+      <Name language="Romanian_Old">Cărvuna</Name>
+      <Name language="Romanian">Balcic</Name>
       <Name language="Serbian">Kavarna</Name>
       <Name language="Slovene">Kavarna</Name>
+      <Name language="Turkish_Old">Balçik</Name>
+      <Name language="Turkmen_Medieval">Balçik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -1977,33 +1985,79 @@
       <GameId game="ImperatorRome">485</GameId> <!-- Philippopolis -->
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Philippopolis</Name>
+      <Name language="Arabic_Andalusia">Maqadúniya</Name>
+      <Name language="Arabic_Bedouin">Maqadúniya</Name>
+      <Name language="Arabic_Egypt">Maqadúniya</Name>
+      <Name language="Arabic_Levant">Maqadúniya</Name>
+      <Name language="Arabic_Maghreb">Maqadúniya</Name>
+      <Name language="Arabic_Yemen">Maqadúniya</Name>
+      <Name language="Aragonese">Philippopolis</Name>
+      <Name language="Arpitan">Philippopolis</Name>
+      <Name language="Basque">Philippopolis</Name>
+      <Name language="Bavarian_Medieval">Philippopolis</Name>
+      <Name language="Castilian">Philippopolis</Name>
+      <Name language="Catalan_Medieval">Philippopolis</Name>
       <Name language="Catalan">Plòvdiv</Name>
+      <Name language="Dalmatian_Medieval">Philippopolis</Name>
+      <Name language="Danish_Middle">Philippopolis</Name>
+      <Name language="Dutch_Middle">Philippopolis</Name>
+      <Name language="English_Middle">Philippopolis</Name>
+      <Name language="Frankish_Low">Philippopolis</Name>
+      <Name language="Frankish">Philippopolis</Name>
+      <Name language="French_Old">Philippopolis</Name>
       <Name language="Frisian_North">Plowdiw</Name>
+      <Name language="German_Middle_High">Philippopolis</Name>
+      <Name language="German_Middle_Low">Philippopolis</Name>
+      <Name language="German_Old_Low">Philippopolis</Name>
       <Name language="German">Plowdiw</Name>
       <Name language="Gothic_Crimean">Philippoupolis</Name>
+      <Name language="Gothic">Philippopolis</Name>
       <Name language="Greek_Medieval">Philippoúpolis</Name>
       <Name language="Greek">Philippoúpolis</Name>
+      <Name language="Hejazi_Arabic">Maqadúniya</Name>
       <Name language="Hungarian_Old">Filipápoly</Name>
+      <Name language="Italian_Central">Philippopolis</Name>
+      <Name language="Italian_Medieval">Philippopolis</Name>
       <Name language="Italian">Filippopoli</Name>
       <Name language="Kurdish">Plovdîv</Name>
+      <Name language="Langobardic">Philippopolis</Name>
       <Name language="Latgalian">Plovdiva</Name>
       <Name language="Latin_Medieval">Philippopolis</Name>
       <Name language="Latin">Trimontium</Name>
       <Name language="Latvian">Plovdiva</Name>
+      <Name language="Leonese">Philippopolis</Name>
+      <Name language="Ligurian">Philippopolis</Name>
       <Name language="Lithuanian">Plovdivas</Name>
       <Name language="Lombard">Filipopul</Name>
       <Name language="Luxembourgish">Plowdiw</Name>
       <Name language="Malagasy">Plôvdiv</Name>
+      <Name language="Masmuda">Maqadúniya</Name>
+      <Name language="Neapolitan">Philippopolis</Name>
+      <Name language="Norman">Philippopolis</Name>
+      <Name language="Norwegian_Old">Philippopolis</Name>
+      <Name language="Occitan_Old">Philippopolis</Name>
       <Name language="Oghuz">Filibe</Name>
       <Name language="Pecheneg">Filibe</Name>
-      <Name language="Polish">Plowdiw</Name>
       <Name language="Polish">Płowdiw</Name>
       <Name language="Romanian">Pulpudeva</Name>
+      <Name language="Sanhaja">Maqadúniya</Name>
+      <Name language="Sardinian">Philippopolis</Name>
+      <Name language="Sicilian_Arabic">Maqadúniya</Name>
+      <Name language="Sicilian">Philippopolis</Name>
+      <Name language="Swedish_Old">Philippopolis</Name>
       <Name language="Szekely_Old">Filipápoly</Name>
       <Name language="Thracian">Pulpudeva</Name>
+      <Name language="Thuringian_Medieval">Philippopolis</Name>
+      <Name language="Tuareg_Tagelmust">Maqadúniya</Name>
+      <Name language="Tuareg">Maqadúniya</Name>
       <Name language="Turkish_Old">Filibe</Name>
       <Name language="Turkmen_Medieval">Filibe</Name>
       <Name language="Turkmen">Plowdiw</Name>
+      <Name language="Tuscan_Medieval">Philippopolis</Name>
+      <Name language="Umbrian_Medieval">Philippopolis</Name>
+      <Name language="Venetian_Medieval">Philippopolis</Name>
+      <Name language="Zenati">Maqadúniya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -2325,6 +2379,8 @@
       <Name language="Hungarian_Old_Early">Tergovistýe</Name>
       <Name language="Hungarian_Old">Tirgovics</Name>
       <Name language="Hungarian">Tirgovics</Name>
+      <Name language="Karluk">Bükres</Name>
+      <Name language="Khazar_Kabar">Bükres</Name>
       <Name language="Latin">Berzovia</Name>
       <Name language="Lithuanian">Tirgovištė</Name>
       <Name language="Polish">Targowica</Name>
@@ -20177,6 +20233,7 @@
       <Name language="Romanian">Nesebar</Name>
       <Name language="Serbian">Zagorje</Name>
       <Name language="Slovene">Zagorje</Name>
+      <Name language="Venetian">Zagora</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20259,6 +20316,7 @@
       <Name language="Greek_Medieval">Hiambouli</Name>
       <Name language="Hejazi_Arabic">Dinibouli</Name>
       <Name language="Latin_Medieval">Diampolis</Name>
+      <Name language="Masmuda">Dinibouli</Name>
       <Name language="Oghuz">Yanbolu</Name>
       <Name language="Pecheneg">Yanbolu</Name>
       <Name language="Romanian">Diampol</Name>
@@ -20266,6 +20324,7 @@
       <Name language="Serbian">Djampolj</Name>
       <Name language="Sicilian_Arabic">Dinibouli</Name>
       <Name language="Slovene">Djampolj</Name>
+      <Name language="Tuareg_Tagelmust">Dinibouli</Name>
       <Name language="Tuareg">Dinibouli</Name>
       <Name language="Turkish_Old">Yanbolu</Name>
       <Name language="Turkmen_Medieval">Yanbolu</Name>
@@ -20958,24 +21017,28 @@
       <Name language="Langobardic">Butella</Name>
       <Name language="Latin_Medieval">Butella</Name>
       <Name language="Ligurian">Butella</Name>
+      <Name language="Masmuda">Butilj</Name>
       <Name language="Neapolitan">Butella</Name>
       <Name language="Norman">Butella</Name>
       <Name language="Occitan_Old">Butella</Name>
       <Name language="Oghuz">Manastir</Name>
       <Name language="Pecheneg">Manastir</Name>
       <Name language="Romanian_Old">Bituli</Name>
+      <Name language="Sanhaja">Butilj</Name>
       <Name language="Sardinian">Butella</Name>
       <Name language="Serbian_Medieval">Hlerin</Name>
       <Name language="Serbian">Bitolj</Name>
       <Name language="Sicilian_Arabic">Butilj</Name>
       <Name language="Sicilian">Butella</Name>
       <Name language="Slovene">Bitolj</Name>
+      <Name language="Tuareg_Tagelmust">Butilj</Name>
       <Name language="Tuareg">Butilj</Name>
       <Name language="Turkish_Old">Manastir</Name>
       <Name language="Turkmen_Medieval">Manastir</Name>
       <Name language="Tuscan_Medieval">Butella</Name>
       <Name language="Umbrian_Medieval">Butella</Name>
       <Name language="Venetian_Medieval">Butella</Name>
+      <Name language="Zenati">Butilj</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -21948,6 +22011,7 @@
       <Name language="English_Old_Norse">Danmörk</Name>
       <Name language="English_Old">Denemearc</Name>
       <Name language="English">Denmark</Name>
+      <Name language="Gothic">Danmörk</Name>
       <Name language="Icelandic_Old">Danmörk</Name>
       <Name language="Irish_Middle_Norse">Danmörk</Name>
       <Name language="Norse">Danmörk</Name>
@@ -21999,6 +22063,7 @@
     </GameIds>
     <Names>
       <Name language="English_Old_Norse">Borgundarhólmi</Name>
+      <Name language="Gothic">Borgundarhólmi</Name>
       <Name language="Icelandic_Old">Borgundarhólmi</Name>
       <Name language="Irish_Middle_Norse">Borgundarhólmi</Name>
       <Name language="Latin">Holmus</Name>
@@ -27699,10 +27764,27 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>nalshia</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_lithuanians" order="3">c_utena</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Alemannic_Medieval">Nalsen</Name>
+      <Name language="Bavarian_Medieval">Nalsen</Name>
+      <Name language="Dutch_Middle">Nalsen</Name>
+      <Name language="Frankish_Low">Nalsen</Name>
+      <Name language="Frankish">Nalsen</Name>
+      <Name language="German_Middle_High">Nalsen</Name>
+      <Name language="German_Middle_Low">Nalsen</Name>
+      <Name language="German_Old_Low">Nalsen</Name>
+      <Name language="Russian_Medieval">Nal'šany</Name>
+      <Name language="Thuringian_Medieval">Nalsen</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>utena</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_utena" order="1">b_utena</GameId>
-      <GameId game="CK2HIP" parent="d_lithuanians" order="3">c_utena</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Utenen</Name>
@@ -28045,12 +28127,32 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>marienburg</Id>
+    <Id>warmia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_prussia" order="2">c_marienburg</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Ermland</Name>
+      <Name language="Bavarian_Medieval">Ermland</Name>
+      <Name language="Czech_Medieval">Varmia</Name>
+      <Name language="Danish_Middle">Ermland</Name>
+      <Name language="Dutch_Middle">Ermland</Name>
+      <Name language="English_Old_Norse">Ermland</Name>
+      <Name language="Frankish_Low">Ermland</Name>
+      <Name language="Frankish">Ermland</Name>
+      <Name language="German_Middle_High">Ermland</Name>
+      <Name language="German_Middle_Low">Ermland</Name>
+      <Name language="German_Old_Low">Ermland</Name>
+      <Name language="Gothic">Ermland</Name>
+      <Name language="Irish_Middle_Norse">Ermland</Name>
+      <Name language="Latgalian">Varmé</Name>
+      <Name language="Lithuanian_Medieval">Varmé</Name>
+      <Name language="Livonian">Varmé</Name>
+      <Name language="Norwegian_Old">Ermland</Name>
+      <Name language="Prussian_Old">Varmé</Name>
       <Name language="Romanian">Varmia</Name>
+      <Name language="Swedish_Old">Ermland</Name>
+      <Name language="Thuringian_Medieval">Ermland</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -29737,6 +29839,8 @@
       <Name language="Croatian">Ramniku Valča</Name>
       <Name language="Cuman">Remnik</Name>
       <Name language="German">Königsberg</Name> <!-- Or Rümnick -->
+      <Name language="Karluk">Remnik</Name>
+      <Name language="Khazar_Kabar">Remnik</Name>
       <Name language="Khazar">Remnik</Name>
       <Name language="Kyrgyz">Remnik</Name>
       <Name language="Lithuanian">Rimniku Vilča</Name>
@@ -29854,6 +29958,8 @@
       <Name language="German_Old_Low">Barchau</Name>
       <Name language="Hungarian_Old_Early">Bako</Name>
       <Name language="Hungarian_Old">Bákó</Name>
+      <Name language="Karluk">Baka</Name>
+      <Name language="Khazar_Kabar">Baka</Name>
       <Name language="Khazar">Baka</Name>
       <Name language="Kyrgyz">Baka</Name>
       <Name language="Mongol_Proto">Baka</Name>
@@ -30045,6 +30151,8 @@
       <Name language="Greek_Medieval">Iásio</Name>
       <Name language="Hungarian_Old_Early">Iazvasar</Name>
       <Name language="Hungarian_Old">Jászvásár</Name>
+      <Name language="Karluk">Yas</Name>
+      <Name language="Khazar_Kabar">Yas</Name>
       <Name language="Khazar">Yas</Name>
       <Name language="Kyrgyz">Yas</Name>
       <Name language="Latgalian">Jasi</Name>
@@ -30142,14 +30250,19 @@
       <Name language="Hejazi_Arabic">Shehr al-Jedid</Name>
       <Name language="Hungarian_Old_Early">Varuhel</Name>
       <Name language="Hungarian_Old">Várhely</Name>
+      <Name language="Karluk">Yangi-Shehr</Name>
+      <Name language="Khazar_Kabar">Yangi-Shehr</Name>
+      <Name language="Khazar">Yangi-Shehr</Name>
       <Name language="Kyrgyz">Yangi-Shehr</Name>
       <Name language="Lithuanian">Orhejus</Name>
+      <Name language="Masmuda">Shehr al-Jedid</Name>
       <Name language="Mongol_Proto">Yangi-Shehr</Name>
       <Name language="Oghuz">Yangi-Shehr</Name>
       <Name language="Pecheneg">Yangi-Shehr</Name>
       <Name language="Polish_Old">Orgeev</Name>
       <Name language="Romanian">Orhei</Name>
       <Name language="Russian">Orgeev</Name>
+      <Name language="Sanhaja">Shehr al-Jedid</Name>
       <Name language="Serbian_Medieval">Orgeev</Name>
       <Name language="Serbian">Orhej</Name>
       <Name language="Sicilian_Arabic">Shehr al-Jedid</Name>
@@ -30158,10 +30271,12 @@
       <Name language="Slovene">Orhej</Name>
       <Name language="Sorbian">Orgeev</Name>
       <Name language="Szekely_Old">Várhely</Name>
+      <Name language="Tuareg_Tagelmust">Shehr al-Jedid</Name>
       <Name language="Tuareg">Shehr al-Jedid</Name>
       <Name language="Turkish_Old">Yangi-Shehr</Name>
       <Name language="Turkmen_Medieval">Yangi-Shehr</Name>
       <Name language="Uyghur">Yangi-Shehr</Name>
+      <Name language="Zenati">Shehr al-Jedid</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -30400,6 +30515,9 @@
       <Name language="Greek_Medieval">Galatsi</Name>
       <Name language="Hungarian_Old_Early">Galac</Name>
       <Name language="Hungarian_Old">Galac</Name>
+      <Name language="Karluk">Kalas</Name>
+      <Name language="Khazar_Kabar">Kalas</Name>
+      <Name language="Khazar">Kalas</Name>
       <Name language="Kyrgyz">Kalas</Name>
       <Name language="Latin">Galatzium</Name>
       <Name language="Lithuanian">Galacis</Name>
@@ -30479,6 +30597,8 @@
       <Name language="Hungarian_Old_Early">Bender</Name>
       <Name language="Hungarian_Old">Bender</Name>
       <Name language="Italian">Teghenaccio</Name>
+      <Name language="Karluk">Bender</Name>
+      <Name language="Khazar_Kabar">Bender</Name>
       <Name language="Khazar">Bender</Name>
       <Name language="Kyrgyz">Bender</Name>
       <Name language="Latgalian">Bendera</Name>
@@ -30570,6 +30690,9 @@
       <Name language="Hungarian_Old_Early">Kisieney</Name>
       <Name language="Hungarian_Old">Kisjenõ</Name>
       <Name language="Hungarian">Kisjenő</Name>
+      <Name language="Karluk">Kisinev</Name>
+      <Name language="Khazar_Kabar">Kisinev</Name>
+      <Name language="Khazar">Kisinev</Name>
       <Name language="Kyrgyz">Kisinev</Name>
       <Name language="Latgalian">Kišineva</Name>
       <Name language="Lithuanian">Kišiniovas</Name>
@@ -30608,12 +30731,13 @@
       <Name language="Dalmatian_Medieval">Mauricastro</Name>
       <Name language="Georgian">Maurókastron</Name>
       <Name language="Gothic_Crimean">Maurókastron</Name>
-      <Name language="Greek_Medieval">Asprokastron</Name>
-      <Name language="Greek_Medieval">Maurókastron</Name>
+      <Name language="Greek_Medieval">Maurókastron</Name> <!-- Or Asprokastron -->
       <Name language="Hungarian_Old_Early">Trullosfehervaru</Name>
       <Name language="Hungarian_Old">Dnyeszterfehérvár</Name>
       <Name language="Italian_Central">Mauricastro</Name>
       <Name language="Italian_Medieval">Mauricastro</Name>
+      <Name language="Karluk">Akkerman</Name>
+      <Name language="Khazar_Kabar">Akkerman</Name>
       <Name language="Khazar">Akkerman</Name>
       <Name language="Kyrgyz">Akkerman</Name>
       <Name language="Langobardic">Mauricastro</Name>
@@ -32461,6 +32585,7 @@
   <LocationEntity>
     <Id>somogy</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="d_pecs" order="3">c_bereg</GameId>
       <GameId game="CK2HIP" parent="k_hungary" order="4">d_pecs</GameId>
       <GameId game="CK3">c_somogy</GameId>
       <GameId game="CK3">d_somogy</GameId>
@@ -32817,7 +32942,6 @@
   <LocationEntity>
     <Id>bereg</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_pecs" order="3">c_bereg</GameId>
       <GameId game="CK3">c_bereg</GameId>
     </GameIds>
     <FallbackLocations>
@@ -32856,10 +32980,12 @@
     <Names>
       <Name language="Bosnian">Fonjod</Name>
       <Name language="Bulgarian">Fonjod</Name>
-      <Name language="Slovene">Fonjod</Name>
       <Name language="Croatian">Fonjod</Name>
       <Name language="German">Fonjod</Name>
+      <Name language="Hungarian_Old_Early">Fonold</Name>
+      <Name language="Hungarian_Old">Fonyód</Name>
       <Name language="Serbian">Fonjod</Name>
+      <Name language="Slovene">Fonjod</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -32947,10 +33073,13 @@
       <GameId game="CK3">c_saris</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Šariš</Name>
+      <Name language="German_Middle_High">Scharosch</Name>
       <Name language="German">Scharosch</Name>
       <Name language="Hungarian_Old">Sáros</Name>
       <Name language="Latin">Sarossiensis</Name>
       <Name language="Romanian">Șaroș</Name>
+      <Name language="Slovak_Medieval">Šariš</Name>
       <Name language="Slovak">Šariš</Name>
     </Names>
   </LocationEntity>
@@ -32970,9 +33099,11 @@
     <Names>
       <Name language="Bosnian">Bil</Name>
       <Name language="Bulgarian">Bjal</Name>
-      <Name language="Slovene">Bel</Name>
       <Name language="Croatian">Bil</Name>
+      <Name language="Hungarian_Old_Early">Apatfalva</Name>
+      <Name language="Hungarian_Old">Apátfalva</Name>
       <Name language="Serbian">Bel</Name>
+      <Name language="Slovene">Bel</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -32981,13 +33112,15 @@
       <GameId game="CK2HIP" parent="c_saris" order="2">b_vadna</GameId>
     </GameIds>
     <Names>
-      <Name language="Czech">Vodná</Name>
       <Name language="Bosnian">Voden</Name>
       <Name language="Bulgarian">Voden</Name>
-      <Name language="Slovene">Voden</Name>
       <Name language="Croatian">Voden</Name>
-      <Name language="Slovak">Vodná</Name>
+      <Name language="Czech">Vodná</Name>
+      <Name language="Hungarian_Old_Early">Vodna</Name>
+      <Name language="Hungarian_Old">Vadna</Name>
       <Name language="Serbian">Voden</Name>
+      <Name language="Slovak">Vodná</Name>
+      <Name language="Slovene">Voden</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -33031,9 +33164,11 @@
     <Names>
       <Name language="Bosnian">Kozinc</Name>
       <Name language="Bulgarian">Kozinc</Name>
-      <Name language="Slovene">Kozinc</Name>
       <Name language="Croatian">Kozinc</Name>
+      <Name language="Czech_Medieval">Kazincz</Name>
       <Name language="Serbian">Kozinc</Name>
+      <Name language="Slovak_Medieval">Kazincz</Name>
+      <Name language="Slovene">Kozinc</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -36197,6 +36332,7 @@
       <Name language="Latin_Medieval">Iadera</Name>
       <Name language="Ligurian">Zara</Name>
       <Name language="Lithuanian">Zadaras</Name>
+      <Name language="Masmuda">Jadhara</Name>
       <Name language="Neapolitan">Zara</Name>
       <Name language="Norman">Jadres</Name>
       <Name language="Sanhaja">Jadhara</Name>
@@ -36206,6 +36342,7 @@
       <Name language="Slovene">Zader</Name>
       <Name language="Szekely_Old">Zára</Name>
       <Name language="Thuringian_Medieval">Zara</Name>
+      <Name language="Tuareg_Tagelmust">Jadhara</Name>
       <Name language="Tuareg">Jadhara</Name>
       <Name language="Tuscan_Medieval">Jatara</Name>
       <Name language="Umbrian_Medieval">Zara</Name>
@@ -37980,18 +38117,21 @@
     <Id>busra</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_suwaida" order="2">b_busra</GameId>
+      <GameId game="ImperatorRome">734</GameId> <!-- Bostra -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Bosra</Name>
       <Name language="Bulgarian">Bosra</Name>
-      <Name language="Slovene">Bosra</Name>
       <Name language="Croatian">Bosra</Name>
       <Name language="Dutch_Middle">Bosra</Name>
       <Name language="French_Old">Bosra</Name>
       <Name language="German">Bostra</Name>
+      <Name language="Greek_Medieval">Bostra</Name>
       <Name language="Italian">Bosra</Name>
+      <Name language="Latin_Medieval">Bostra</Name>
       <Name language="Portuguese">Bosra</Name>
       <Name language="Serbian">Bosra</Name>
+      <Name language="Slovene">Bosra</Name>
       <Name language="Swedish">Bosra</Name>
     </Names>
   </LocationEntity>
@@ -38008,18 +38148,27 @@
     <Id>amman</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_amman" order="1">b_amman</GameId>
+      <GameId game="CK2HIP" parent="d_jordan" order="1">c_amman</GameId>
+      <GameId game="ImperatorRome">718</GameId> <!-- Rabbat Ammon -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Aman</Name>
       <Name language="Bulgarian">Aman</Name>
-      <Name language="Slovene">Aman</Name>
       <Name language="Croatian">Aman</Name>
+      <Name language="Estonian">‘Ammãn</Name>
+      <Name language="French_Old">Ahamant</Name>
       <Name language="Galician">Amán</Name>
+      <Name language="Greek_Ancient_Egypt">Philadelpheia Palaistinis</Name>
+      <Name language="Greek_Medieval">Philadelpheia</Name>
       <Name language="Latgalian">Ammãna</Name>
+      <Name language="Latin_Medieval">Philadelphia</Name>
+      <Name language="Latin_Old">Philadelphia Palestinum</Name>
       <Name language="Lithuanian">Amanas</Name>
+      <Name language="Norman">Ahamant</Name>
       <Name language="Portuguese">Amã</Name>
       <Name language="Serbian">Aman</Name>
-      <Name language="Estonian">‘Ammãn</Name>
+      <Name language="Slovene">Aman</Name>
+      <Name language="west_levantine">Rabbat Ammon</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38039,8 +38188,11 @@
     <Id>irbid</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_madaba" order="2">b_irbid</GameId>
+      <GameId game="ImperatorRome">880</GameId> <!-- Arbela -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Arbela</Name>
+      <Name language="Latin_Medieval">Arbela</Name>
       <Name language="Lithuanian">Irbidas</Name>
     </Names>
   </LocationEntity>
@@ -38048,10 +38200,39 @@
     <Id>jerash</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_madaba" order="4">b_jerash</GameId>
+      <GameId game="ImperatorRome">721</GameId> <!-- Gerasa -->
     </GameIds>
     <Names>
       <Name language="Catalan">Gerasa</Name>
+      <Name language="French_Old">Gerasa</Name>
       <Name language="German">Gerasa</Name>
+      <Name language="Greek_Medieval">Gerasa</Name>
+      <Name language="Latin_Medieval">Gerasa</Name>
+      <Name language="Norman">Gerasa</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>palestine</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_jerusalem" order="1">d_jerusalem</GameId>
+      <GameId game="CK2HIP" parent="e_arabia" order="6">k_jerusalem</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Arabic_Andalusia">Filastin</Name>
+      <Name language="Arabic_Bedouin">Filastin</Name>
+      <Name language="Arabic_Egypt">Filastin</Name>
+      <Name language="Arabic_Levant">Filastin</Name>
+      <Name language="Arabic_Maghreb">Filastin</Name>
+      <Name language="Arabic_Yemen">Filastin</Name>
+      <Name language="Greek_Medieval">Palaestina</Name>
+      <Name language="Hejazi_Arabic">Filastin</Name>
+      <Name language="Latin_Medieval">Palaestina</Name>
+      <Name language="Masmuda">Filastin</Name>
+      <Name language="Sanhaja">Filastin</Name>
+      <Name language="Sicilian_Arabic">Filastin</Name>
+      <Name language="Tuareg_Tagelmust">Filastin</Name>
+      <Name language="Tuareg">Filastin</Name>
+      <Name language="Zenati">Filastin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38059,11 +38240,15 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_jerusalem" order="3">b_jerusalem</GameId>
       <GameId game="CK2HIP" parent="d_jerusalem" order="1">c_jerusalem</GameId>
-      <GameId game="CK2HIP" parent="k_jerusalem" order="1">d_jerusalem</GameId>
-      <GameId game="CK2HIP" parent="e_arabia" order="6">k_jerusalem</GameId>
     </GameIds>
     <Names>
-      <Name language="English_Old_Norse">Ierusalem</Name>
+      <Name language="Amharic">Yerusalem</Name>
+      <Name language="Arabic_Andalusia">Al-Quds</Name>
+      <Name language="Arabic_Bedouin">Al-Quds</Name>
+      <Name language="Arabic_Egypt">Al-Quds</Name>
+      <Name language="Arabic_Levant">Al-Quds</Name>
+      <Name language="Arabic_Maghreb">Al-Quds</Name>
+      <Name language="Arabic_Yemen">Al-Quds</Name>
       <Name language="Aragonese">Cherusalem</Name>
       <Name language="Bosnian">Jerusalim</Name>
       <Name language="Breton_Middle">Jeruzalem</Name>
@@ -38072,36 +38257,48 @@
       <Name language="Croatian">Jerusalim</Name>
       <Name language="Czech">Jeruzalém</Name>
       <Name language="Dutch_Middle">Jeruzalem</Name>
+      <Name language="English_Old_Norse">Ierusalem</Name>
       <Name language="Estonian">Jeruusalemm</Name>
       <Name language="Frisian_Old">Jeruzalim</Name>
       <Name language="Galician">Xerusalén</Name>
       <Name language="Greek_Medieval">Hierosolyma</Name>
+      <Name language="Hejazi_Arabic">Al-Quds</Name>
       <Name language="Hungarian">Jeruzsálem</Name>
       <Name language="Irish">Iarúsailéim</Name>
       <Name language="Italian">Gerusalemme</Name>
       <Name language="Latgalian">Jeruzaleme</Name>
+      <Name language="Latin_Medieval">Ierosolyma</Name>
       <Name language="Latin">Hierosolyma</Name>
       <Name language="Leonese">Xerusalén</Name>
       <Name language="Ligurian">Gerusalemme</Name>
       <Name language="Lithuanian">Jeruzale</Name>
       <Name language="Lombard">Gerüsalem</Name>
+      <Name language="Masmuda">Al-Quds</Name>
       <Name language="Nahuatl">Ierusalem</Name>
       <Name language="Neapolitan">Gierusalemme</Name>
       <Name language="Norse">Jórsalaborg</Name>
+      <Name language="Nubian_Old">Ierousalmi</Name>
+      <Name language="Oghuz">Kudüs</Name>
       <Name language="Polish">Jerozolima</Name>
       <Name language="Prussian_Old">Jaruzalams</Name>
       <Name language="Romanian">Ierusalim</Name>
+      <Name language="Sanhaja">Al-Quds</Name>
       <Name language="Sardinian">Gerusalemme</Name>
       <Name language="Scottish_Gaelic">Ierusalem</Name>
+      <Name language="Sicilian_Arabic">Al-Quds</Name>
       <Name language="Sicilian">Girusalemmi</Name>
       <Name language="Slovak">Jeruzalem</Name>
       <Name language="Slovene">Jerusalim</Name>
       <Name language="Somali">Qudus</Name>
+      <Name language="Tuareg_Tagelmust">Al-Quds</Name>
+      <Name language="Tuareg">Al-Quds</Name>
       <Name language="Turkish">Kudüs</Name>
+      <Name language="Turkmen_Medieval">Kudüs</Name>
       <Name language="Turkmen">Iýerusalim</Name>
       <Name language="Venetian">Hierusalem</Name>
       <Name language="Vepsian">Jerusalim</Name>
       <Name language="Welsh">Jeriwsalem</Name>
+      <Name language="Zenati">Al-Quds</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38110,7 +38307,22 @@
       <GameId game="CK2HIP" parent="c_jerusalem" order="1">b_towerofdavid</GameId>
     </GameIds>
     <Names>
-      <Name language="Romanian">Turnu lu David</Name> <!-- Or lui instead of lu but that is the modern form (Also Turnul for Turnu) -->
+      <Name language="Arabic_Andalusia">Burj Daud</Name>
+      <Name language="Arabic_Bedouin">Burj Daud</Name>
+      <Name language="Arabic_Egypt">Burj Daud</Name>
+      <Name language="Arabic_Levant">Burj Daud</Name>
+      <Name language="Arabic_Maghreb">Burj Daud</Name>
+      <Name language="Arabic_Yemen">Burj Daud</Name>
+      <Name language="Greek_Medieval">Kastro David</Name>
+      <Name language="Hejazi_Arabic">Burj Daud</Name>
+      <Name language="Masmuda">Burj Daud</Name>
+      <Name language="Romanian_Old">Turnu lu David</Name> <!-- Or lui instead of lu but that is the modern form (Also Turnul for Turnu) -->
+      <Name language="Romanian">Turnul lui David</Name>
+      <Name language="Sanhaja">Burj Daud</Name>
+      <Name language="Sicilian_Arabic">Burj Daud</Name>
+      <Name language="Tuareg_Tagelmust">Burj Daud</Name>
+      <Name language="Tuareg">Burj Daud</Name>
+      <Name language="Zenati">Burj Daud</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38119,6 +38331,13 @@
       <GameId game="CK2HIP" parent="c_jerusalem" order="2">b_bethlehem</GameId>
     </GameIds>
     <Names>
+      <Name language="Amharic">Bete Lihem</Name>
+      <Name language="Arabic_Andalusia">Bayt Lahm</Name>
+      <Name language="Arabic_Bedouin">Bayt Lahm</Name>
+      <Name language="Arabic_Egypt">Bayt Lahm</Name>
+      <Name language="Arabic_Levant">Bayt Lahm</Name>
+      <Name language="Arabic_Maghreb">Bayt Lahm</Name>
+      <Name language="Arabic_Yemen">Bayt Lahm</Name>
       <Name language="Bulgarian">Vitleem</Name>
       <Name language="Castilian">Belén</Name>
       <Name language="Catalan">Betlem</Name>
@@ -38126,17 +38345,24 @@
       <Name language="Danish">Betlehem</Name>
       <Name language="Finnish">Betlehem</Name>
       <Name language="German">Bait Lahm</Name>
+      <Name language="Hejazi_Arabic">Bayt Lahm</Name>
       <Name language="Hungarian">Betlehem</Name>
       <Name language="Irish">Beitheal</Name>
       <Name language="Italian">Betlemme</Name>
+      <Name language="Masmuda">Bayt Lahm</Name>
       <Name language="Norwegian">Betlehem</Name>
       <Name language="Polish">Betlejem</Name>
       <Name language="Portuguese">Belem</Name>
       <Name language="Romanian">Betleem</Name>
+      <Name language="Sanhaja">Bayt Lahm</Name>
       <Name language="Serbian">Vitlejem</Name>
+      <Name language="Sicilian_Arabic">Bayt Lahm</Name>
       <Name language="Slovak">Betlehem</Name>
       <Name language="Swedish">Betlehem</Name>
+      <Name language="Tuareg_Tagelmust">Bayt Lahm</Name>
+      <Name language="Tuareg">Bayt Lahm</Name>
       <Name language="Turkish">Betlehem</Name>
+      <Name language="Zenati">Bayt Lahm</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -41049,6 +41275,7 @@
       <Name language="English_Middle">Lincoln</Name>
       <Name language="English_Old_Norse">Lincylene</Name>
       <Name language="English_Old">Lincylene</Name>
+      <Name language="Gothic">Lincylene</Name>
       <Name language="Icelandic_Old">Lincylene</Name>
       <Name language="Irish_Middle_Norse">Lincylene</Name>
       <Name language="Irish_Middle">Lindon</Name>
@@ -54438,8 +54665,23 @@
       <GameId game="CK2HIP" parent="d_granada" order="1">c_almeria</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Mariyya</Name>
+      <Name language="Arabic_Bedouin">al-Mariyya</Name>
+      <Name language="Arabic_Egypt">al-Mariyya</Name>
+      <Name language="Arabic_Levant">al-Mariyya</Name>
+      <Name language="Arabic_Maghreb">al-Mariyya</Name>
+      <Name language="Arabic_Yemen">al-Mariyya</Name>
+      <Name language="Basque">Almeria</Name>
+      <Name language="French_Old">Almérie</Name>
+      <Name language="Hejazi_Arabic">al-Mariyya</Name>
       <Name language="Latgalian">Almerija</Name>
       <Name language="Lithuanian">Almerija</Name>
+      <Name language="Masmuda">al-Mariyya</Name>
+      <Name language="Sanhaja">al-Mariyya</Name>
+      <Name language="Sicilian_Arabic">al-Mariyya</Name>
+      <Name language="Tuareg_Tagelmust">al-Mariyya</Name>
+      <Name language="Tuareg">al-Mariyya</Name>
+      <Name language="Zenati">al-Mariyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56910,6 +57152,27 @@
       <Name language="Sicilian_Arabic">Arminiya</Name> <!-- Or al-Arminiya -->
       <Name language="Turkish_Old">Ermenistan</Name>
       <Name language="Turkmen_Medieval">Ermenistan</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>armeniacon</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_trebizond" order="3">d_armeniacon</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Arabic_Andalusia">Arminyáq</Name>
+      <Name language="Arabic_Bedouin">Arminyáq</Name>
+      <Name language="Arabic_Egypt">Arminyáq</Name>
+      <Name language="Arabic_Levant">Arminyáq</Name>
+      <Name language="Arabic_Maghreb">Arminyáq</Name>
+      <Name language="Arabic_Yemen">Arminyáq</Name>
+      <Name language="French_Old">Amasée</Name>
+      <Name language="Hejazi_Arabic">Arminyáq</Name>
+      <Name language="Norman">Amasée</Name>
+      <Name language="Oghuz">Amasiyya</Name>
+      <Name language="Sicilian_Arabic">Arminyáq</Name>
+      <Name language="Turkish_Old">Amasiyya</Name>
+      <Name language="Turkmen_Medieval">Amasiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62431,14 +62694,6 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>armeniacon</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="k_trebizond" order="3">d_armeniacon</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>amaseia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_amasia" order="1">b_amaseia</GameId>
@@ -62798,17 +63053,10 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>teluch</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_armenia_minor" order="4">c_teluch</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>marash</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_teluch" order="2">b_marash</GameId>
+      <GameId game="CK2HIP" parent="d_armenia_minor" order="4">c_teluch</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Mar'ash</Name>
@@ -62819,6 +63067,7 @@
       <Name language="Arabic_Yemen">Mar'ash</Name>
       <Name language="Armenian_Middle">Maraš</Name>
       <Name language="French_Old">Mariscum</Name>
+      <Name language="Greek_Medieval">Germanikeia</Name>
       <Name language="Hejazi_Arabic">Mar'ash</Name>
       <Name language="Norman">Mariscum</Name>
       <Name language="Oghuz">Maras</Name>
@@ -63010,14 +63259,6 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>anamur</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_seleukeia" order="2">c_anamur</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>germanikopolis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_anamur" order="4">b_germanikopolis</GameId>
@@ -63041,6 +63282,7 @@
     <Id>anemurium</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_anamur" order="3">b_anemurium</GameId>
+      <GameId game="CK2HIP" parent="d_seleukeia" order="2">c_anamur</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Ma'muriya</Name>
@@ -63050,6 +63292,7 @@
       <Name language="Arabic_Maghreb">Ma'muriya</Name>
       <Name language="Arabic_Yemen">Ma'muriya</Name>
       <Name language="Armenian_Middle">Anamur</Name>
+      <Name language="Armenian_Middle">Stalemura</Name>
       <Name language="French_Old">Stallimuri</Name>
       <Name language="Hejazi_Arabic">Ma'muriya</Name>
       <Name language="Norman">Stallimuri</Name>
@@ -63939,6 +64182,7 @@
       <Name language="Frisian_West">Sleeswyk</Name>
       <Name language="German_Middle_High">Schleswig</Name>
       <Name language="German_Middle_Low">Sleswig</Name>
+      <Name language="Gothic">Sillendi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -64622,7 +64866,10 @@
       <Name language="Estonian">Stientjie</Name>
       <Name language="Finnish">Stientjie</Name>
       <Name language="Karelian">Stientjie</Name>
+      <Name language="Khanty">Stientjie</Name>
+      <Name language="Komi">Stientjie</Name>
       <Name language="Livonian">Stientjie</Name>
+      <Name language="Mari">Stientjie</Name>
       <Name language="Moksha">Stientjie</Name>
       <Name language="Sami">Stientjie</Name>
       <Name language="Samoyed">Stientjie</Name>
@@ -64638,6 +64885,9 @@
       <Name language="Estonian">Vuogát</Name>
       <Name language="Finnish">Vuogát</Name>
       <Name language="Karelian">Vuogát</Name>
+      <Name language="Khanty">Vuogát</Name>
+      <Name language="Komi">Vuogát</Name>
+      <Name language="Mari">Vuogát</Name>
       <Name language="Moksha">Vuogát</Name>
       <Name language="Sami">Vuogát</Name>
       <Name language="Samoyed">Vuogát</Name>
@@ -64659,20 +64909,26 @@
       <GameId game="CK2HIP" parent="c_karachev" order="3">b_orel</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Ugol</Name>
+      <Name language="Bashkir">Ugol</Name>
+      <Name language="Bulgar">Ugol</Name>
+      <Name language="Cuman">Ugol</Name>
+      <Name language="Karluk">Ugol</Name>
+      <Name language="Khazar_Kabar">Ugol</Name>
+      <Name language="Khazar">Ugol</Name>
+      <Name language="Kyrgyz">Ugol</Name>
+      <Name language="Oghuz">Ugol</Name>
+      <Name language="Pecheneg">Ugol</Name>
+      <Name language="Turkish_Old">Ugol</Name>
+      <Name language="Turkmen_Medieval">Ugol</Name>
+      <Name language="Uyghur">Ugol</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>bezhetsky_verh</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_novgorod" order="2">c_bezhetsky_verh</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>staryaladoga</Id>
+    <Id>ladoga</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_bezhetsky_verh" order="1">b_staryaladoga</GameId>
+      <GameId game="CK2HIP" parent="d_novgorod" order="2">c_bezhetsky_verh</GameId>
     </GameIds>
     <Names>
       <Name language="Danish_Middle">Aldeigjuburgh</Name>
@@ -66087,6 +66343,13 @@
       <GameId game="CK2HIP" parent="c_bartia" order="2">b_bartenstein</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Bartošice</Name>
+      <Name language="Latgalian">Barštynas</Name>
+      <Name language="Lithuanian_Medieval">Barštynas</Name>
+      <Name language="Livonian">Barštynas</Name>
+      <Name language="Polish_Old">Bartoszyce</Name>
+      <Name language="Prussian_Old">Barštynas</Name>
+      <Name language="Sorbian">Bartoszyce</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66095,6 +66358,13 @@
       <GameId game="CK2HIP" parent="c_bartia" order="3">b_rastembork</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Rastembork</Name>
+      <Name language="Latgalian">Raistpilis</Name>
+      <Name language="Lithuanian_Medieval">Raistpilis</Name>
+      <Name language="Livonian">Raistpilis</Name>
+      <Name language="Polish_Old">Rastembork</Name>
+      <Name language="Prussian_Old">Raistpilis</Name>
+      <Name language="Sorbian">Rastembork</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66103,6 +66373,13 @@
       <GameId game="CK2HIP" parent="c_bartia" order="4">b_heilsberg</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Lidzbark</Name>
+      <Name language="Latgalian">Lecbarg</Name>
+      <Name language="Lithuanian_Medieval">Lecbarg</Name>
+      <Name language="Livonian">Lecbarg</Name>
+      <Name language="Polish_Old">Lidzbark</Name>
+      <Name language="Prussian_Old">Lecbarg</Name>
+      <Name language="Sorbian">Lidzbark</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66111,6 +66388,22 @@
       <GameId game="CK2HIP" parent="c_bartia" order="5">b_reszel</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Rößel</Name>
+      <Name language="Bavarian_Medieval">Rößel</Name>
+      <Name language="Czech_Medieval">Rešel</Name>
+      <Name language="Dutch_Middle">Rößel</Name>
+      <Name language="Frankish_Low">Rößel</Name>
+      <Name language="Frankish">Rößel</Name>
+      <Name language="German_Middle_High">Rößel</Name>
+      <Name language="German_Middle_Low">Rößel</Name>
+      <Name language="German_Old_Low">Rößel</Name>
+      <Name language="Latgalian">Resl</Name>
+      <Name language="Lithuanian_Medieval">Resl</Name>
+      <Name language="Livonian">Resl</Name>
+      <Name language="Polish_Old">Reszel</Name>
+      <Name language="Prussian_Old">Resl</Name>
+      <Name language="Sorbian">Reszel</Name>
+      <Name language="Thuringian_Medieval">Rößel</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68324,6 +68617,8 @@
       <GameId game="CK2HIP" parent="c_syria" order="3">b_izra</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Zorava</Name>
+      <Name language="Latin_Medieval">Zorava</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68338,8 +68633,13 @@
     <Id>suwaida</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_suwaida" order="1">b_suwaida</GameId>
+      <GameId game="ImperatorRome">540</GameId> <!-- Dionysias -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Late">Per-Demy-Ma</Name>
+      <Name language="Greek_Ancient">Dionysias</Name>
+      <Name language="Greek_Medieval">Dionysias</Name>
+      <Name language="Latin_Old">Dionisias</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68348,6 +68648,8 @@
       <GameId game="CK2HIP" parent="c_suwaida" order="3">b_shahba</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Philippopolis</Name>
+      <Name language="Latin_Medieval">Philippopolis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68356,6 +68658,8 @@
       <GameId game="CK2HIP" parent="c_suwaida" order="4">b_shaqqa</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Maximianopolis</Name>
+      <Name language="Latin_Medieval">Maximianopolis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68364,14 +68668,8 @@
       <GameId game="CK2HIP" parent="c_suwaida" order="5">b_salkhard</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>balqa</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_jordan" order="1">c_amman</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Medieval">Salcah</Name>
+      <Name language="Latin_Medieval">Salcah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68380,6 +68678,8 @@
       <GameId game="CK2HIP" parent="c_amman" order="2">b_dhiban</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Dibon</Name>
+      <Name language="Latin_Medieval">Dibon</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68403,25 +68703,27 @@
   <LocationEntity>
     <Id>az_zarqa</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_az_zarqa" order="2">b_azraq</GameId>
       <GameId game="CK2HIP" parent="d_jordan" order="2">c_az_zarqa</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>azraq</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_az_zarqa" order="2">b_azraq</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Medieval">Basienis</Name>
+      <Name language="Latin_Medieval">Basienis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>aljun</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_madaba" order="3">b_aljun</GameId>
+      <GameId game="ImperatorRome">675</GameId> <!-- Pella -->
     </GameIds>
     <Names>
+      <Name language="French_Old">Haylon</Name>
+      <Name language="Greek_Ancient">Pella Palaistinai</Name>
+      <Name language="Greek_Medieval">Pella</Name>
+      <Name language="Latin_Medieval">Pella</Name>
+      <Name language="Latin_Old">Pella Palestinum</Name>
+      <Name language="Norman">Haylon</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68430,6 +68732,8 @@
       <GameId game="CK2HIP" parent="c_jerusalem" order="4">b_rammala</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Rámla</Name>
+      <Name language="Latin_Medieval">Rámla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68438,6 +68742,20 @@
       <GameId game="CK2HIP" parent="c_jerusalem" order="5">b_blanchegarde</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sáfíthá</Name>
+      <Name language="Arabic_Bedouin">Sáfíthá</Name>
+      <Name language="Arabic_Egypt">Sáfíthá</Name>
+      <Name language="Arabic_Levant">Sáfíthá</Name>
+      <Name language="Arabic_Maghreb">Sáfíthá</Name>
+      <Name language="Arabic_Yemen">Sáfíthá</Name>
+      <Name language="Greek_Medieval">Saphitha</Name>
+      <Name language="Hejazi_Arabic">Sáfíthá</Name>
+      <Name language="Masmuda">Sáfíthá</Name>
+      <Name language="Sanhaja">Sáfíthá</Name>
+      <Name language="Sicilian_Arabic">Sáfíthá</Name>
+      <Name language="Tuareg_Tagelmust">Sáfíthá</Name>
+      <Name language="Tuareg">Sáfíthá</Name>
+      <Name language="Zenati">Sáfíthá</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68446,6 +68764,8 @@
       <GameId game="CK2HIP" parent="c_jerusalem" order="6">b_saintsamuel</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Monì tìs Agios Samuel</Name>
+      <Name language="Romanian">Sfântul Samuil</Name> <!-- Translated -->
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68454,6 +68774,20 @@
       <GameId game="CK2HIP" parent="c_jerusalem" order="7">b_syrbelmont</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Súbá</Name>
+      <Name language="Arabic_Bedouin">Súbá</Name>
+      <Name language="Arabic_Egypt">Súbá</Name>
+      <Name language="Arabic_Levant">Súbá</Name>
+      <Name language="Arabic_Maghreb">Súbá</Name>
+      <Name language="Arabic_Yemen">Súbá</Name>
+      <Name language="Greek_Medieval">Balamand</Name>
+      <Name language="Hejazi_Arabic">Súbá</Name>
+      <Name language="Masmuda">Súbá</Name>
+      <Name language="Sanhaja">Súbá</Name>
+      <Name language="Sicilian_Arabic">Súbá</Name>
+      <Name language="Tuareg_Tagelmust">Súbá</Name>
+      <Name language="Tuareg">Súbá</Name>
+      <Name language="Zenati">Súbá</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70183,6 +70517,16 @@
       <GameId game="CK2HIP" parent="c_wiltshire" order="1">b_wilton</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Wiltun</Name>
+      <Name language="English_Old_Norse">Wiltun</Name>
+      <Name language="English_Old">Wiltun</Name>
+      <Name language="English">Wilton</Name>
+      <Name language="Gothic">Wiltun</Name>
+      <Name language="Icelandic_Old">Wiltun</Name>
+      <Name language="Irish_Middle_Norse">Wiltun</Name>
+      <Name language="Norse">Wiltun</Name>
+      <Name language="Norwegian_Old">Wiltun</Name>
+      <Name language="Swedish_Old">Wiltun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -70989,6 +71333,9 @@
       <GameId game="CK2HIP" parent="c_lincoln" order="4">b_torksey</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Old_Norse">Torkeseg</Name>
+      <Name language="English_Old">Spaldingas</Name>
+      <Name language="English">Torksey</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -98650,8 +98997,15 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_adana" order="2">b_adana</GameId>
       <GameId game="CK2HIP" parent="d_armenia_minor" order="2">c_adana</GameId>
+      <GameId game="ImperatorRome">1882</GameId> <!-- Adana -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient_Seleukia">Antiocheia Saron</Name>
+      <Name language="Greek_Ancient">Adanos</Name>
+      <Name language="Latin_Old">Adanus</Name>
+      <Name language="Oghuz">Ataná</Name>
+      <Name language="Turkish_Old">Ataná</Name>
+      <Name language="Turkmen_Medieval">Ataná</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -43361,6 +43361,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_galloway" order="1">c_galloway</GameId>
       <GameId game="CK2HIP" parent="k_scotland" order="1">d_galloway</GameId>
+      <GameId game="CK3">c_galloway</GameId>
     </GameIds>
     <Names>
       <Name language="Breton_Middle">Gall Ghaidheal</Name> <!-- Or Galwyddel -->
@@ -43766,6 +43767,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_inbhirnis" order="2">b_inverness</GameId>
       <GameId game="CK2HIP" parent="d_moray" order="3">c_inbhirnis</GameId>
+      <GameId game="CK3">b_inverness</GameId>
       <GameId game="CK3">c_inverness</GameId>
     </GameIds>
     <Names>
@@ -43910,7 +43912,7 @@
       <Name language="English_Old">Lennox</Name>
       <Name language="English">Lennox</Name>
       <Name language="Irish_Middle_Norse">Lennox</Name>
-      <Name language="Scots_Medieval">Lennox</Name>
+      <Name language="Scots_Early">Lennox</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -13940,8 +13940,11 @@
       <GameId game="CK2HIP" parent="d_thessalonika" order="2">c_thessalonike</GameId>
       <GameId game="CK2HIP" parent="k_thrace" order="4">d_thessalonika</GameId>
       <GameId game="CK2HIP" parent="e_byzantium" order="1">k_thrace</GameId>
+      <GameId game="CK3">b_thessaloniki</GameId>
+      <GameId game="CK3">c_thessalonika</GameId>
+      <GameId game="CK3">d_thessalonika</GameId>
       <GameId game="CK3">k_thessalonika</GameId>
-      <GameId game="ImperatorRome">373</GameId>
+      <GameId game="ImperatorRome">373</GameId> <!-- Thessalonica -->
     </GameIds>
     <Names>
       <Name language="Avar_Old">Solun</Name>
@@ -13964,7 +13967,8 @@
       <Name language="Italian_Medieval">Tessalonica</Name>
       <Name language="Langobardic">Tessalonica</Name>
       <Name language="Latgalian">Saloniki</Name>
-      <Name language="Latin_Latin">Thessalonica</Name>
+      <Name language="Latin_Late">Thessalonica</Name>
+      <Name language="Latin_Old">Thessalonica</Name>
       <Name language="Latin">Thessalonica</Name>
       <Name language="Ligurian">Tessalonica</Name>
       <Name language="Lithuanian">Salonikai</Name>
@@ -15201,11 +15205,13 @@
     <Id>chalkidike</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_thessalonika" order="1">c_chalkidike</GameId>
+      <GameId game="CK3">c_chalkidike</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Halkidik</Name>
       <Name language="Bulgarian">Halkidik</Name>
       <Name language="Croatian">Halkidik</Name>
+      <Name language="Greek_Medieval">Chalkidike</Name>
       <Name language="Oghuz">Halkidikya</Name>
       <Name language="Pecheneg">Halkidikya</Name>
       <Name language="Serbian">Halkidik</Name>
@@ -15215,9 +15221,20 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>polygyros</Id>
+    <GameIds>
+      <GameId game="CK3">b_polygyros</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Polygyros</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>kassandria</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_chalkidike" order="1">b_kassandria</GameId>
+      <GameId game="CK3">b_kassandreia</GameId>
+      <GameId game="ImperatorRome">376</GameId> <!-- Poteidaia -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Kasandrija</Name>
@@ -15225,7 +15242,10 @@
       <Name language="Croatian">Kasandrija</Name>
       <Name language="Dutch_Middle">Kassandria</Name>
       <Name language="German">Kassandria</Name>
+      <Name language="Greek_Ancient">Kassandreia</Name>
+      <Name language="Greek_Medieval">Kassandreia</Name>
       <Name language="Italian">Kassandra</Name>
+      <Name language="Latin_Old">Cassandreia</Name>
       <Name language="Oghuz">Kesendire</Name>
       <Name language="Pecheneg">Kesendire</Name>
       <Name language="Serbian">Kasandrija</Name>
@@ -15256,11 +15276,13 @@
     <Id>ierissos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_chalkidike" order="3">b_ierissos</GameId>
+      <GameId game="CK3">b_ierrisos</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Jeriso</Name>
       <Name language="Bulgarian">Jeriso</Name>
       <Name language="Croatian">Jeriso</Name>
+      <Name language="Greek_Medieval">Hierissos</Name>
       <Name language="Oghuz">Erse</Name>
       <Name language="Pecheneg">Erse</Name>
       <Name language="Serbian">Jeriso</Name>
@@ -15307,6 +15329,7 @@
     <Id>thesedessa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thessalonike" order="4">b_thesedessa</GameId>
+      <GameId game="CK3">b_voden</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Vodena</Name>
@@ -15315,6 +15338,7 @@
       <Name language="Croatian">Vodena</Name>
       <Name language="Dutch_Middle">Edessa</Name>
       <Name language="German">Edessa</Name>
+      <Name language="Greek_Medieval">Vodená</Name>
       <Name language="Oghuz">Vodina</Name>
       <Name language="Pecheneg">Vodina</Name>
       <Name language="Romanian_Old">Vudena</Name>
@@ -15323,6 +15347,15 @@
       <Name language="Slovene">Vodena</Name>
       <Name language="Turkish_Old">Vodina</Name>
       <Name language="Turkmen_Medieval">Vodina</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>kalyvia</Id>
+    <GameIds>
+      <GameId game="CK3">b_kalyvia</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Kalyvia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15346,24 +15379,46 @@
     <Id>gynaikokastron</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thessalonike" order="6">b_gynaikokastron</GameId>
+      <GameId game="CK3">b_gynaikokastron</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Žensko</Name>
       <Name language="Bulgarian">Žensko</Name>
-      <Name language="Slovene">Žensko</Name>
       <Name language="Croatian">Žensko</Name>
+      <Name language="Greek_Medieval">Gynaikokastron</Name>
       <Name language="Serbian">Žensko</Name>
+      <Name language="Slovene">Žensko</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>langades</Id>
+    <GameIds>
+      <GameId game="CK3">b_langades</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Langades</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>mavrouda</Id>
+    <GameIds>
+      <GameId game="CK3">b_mavrouda</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Mavrouda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sthlanitza</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thessalonike" order="7">b_sthlanitza</GameId>
+      <GameId game="CK3">b_sthlanitza</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Janica</Name>
       <Name language="Bulgarian">Janica</Name>
       <Name language="Croatian">Janica</Name>
+      <Name language="Greek_Medieval">Sthlanitza</Name>
       <Name language="Oghuz">Yenice-i Vardar</Name>
       <Name language="Pecheneg">Yenice-i Vardar</Name>
       <Name language="Serbian">Janica</Name>
@@ -15377,11 +15432,14 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_veria" order="2">b_veria</GameId>
       <GameId game="CK2HIP" parent="d_thessalonika" order="3">c_veria</GameId>
+      <GameId game="CK3">b_veria</GameId>
+      <GameId game="CK3">c_veria</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Ber</Name>
       <Name language="Bulgarian_Old">Ber</Name>
       <Name language="Croatian">Ber</Name>
+      <Name language="Greek_Medieval">Berroia</Name>
       <Name language="Oghuz">Karaferye</Name>
       <Name language="Pecheneg">Karaferye</Name>
       <Name language="Slovene">Ber</Name>
@@ -15390,9 +15448,19 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>maglen</Id>
+    <GameIds>
+      <GameId game="CK3">b_maglen</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Maglen</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>servia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_veria" order="1">b_servia</GameId>
+      <GameId game="CK3">b_servia</GameId>
     </GameIds>
     <Names>
       <Name language="Arpitan">Sèrvie</Name>
@@ -15408,6 +15476,7 @@
       <Name language="German_Middle_Low">Servien</Name>
       <Name language="German_Old_Low">Servien</Name>
       <Name language="German">Servien</Name>
+      <Name language="Greek_Medieval">Servia</Name>
       <Name language="Hausa">Serviya</Name>
       <Name language="Hungarian">Szervia</Name>
       <Name language="Irish">An tSeirvia</Name>
@@ -15439,11 +15508,32 @@
     <Names>
       <Name language="Bosnian">Neopatrija</Name>
       <Name language="Bulgarian">Neopatrija</Name>
-      <Name language="Slovene">Neopatrija</Name>
+      <Name language="Catalan_Medieval">La Pátria</Name>
+      <Name language="Catalan_Medieval">Neopatria</Name>
       <Name language="Croatian">Neopatrija</Name>
+      <Name language="Dalmatian_Medieval">La Pátria</Name>
+      <Name language="French_Old">La Patre</Name>
+      <Name language="French_Old">Neopatrie</Name>
+      <Name language="Greek_Medieval">Neai Patrai</Name>
+      <Name language="Italian_Central">La Pátria</Name>
+      <Name language="Italian_Medieval">La Pátria</Name>
+      <Name language="Langobardic">La Pátria</Name>
+      <Name language="Ligurian">La Pátria</Name>
+      <Name language="Neapolitan">La Pátria</Name>
+      <Name language="Norman">La Patre</Name>
+      <Name language="Norman">Neopatrie</Name>
+      <Name language="Oghuz">Patracik</Name>
+      <Name language="Pecheneg">Patracik</Name>
       <Name language="Polish">Neopatria</Name>
-      <Name language="Latin">Hypata</Name>
+      <Name language="Sardinian">La Pátria</Name>
       <Name language="Serbian">Neopatrija</Name>
+      <Name language="Sicilian">La Pátria</Name>
+      <Name language="Slovene">Neopatrija</Name>
+      <Name language="Turkish_Old">Patracik</Name>
+      <Name language="Turkmen_Medieval">Patracik</Name>
+      <Name language="Tuscan_Medieval">La Pátria</Name>
+      <Name language="Umbrian_Medieval">La Pátria</Name>
+      <Name language="Venetian_Medieval">La Pátria</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15451,38 +15541,64 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_neopatras" order="1">c_thessalia</GameId>
       <GameId game="CK2HIP" parent="" order="11813">d_thessalia</GameId>
+      <GameId game="CK3">c_thessalia</GameId>
+      <GameId game="CK3">d_thessaly</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Tesalija</Name>
       <Name language="Bulgarian">Tesalija</Name>
-      <Name language="Slovene">Tesalija</Name>
       <Name language="Castilian">Tesalia</Name>
+      <Name language="Catalan_Medieval">Tessália</Name>
       <Name language="Croatian">Tesalija</Name>
+      <Name language="Dalmatian_Medieval">Tessaglia</Name>
       <Name language="Dutch_Middle">Thessalië</Name>
+      <Name language="English">Thessaly</Name>
       <Name language="Finnish">Thessalia</Name>
+      <Name language="French_Old">Thessalie</Name>
       <Name language="German">Thessalien</Name>
+      <Name language="Greek_Medieval">Thessalía</Name>
       <Name language="Hungarian">Thesszália</Name>
       <Name language="Icelandic">Þessalía</Name>
+      <Name language="Italian_Central">Tessaglia</Name>
+      <Name language="Italian_Medieval">Tessaglia</Name>
+      <Name language="Langobardic">Tessaglia</Name>
+      <Name language="Ligurian">Tessaglia</Name>
       <Name language="Lithuanian">Tesalija</Name>
+      <Name language="Neapolitan">Tessaglia</Name>
+      <Name language="Norman">Thessalie</Name>
       <Name language="Norwegian">Thessalia</Name>
+      <Name language="Oghuz">Tesalya</Name>
+      <Name language="Pecheneg">Tesalya</Name>
       <Name language="Polish">Tesalia</Name>
       <Name language="Portuguese">Tessália</Name>
-      <Name language="Latin">Hypata</Name>
       <Name language="Romanian">Tesalia</Name>
+      <Name language="Sardinian">Tessaglia</Name>
       <Name language="Serbian">Tesalija</Name>
+      <Name language="Sicilian">Tessaglia</Name>
       <Name language="Slovak">Tesália</Name>
+      <Name language="Slovene">Tesalija</Name>
       <Name language="Swedish">Thessalien</Name>
+      <Name language="Turkish_Old">Tesalya</Name>
+      <Name language="Turkmen_Medieval">Tesalya</Name>
+      <Name language="Tuscan_Medieval">Tessaglia</Name>
+      <Name language="Umbrian_Medieval">Tessaglia</Name>
+      <Name language="Venetian_Medieval">Tessaglia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>larissa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thessalia" order="1">b_larissa</GameId>
+      <GameId game="CK3">b_larissa</GameId>
+      <GameId game="ImperatorRome">389</GameId> <!-- Larissa -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Larisa</Name>
       <Name language="Bulgarian">Larisa</Name>
       <Name language="Croatian">Larisa</Name>
+      <Name language="Greek_Ancient">Larisa</Name>
+      <Name language="Greek_Medieval">Larissa</Name>
+      <Name language="Latin_Old">Larissa</Name>
       <Name language="Oghuz">Yenisehir i-Fenari</Name>
       <Name language="Pecheneg">Yenisehir i-Fenari</Name>
       <Name language="Serbian">Larisa</Name>
@@ -15495,11 +15611,13 @@
     <Id>elasson</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thessalia" order="2">b_elasson</GameId>
+      <GameId game="CK3">b_elasson</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Elasona</Name>
       <Name language="Bulgarian">Elasona</Name>
       <Name language="Croatian">Elasona</Name>
+      <Name language="Greek_Medieval">Elasson</Name>
       <Name language="Oghuz">Alasonya</Name>
       <Name language="Pecheneg">Alasonya</Name>
       <Name language="Serbian">Elasona</Name>
@@ -15512,9 +15630,11 @@
     <Id>platamon</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thessalia" order="3">b_platamon</GameId>
+      <GameId game="CK3">b_platamon</GameId>
     </GameIds>
     <Names>
       <Name language="French_Old">Platamonas</Name>
+      <Name language="Greek_Medieval">Platamon</Name>
       <Name language="Oghuz">Platamona</Name>
       <Name language="Pecheneg">Platamona</Name>
       <Name language="Turkish_Old">Platamona</Name>
@@ -15539,6 +15659,9 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_demetrias" order="1">b_demetrias</GameId>
       <GameId game="CK2HIP" parent="d_neopatras" order="2">c_demetrias</GameId>
+      <GameId game="CK3">b_demetrias</GameId>
+      <GameId game="CK3">c_demetrias</GameId>
+      <GameId game="ImperatorRome">391</GameId> <!-- Demetrias -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Dimitrijas</Name>
@@ -15546,9 +15669,12 @@
       <Name language="Croatian">Dimitrijas</Name>
       <Name language="Dalmatian_Medieval">Dimitrias</Name>
       <Name language="French_Old">Mitre</Name>
+      <Name language="Greek_Ancient">Pagasai</Name>
+      <Name language="Greek_Medieval">Demetrias</Name>
       <Name language="Italian_Central">Dimitrias</Name>
       <Name language="Italian_Medieval">Dimitrias</Name>
       <Name language="Langobardic">Dimitrias</Name>
+      <Name language="Latin_Old">Pagasae</Name>
       <Name language="Ligurian">Dimitrias</Name>
       <Name language="Neapolitan">Dimitrias</Name>
       <Name language="Norman">Mitre</Name>
@@ -15569,6 +15695,7 @@
     <Id>halmyros</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_demetrias" order="2">b_halmyros</GameId>
+      <GameId game="CK3">b_halmyros</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Almiros</Name>
@@ -15576,6 +15703,7 @@
       <Name language="Croatian">Almiros</Name>
       <Name language="Dalmatian_Medieval">Almiró</Name>
       <Name language="French_Old">L'Amiro</Name>
+      <Name language="Greek_Medieval">Halmyros</Name>
       <Name language="Italian_Central">Almiró</Name>
       <Name language="Italian_Medieval">Almiró</Name>
       <Name language="Langobardic">Almiró</Name>
@@ -15625,15 +15753,22 @@
     <Id>upper_wallachia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_neopatras" order="3">c_upper_wallachia</GameId>
+      <GameId game="CK3">c_thessaliotis</GameId>
     </GameIds>
     <Names>
+      <Name language="Aragonese">Gran Vlaquia</Name> <!-- Guessed, Translated -->
+      <Name language="Aragonese">Vlaquia la Gran</Name>
       <Name language="Bosnian">Velika Vlaška</Name>
       <Name language="Bulgarian">Velika Vlahija</Name>
       <Name language="Croatian">Velika Vlaška</Name>
+      <Name language="English">Great Wallachia</Name>
+      <Name language="German">Große Walachei</Name> <!-- Or Großwlachien -->
+      <Name language="Greek_Medieval">Megále Vlachia</Name>
+      <Name language="Italian">Grande Valacchia</Name>
       <Name language="Oghuz">Tirhala</Name>
       <Name language="Pecheneg">Tirhala</Name>
-      <Name language="Polish">Wielka Woloszczyzna</Name> <!-- Historical? Translated -->
-      <Name language="Romanian">Rumânia Mare</Name> <!-- Historical? Translated -->
+      <Name language="Polish">Wielka Wołoszczyzna</Name>
+      <Name language="Romanian">Vlahia Mare</Name> <!-- Sometimes: Tesalia Vlahă -->
       <Name language="Serbian_Medieval">Megalovlahija</Name>
       <Name language="Serbian">Velika Vlaška</Name>
       <Name language="Slovene">Velika Vlaška</Name>
@@ -15662,14 +15797,16 @@
     <Id>trikala</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_upper_wallachia" order="2">b_trikala</GameId>
+      <GameId game="CK3">b_trikala</GameId>
     </GameIds>
     <Names>
+      <Name language="Aromanian">Tricolj</Name> <!-- k instead of c ? -->
       <Name language="Bosnian">Trikolj</Name>
       <Name language="Bulgarian">Trikol</Name>
       <Name language="Croatian">Trikolj</Name>
+      <Name language="Greek_Medieval">Trikala</Name>
       <Name language="Oghuz">Tirhala</Name>
       <Name language="Pecheneg">Tirhala</Name>
-      <Name language="Romanian">Tricolj</Name> <!-- Aromanian; k instead of c ? -->
       <Name language="Serbian">Trikolj</Name>
       <Name language="Slovene">Trikolj</Name>
       <Name language="Turkish_Old">Tirhala</Name>
@@ -15680,12 +15817,14 @@
     <Id>grevena</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_upper_wallachia" order="3">b_grevena</GameId>
+      <GameId game="CK3">b_grevena</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Greben</Name>
       <Name language="Bulgarian_Old">Grebena</Name>
       <Name language="Bulgarian">Greben</Name>
       <Name language="Croatian">Greben</Name>
+      <Name language="Greek_Medieval">Grevená</Name>
       <Name language="Oghuz">Gerebena</Name>
       <Name language="Pecheneg">Gerebena</Name>
       <Name language="Romanian_Old">Grebini</Name>
@@ -15693,6 +15832,15 @@
       <Name language="Slovene">Greben</Name>
       <Name language="Turkish_Old">Gerebena</Name>
       <Name language="Turkmen_Medieval">Gerebena</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>stagoi</Id>
+    <GameIds>
+      <GameId game="CK3">b_stagoi</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Stagoi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -15712,6 +15860,7 @@
     <Id>zetounion</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_neopatras" order="1">b_zetounion</GameId>
+      <GameId game="CK3">b_zetouni</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Zituni</Name>
@@ -15719,6 +15868,7 @@
       <Name language="Croatian">Zituni</Name>
       <Name language="Dalmatian_Medieval">Citó</Name>
       <Name language="French_Old">Girton</Name>
+      <Name language="Greek_Medieval">Zetounion</Name>
       <Name language="Italian_Central">Citó</Name>
       <Name language="Italian_Medieval">Citó</Name>
       <Name language="Langobardic">Citó</Name>
@@ -15742,12 +15892,17 @@
     <Id>pharsalos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_neopatras" order="2">b_pharsalos</GameId>
+      <GameId game="CK3">b_pharsalos</GameId>
+      <GameId game="ImperatorRome">394</GameId> <!-- Pharsalos -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Farsal</Name>
       <Name language="Bulgarian">Farsal</Name>
       <Name language="Croatian">Farsal</Name>
       <Name language="French_Old">Ferselle</Name>
+      <Name language="Greek_Ancient">Pharsalos</Name>
+      <Name language="Greek_Medieval">Pharsalos</Name>
+      <Name language="Latin_Old">Pharsalus</Name>
       <Name language="Norman">Ferselle</Name>
       <Name language="Oghuz">Catalca</Name>
       <Name language="Pecheneg">Catalca</Name>
@@ -15761,6 +15916,7 @@
     <Id>domokos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_neopatras" order="4">b_domokos</GameId>
+      <GameId game="CK3">b_domokos</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Domok</Name>
@@ -15768,6 +15924,7 @@
       <Name language="Croatian">Domok</Name>
       <Name language="Dalmatian_Medieval">Domaco</Name>
       <Name language="French_Old">Donchie</Name>
+      <Name language="Greek_Medieval">Domokos</Name>
       <Name language="Italian_Central">Domaco</Name>
       <Name language="Italian_Medieval">Domaco</Name>
       <Name language="Langobardic">Domaco</Name>
@@ -15788,7 +15945,16 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>siderokastronthessaly</Id>
+    <Id>gardikia</Id>
+    <GameIds>
+      <GameId game="CK3">b_gardikia</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Gardikia</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>siderokastron_thessaly</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_neopatras" order="4">b_siderokastronthessaly</GameId>
     </GameIds>
@@ -18329,6 +18495,8 @@
     <Id>rhodos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_rhodos" order="1">b_rhodos</GameId>
+      <GameId game="CK3">b_rhodos</GameId>
+      <GameId game="CK3">c_rhodos</GameId>
       <GameId game="ImperatorRome">266</GameId> <!-- Rhodos -->
     </GameIds>
     <Names>
@@ -18346,6 +18514,7 @@
       <Name language="German_Old_Low">Rhodos</Name>
       <Name language="German">Rhodos</Name>
       <Name language="Greek_Ancient">Rhodos</Name>
+      <Name language="Greek_Medieval">Rhodos</Name>
       <Name language="Hungarian">Rodosz</Name>
       <Name language="Italian_Central">Rodi</Name>
       <Name language="Italian_Medieval">Rodi</Name>
@@ -18374,8 +18543,10 @@
     <Id>lindos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_rhodos" order="3">b_lindos</GameId>
+      <GameId game="CK3">b_lindos</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Lindos</Name>
       <Name language="Italian">Lindo</Name>
       <Name language="Oghuz">Lindoz</Name>
       <Name language="Turkish_Old">Lindoz</Name>
@@ -59747,8 +59918,10 @@
     <Id>velestino</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_demetrias" order="3">b_velestino</GameId>
+      <GameId game="CK3">b_velestino</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Velestinon</Name>
       <Name language="Oghuz">Velestin</Name>
       <Name language="Pecheneg">Velestin</Name>
       <Name language="Turkish_Old">Velestin</Name>
@@ -61245,8 +61418,12 @@
     <Id>kos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_rhodos" order="2">b_kos</GameId>
+      <GameId game="CK3">b_kos</GameId>
+      <GameId game="ImperatorRome">1970</GameId> <!-- Kos -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Kos</Name>
+      <Name language="Latin_Old">Cos</Name>
       <Name language="Oghuz">Istanköy</Name>
       <Name language="Turkish_Old">Istanköy</Name>
       <Name language="Turkmen_Medieval">Istanköy</Name>
@@ -61256,10 +61433,12 @@
     <Id>karpathos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_rhodos" order="4">b_karpathos</GameId>
+      <GameId game="CK3">b_karpathos</GameId>
       <GameId game="ImperatorRome">280</GameId> <!-- Karpathos -->
     </GameIds>
     <Names>
       <Name language="Greek_Ancient">Karpathos</Name>
+      <Name language="Greek_Medieval">Karpathos</Name>
       <Name language="Latin_Old">Carpathus</Name>
       <Name language="Oghuz">Kerpe</Name>
       <Name language="Turkish_Old">Kerpe</Name>
@@ -98820,8 +98999,10 @@
     <Id>rendina</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_chalkidike" order="4">b_rendina</GameId>
+      <GameId game="CK3">b_rendina</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Rendina</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -40234,7 +40234,17 @@
       <GameId game="CK2HIP" parent="c_devon" order="5">b_crediton</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Cridiantun</Name>
+      <Name language="English_Old_Norse">Cridiantun</Name>
+      <Name language="English_Old">Cridiantun</Name>
+      <Name language="English">Crediton</Name>
+      <Name language="Gothic">Cridiantun</Name>
+      <Name language="Icelandic_Old">Cridiantun</Name>
+      <Name language="Irish_Middle_Norse">Cridiantun</Name>
       <Name language="Latin">Cridia</Name>
+      <Name language="Norse">Cridiantun</Name>
+      <Name language="Norwegian_Old">Cridiantun</Name>
+      <Name language="Swedish_Old">Cridiantun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -40243,7 +40253,17 @@
       <GameId game="CK2HIP" parent="c_devon" order="6">b_tavistock</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Tæfingstoc</Name>
+      <Name language="English_Old_Norse">Tæfingstoc</Name>
+      <Name language="English_Old">Tæfingstoc</Name>
+      <Name language="English">Tavistock</Name>
+      <Name language="Gothic">Tæfingstoc</Name>
+      <Name language="Icelandic_Old">Tæfingstoc</Name>
+      <Name language="Irish_Middle_Norse">Tæfingstoc</Name>
       <Name language="Latin">Tavistochia</Name>
+      <Name language="Norse">Tæfingstoc</Name>
+      <Name language="Norwegian_Old">Tæfingstoc</Name>
+      <Name language="Swedish_Old">Tæfingstoc</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60279,6 +60299,21 @@
       <GameId game="CK2HIP" parent="c_chandax" order="3">b_sitia</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Sitia</Name>
+      <Name language="Italian_Central">Sitia</Name>
+      <Name language="Italian_Medieval">Sitia</Name>
+      <Name language="Langobardic">Sitia</Name>
+      <Name language="Ligurian">Sitia</Name>
+      <Name language="Neapolitan">Sitia</Name>
+      <Name language="Oghuz">Sitya</Name>
+      <Name language="Pecheneg">Sitya</Name>
+      <Name language="Sardinian">Sitia</Name>
+      <Name language="Sicilian">Sitia</Name>
+      <Name language="Turkish_Old">Sitya</Name>
+      <Name language="Turkmen_Medieval">Sitya</Name>
+      <Name language="Tuscan_Medieval">Sitia</Name>
+      <Name language="Umbrian_Medieval">Sitia</Name>
+      <Name language="Venetian_Medieval">Sitia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60287,6 +60322,17 @@
       <GameId game="CK2HIP" parent="c_chandax" order="5">b_palaeokastro_sitia</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Palaeocastro</Name>
+      <Name language="Italian_Central">Palaeocastro</Name>
+      <Name language="Italian_Medieval">Palaeocastro</Name>
+      <Name language="Langobardic">Palaeocastro</Name>
+      <Name language="Ligurian">Palaeocastro</Name>
+      <Name language="Neapolitan">Palaeocastro</Name>
+      <Name language="Sardinian">Palaeocastro</Name>
+      <Name language="Sicilian">Palaeocastro</Name>
+      <Name language="Tuscan_Medieval">Palaeocastro</Name>
+      <Name language="Umbrian_Medieval">Palaeocastro</Name>
+      <Name language="Venetian_Medieval">Palaeocastro</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60318,6 +60364,17 @@
       <GameId game="CK2HIP" parent="c_chandax" order="7">b_palaeokastro_iraklio</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Palaeocastro</Name>
+      <Name language="Italian_Central">Palaeocastro</Name>
+      <Name language="Italian_Medieval">Palaeocastro</Name>
+      <Name language="Langobardic">Palaeocastro</Name>
+      <Name language="Ligurian">Palaeocastro</Name>
+      <Name language="Neapolitan">Palaeocastro</Name>
+      <Name language="Sardinian">Palaeocastro</Name>
+      <Name language="Sicilian">Palaeocastro</Name>
+      <Name language="Tuscan_Medieval">Palaeocastro</Name>
+      <Name language="Umbrian_Medieval">Palaeocastro</Name>
+      <Name language="Venetian_Medieval">Palaeocastro</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -85959,6 +86016,7 @@
       <GameId game="CK2HIP" parent="c_maragheh" order="4">b_shiz</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Adur-Gushnasp</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -18055,6 +18055,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="k_candia" order="1">d_krete</GameId>
       <GameId game="CK2HIP" parent="e_byzantium" order="4">k_candia</GameId>
+      <GameId game="CK3">d_krete</GameId>
+      <GameId game="CK3">k_krete</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Iqrítish</Name>
@@ -18063,35 +18065,32 @@
       <Name language="Arabic_Levant">Iqrítish</Name>
       <Name language="Arabic_Maghreb">Iqrítish</Name>
       <Name language="Arabic_Yemen">Iqrítish</Name>
-      <Name language="Arpitan">Candie</Name>
       <Name language="Avar_Old">Krit</Name>
       <Name language="Bulgar">Krit</Name>
       <Name language="Bulgarian">Krit</Name>
-      <Name language="Dalmatian">Candia</Name>
-      <Name language="French_Old">Candie</Name>
+      <Name language="Dalmatian">Creta</Name>
+      <Name language="English">Crete</Name>
       <Name language="German">Kreta</Name>
       <Name language="Hejazi_Arabic">Iqrítish</Name>
-      <Name language="Italian_Central">Candia</Name>
-      <Name language="Italian_Medieval">Candia</Name>
-      <Name language="Langobardic">Candia</Name>
+      <Name language="Italian_Central">Creta</Name>
+      <Name language="Italian_Medieval">Creta</Name>
       <Name language="Latin">Creta</Name>
-      <Name language="Ligurian">Candia</Name>
-      <Name language="Neapolitan">Candia</Name>
-      <Name language="Norman">Candie</Name>
+      <Name language="Ligurian">Creta</Name>
+      <Name language="Neapolitan">Creta</Name>
       <Name language="Norse">Krít</Name>
       <Name language="Oghuz">Girit</Name>
       <Name language="Pecheneg">Girit</Name>
       <Name language="Polish">Kreta</Name>
       <Name language="Romanian">Creta</Name>
-      <Name language="Sardinian">Candia</Name>
+      <Name language="Sardinian">Creta</Name>
       <Name language="Sicilian_Arabic">Iqrítish</Name>
-      <Name language="Sicilian">Candia</Name>
+      <Name language="Sicilian">Creta</Name>
       <Name language="Turkish_Old">Girit</Name>
       <Name language="Turkish">Girit</Name>
       <Name language="Turkmen_Medieval">Girit</Name>
-      <Name language="Tuscan">Candia</Name>
-      <Name language="Umbrian_Medieval">Candia</Name>
-      <Name language="Venetian">Candia</Name>
+      <Name language="Tuscan">Creta</Name>
+      <Name language="Umbrian_Medieval">Creta</Name>
+      <Name language="Venetian">Creta</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -18124,9 +18123,11 @@
     <Id>paleohora</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_kaneia" order="6">b_paleohora</GameId>
+      <GameId game="CK3">b_paleohora</GameId>
     </GameIds>
     <Names>
       <Name language="Dalmatian_Medieval">Palaeohora</Name>
+      <Name language="Greek_Medieval">Palaiochora</Name>
       <Name language="Italian_Central">Palaeohora</Name>
       <Name language="Italian_Medieval">Palaeohora</Name>
       <Name language="Langobardic">Palaeohora</Name>
@@ -60122,31 +60123,55 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>kaneia</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_krete" order="1">c_kaneia</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>kandia</Id>
+    <Id>khandia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_kaneia" order="1">b_kandia</GameId>
+      <GameId game="CK2HIP" parent="d_krete" order="1">c_kaneia</GameId>
+      <GameId game="CK3">b_chania</GameId>
+      <GameId game="CK3">c_chania</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Al-Hanim</Name>
+      <Name language="Arabic_Bedouin">Al-Hanim</Name>
+      <Name language="Arabic_Egypt">Al-Hanim</Name>
+      <Name language="Arabic_Levant">Al-Hanim</Name>
+      <Name language="Arabic_Maghreb">Al-Hanim</Name>
+      <Name language="Arabic_Yemen">Al-Hanim</Name>
+      <Name language="Dalmatian_Medieval">Canea</Name>
+      <Name language="Greek_Medieval">Khanià</Name>
+      <Name language="Hejazi_Arabic">Al-Hanim</Name>
+      <Name language="Italian_Central">Canea</Name>
+      <Name language="Italian_Medieval">Canea</Name>
+      <Name language="Langobardic">Canea</Name>
+      <Name language="Ligurian">Canea</Name>
+      <Name language="Neapolitan">Canea</Name>
+      <Name language="Oghuz">Hanya</Name>
+      <Name language="Pecheneg">Hanya</Name>
+      <Name language="Sardinian">Canea</Name>
+      <Name language="Sicilian_Arabic">Al-Hanim</Name>
+      <Name language="Sicilian">Canea</Name>
+      <Name language="Turkish_Old">Hanya</Name>
+      <Name language="Turkmen_Medieval">Hanya</Name>
+      <Name language="Tuscan_Medieval">Canea</Name>
+      <Name language="Umbrian_Medieval">Canea</Name>
+      <Name language="Venetian_Medieval">Canea</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>rethymno</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_kaneia" order="2">b_rethymno</GameId>
+      <GameId game="CK3">b_rethymno</GameId>
+      <GameId game="ImperatorRome">351</GameId> <!-- Rhithymna -->
     </GameIds>
     <Names>
       <Name language="Dalmatian_Medieval">Rettimo</Name>
+      <Name language="Greek_Ancient">Eleutherna</Name>
+      <Name language="Greek_Medieval">Rhíthimna</Name>
       <Name language="Italian_Central">Rettimo</Name>
       <Name language="Italian_Medieval">Rettimo</Name>
       <Name language="Langobardic">Rettimo</Name>
+      <Name language="Latin_Old">Eleutherna</Name>
       <Name language="Ligurian">Rettimo</Name>
       <Name language="Neapolitan">Rettimo</Name>
       <Name language="Oghuz">Resmo</Name>
@@ -60182,25 +60207,70 @@
   <LocationEntity>
     <Id>chandax</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_krete" order="2">c_chandax</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>iraklio</Id>
-    <GameIds>
       <GameId game="CK2HIP" parent="c_chandax" order="1">b_iraklio</GameId>
+      <GameId game="CK2HIP" parent="d_krete" order="2">c_chandax</GameId>
+      <GameId game="CK3">b_iraklio</GameId>
+      <GameId game="CK3">c_chandax</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Khandaq</Name>
+      <Name language="Arabic_Bedouin">Khandaq</Name>
+      <Name language="Arabic_Egypt">Khandaq</Name>
+      <Name language="Arabic_Levant">Khandaq</Name>
+      <Name language="Arabic_Maghreb">Khandaq</Name>
+      <Name language="Arabic_Yemen">Khandaq</Name>
+      <Name language="Arpitan">Candie</Name>
+      <Name language="Dalmatian_Medieval">Candia</Name>
+      <Name language="Dalmatian">Candia</Name>
+      <Name language="French_Old">Candie</Name>
+      <Name language="Hejazi_Arabic">Khandaq</Name>
+      <Name language="Italian_Central">Candia</Name>
+      <Name language="Italian_Medieval">Candia</Name>
+      <Name language="Langobardic">Candia</Name>
+      <Name language="Ligurian">Candia</Name>
+      <Name language="Neapolitan">Candia</Name>
+      <Name language="Norman">Candie</Name>
+      <Name language="Oghuz">Kandiye</Name>
+      <Name language="Pecheneg">Kandiye</Name>
+      <Name language="Sardinian">Candia</Name>
+      <Name language="Sicilian_Arabic">Khandaq</Name>
+      <Name language="Sicilian">Candia</Name>
+      <Name language="Turkish_Old">Kandiye</Name>
+      <Name language="Turkmen_Medieval">Kandiye</Name>
+      <Name language="Tuscan_Medieval">Candia</Name>
+      <Name language="Tuscan">Candia</Name>
+      <Name language="Umbrian_Medieval">Candia</Name>
+      <Name language="Venetian_Medieval">Candia</Name>
+      <Name language="Venetian">Candia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>ierapetra</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_chandax" order="2">b_ierapetra</GameId>
+      <GameId game="CK3">b_ierapetra</GameId>
+      <GameId game="ImperatorRome">355</GameId> <!-- Ierapetra -->
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Gerapetra</Name>
+      <Name language="Greek_Ancient">Hierapytna</Name>
+      <Name language="Greek_Medieval">Hierà Pýtna</Name>
+      <Name language="Italian_Central">Gerapetra</Name>
+      <Name language="Italian_Medieval">Gerapetra</Name>
+      <Name language="Langobardic">Gerapetra</Name>
+      <Name language="Latin">Ierapetra</Name>
+      <Name language="Ligurian">Gerapetra</Name>
+      <Name language="Neapolitan">Gerapetra</Name>
+      <Name language="Oghuz">Yerapetre</Name>
+      <Name language="Pecheneg">Yerapetre</Name>
+      <Name language="Romanian">Ierapetra</Name>
+      <Name language="Sardinian">Gerapetra</Name>
+      <Name language="Sicilian">Gerapetra</Name>
+      <Name language="Turkish_Old">Yerapetre</Name>
+      <Name language="Turkmen_Medieval">Yerapetre</Name>
+      <Name language="Tuscan_Medieval">Gerapetra</Name>
+      <Name language="Umbrian_Medieval">Gerapetra</Name>
+      <Name language="Venetian_Medieval">Gerapetra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60223,8 +60293,23 @@
     <Id>agiosnikolaos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_chandax" order="6">b_agiosnikolaos</GameId>
+      <GameId game="CK3">b_agiosnikolaos</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">San Nicolo</Name>
+      <Name language="Greek_Medieval">Hagiós Nikolaos</Name>
+      <Name language="Italian_Central">San Nicolo</Name>
+      <Name language="Italian_Medieval">San Nicolo</Name>
+      <Name language="Langobardic">San Nicolo</Name>
+      <Name language="Ligurian">San Nicolo</Name>
+      <Name language="Neapolitan">San Nicolo</Name>
+      <Name language="Romanian_Old">Sfîntu Nicolae</Name> <!-- Translated / Or Sfîntul Nicolae-->
+      <Name language="Romanian">Sfântul Nicolae</Name> <!-- Translated -->
+      <Name language="Sardinian">San Nicolo</Name>
+      <Name language="Sicilian">San Nicolo</Name>
+      <Name language="Tuscan_Medieval">San Nicolo</Name>
+      <Name language="Umbrian_Medieval">San Nicolo</Name>
+      <Name language="Venetian_Medieval">San Nicolo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -19074,7 +19074,26 @@
       <GameId game="CK2HIP" parent="d_armenia_minor" order="5">c_alexandretta</GameId>
     </GameIds>
     <Names>
-      <Name language="Romanian">Alexandria Mică</Name>
+      <Name language="Arabic_Andalusia">Al-Iskandarun</Name>
+      <Name language="Arabic_Bedouin">Al-Iskandarun</Name>
+      <Name language="Arabic_Egypt">Al-Iskandarun</Name>
+      <Name language="Arabic_Levant">Al-Iskandarun</Name>
+      <Name language="Arabic_Maghreb">Al-Iskandarun</Name>
+      <Name language="Arabic_Yemen">Al-Iskandarun</Name>
+      <Name language="Armenian_Middle">Aleksandret</Name>
+      <Name language="French_Old">Alexandrette</Name>
+      <Name language="Hejazi_Arabic">Al-Iskandarun</Name>
+      <Name language="Masmuda">Al-Iskandarun</Name>
+      <Name language="Norman">Alexandrette</Name>
+      <Name language="Oghuz">Iskenderun</Name>
+      <Name language="Romanian">Alexandria Mică</Name> <!-- ??? -->
+      <Name language="Sanhaja">Al-Iskandarun</Name>
+      <Name language="Sicilian_Arabic">Al-Iskandarun</Name>
+      <Name language="Tuareg_Tagelmust">Al-Iskandarun</Name>
+      <Name language="Tuareg">Al-Iskandarun</Name>
+      <Name language="Turkish_Old">Iskenderun</Name>
+      <Name language="Turkmen_Medieval">Iskenderun</Name>
+      <Name language="Zenati">Al-Iskandarun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -19381,9 +19400,13 @@
     </GameIds>
     <Names>
       <Name language="Bosnian">Jetropole</Name>
-      <Name language="Slovene">Jetropole</Name>
       <Name language="Croatian">Jetropole</Name>
+      <Name language="Oghuz">Etrebolu</Name>
+      <Name language="Pecheneg">Etrebolu</Name>
       <Name language="Serbian">Jetropole</Name>
+      <Name language="Slovene">Jetropole</Name>
+      <Name language="Turkish_Old">Etrebolu</Name>
+      <Name language="Turkmen_Medieval">Etrebolu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -19437,7 +19460,6 @@
     <Id>dorostotum</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_dorostotum" order="3">b_silistra</GameId>
-      <GameId game="CK2HIP" parent="d_turnovo" order="3">c_dorostotum</GameId>
       <GameId game="CK3">b_dorostorum</GameId>
       <GameId game="CK3">c_dorostotum</GameId>
     </GameIds>
@@ -19554,17 +19576,25 @@
     <Id>preslav</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_dorostotum" order="5">b_preslav</GameId>
+      <GameId game="CK2HIP" parent="d_turnovo" order="3">c_dorostotum</GameId>
       <GameId game="CK3">b_preslav</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Preslav</Name>
       <Name language="Bulgarian">Preslav</Name>
-      <Name language="Slovene">Preslav</Name>
       <Name language="Castilian">Preslav</Name>
       <Name language="Croatian">Preslav</Name>
       <Name language="French_Old">Preslav</Name>
+      <Name language="Gothic_Crimean">Ioannoupolis</Name>
+      <Name language="Greek_Medieval">Ioannoupolis</Name>
+      <Name language="Latin_Medieval">Ioannopolis</Name>
+      <Name language="Oghuz">Stamboluk</Name>
+      <Name language="Pecheneg">Stamboluk</Name>
       <Name language="Serbian">Preslav</Name>
+      <Name language="Slovene">Preslav</Name>
       <Name language="Swedish">Preslav</Name>
+      <Name language="Turkish_Old">Stamboluk</Name>
+      <Name language="Turkmen_Medieval">Stamboluk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -19615,11 +19645,15 @@
     <Names>
       <Name language="Bosnian">Trjavna</Name>
       <Name language="Bulgarian">Trjavna</Name>
-      <Name language="Slovene">Trjavna</Name>
       <Name language="Croatian">Trjavna</Name>
+      <Name language="Oghuz">Travna</Name>
+      <Name language="Pecheneg">Travna</Name>
       <Name language="Polish">Trjawna</Name>
       <Name language="Romanian">Treavna</Name>
       <Name language="Serbian">Trjavna</Name>
+      <Name language="Slovene">Trjavna</Name>
+      <Name language="Turkish_Old">Travna</Name>
+      <Name language="Turkmen_Medieval">Travna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -24770,7 +24804,7 @@
       <Name language="English">Greater Poland</Name>
       <Name language="Frankish_Low">Großpolen</Name>
       <Name language="Frankish">Grosspolen</Name>
-      <Name language="French_Old">Großpolen</Name>
+      <Name language="French">Grande-Pologne</Name>
       <Name language="German_Middle_Low">Großpolen</Name>
       <Name language="German_Old_Low">Großpolen</Name>
       <Name language="German">Großpolen</Name>
@@ -37127,7 +37161,8 @@
       <GameId game="CK2HIP" parent="e_arabia" order="4">k_egypt</GameId>
     </GameIds>
     <Names>
-       <Name language="Armenian">Yegiptos</Name>
+      <Name language="Amharic">Gibs</Name>
+      <Name language="Armenian">Yegiptos</Name>
       <Name language="Basque">Egipto</Name>
       <Name language="Breton_Middle">Egipt</Name>
       <Name language="Bulgarian">Egipet</Name>
@@ -37155,8 +37190,10 @@
       <Name language="Latin_Medieval">Aegyptus</Name>
       <Name language="Lithuanian">Egiptas</Name>
       <Name language="Lombard">Egit</Name>
+      <Name language="Masmuda">Igibt</Name>
       <Name language="Norman">Égypte</Name>
       <Name language="Norse">Egiptaland</Name>
+      <Name language="Nubian_Old">Khemi</Name>
       <Name language="Occitan">Egipte</Name>
       <Name language="Pictish">an Èiphit</Name>
       <Name language="Polish">Egipt</Name>
@@ -37165,15 +37202,18 @@
       <Name language="Romanian">Egipt</Name>
       <Name language="Russian">Yegipet</Name>
       <Name language="Sami">Egypta</Name>
+      <Name language="Sanhaja">Igibt</Name>
       <Name language="Scottish_Gaelic">An Èipheit</Name>
       <Name language="Serbian">Egipat</Name>
       <Name language="Slovene">Egipt</Name>
       <Name language="Sorbian">Egipt</Name>
       <Name language="Swedish">Egypten</Name>
+      <Name language="Tuareg_Tagelmust">Igibt</Name>
       <Name language="Tuareg">Igibt</Name>
       <Name language="Turkish">Misir</Name>
       <Name language="Welsh">Yr Aifft</Name>
       <Name language="Yiddish">Mitsroim</Name>
+      <Name language="Zenati">Igibt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37182,6 +37222,7 @@
       <GameId game="CK2HIP" parent="c_alexandria" order="1">b_alexandria</GameId>
       <GameId game="CK2HIP" parent="d_alexandria" order="1">c_alexandria</GameId>
       <GameId game="CK2HIP" parent="k_egypt" order="1">d_alexandria</GameId>
+      <GameId game="ImperatorRome">516</GameId> <!-- Alexandria -->
     </GameIds>
     <Names>
       <Name language="Aragonese">Aleixandría</Name>
@@ -37190,25 +37231,36 @@
       <Name language="Croatian">Aleksandrija</Name>
       <Name language="Czech">Alexandrie</Name>
       <Name language="Dutch_Middle">Alexandrië</Name>
+      <Name language="Egyptian_Coptic">Rakote</Name>
+      <Name language="Egyptian_Late">Rhakote</Name>
       <Name language="Estonian">Aleksandria</Name>
       <Name language="Finnish">Aleksandria</Name>
       <Name language="French_Old">Alexandrie</Name>
       <Name language="Frisian_Old">Aleksandrje</Name>
+      <Name language="Greek_Ancient">Alexandreia</Name>
+      <Name language="Greek_Medieval">Alexandreia</Name>
       <Name language="Irish">Alastair</Name>
       <Name language="Italian">Alessandria</Name>
       <Name language="Latgalian">Aleksandrija</Name>
+      <Name language="Latin_Old">Alexandria</Name>
       <Name language="Latin">Alexandria Magna</Name>
       <Name language="Lithuanian">Aleksandrija</Name>
-      <Name language="Neapolitan">Alessandria e Naggitto</Name>
+      <Name language="Masmuda">Taskendrit</Name>
+      <Name language="Neapolitan">Alessandria</Name>
+      <Name language="Nubian_Old">Alexandre</Name>
       <Name language="Polish">Aleksandria</Name>
       <Name language="Romanian">Alexandria</Name>
+      <Name language="Sanhaja">Taskendrit</Name>
       <Name language="Sardinian">Lisàndria</Name>
       <Name language="Sicilian">Alessandria</Name>
       <Name language="Slovene">Aleksandrija</Name>
+      <Name language="Tuareg_Tagelmust">Taskendrit</Name>
+      <Name language="Tuareg">Taskendrit</Name>
       <Name language="Turkish">Iskenderiye</Name>
       <Name language="Venetian">Alesandria</Name>
       <Name language="Vepsian">Aleksandrii</Name>
       <Name language="Wolof">Alegsàndiri</Name>
+      <Name language="Zenati">Taskendrit</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37331,30 +37383,50 @@
       <GameId game="CK2HIP" parent="c_cairo" order="1">b_cairo</GameId>
       <GameId game="CK2HIP" parent="d_cairo" order="1">c_cairo</GameId>
       <GameId game="CK2HIP" parent="k_egypt" order="3">d_cairo</GameId>
+      <GameId game="ImperatorRome">536</GameId> <!-- Babylon -->
     </GameIds>
     <Names>
+      <Name language="Amharic">Kayro</Name>
+      <Name language="Arabic_Andalusia">Qáhira</Name>
+      <Name language="Arabic_Bedouin">Qáhira</Name>
+      <Name language="Arabic_Egypt">Qáhira</Name>
+      <Name language="Arabic_Levant">Qáhira</Name>
+      <Name language="Arabic_Maghreb">Qáhira</Name>
+      <Name language="Arabic_Yemen">Qáhira</Name>
       <Name language="Arpitan">Lo Cayiro</Name>
       <Name language="Basque">Kairo</Name>
       <Name language="Catalan">El Caire</Name>
       <Name language="Croatian">Kairo</Name>
       <Name language="Czech">Káhira</Name>
       <Name language="Danish">Kairo</Name>
+      <Name language="Egyptian_Coptic">Kahire</Name>
+      <Name language="Egyptian_Late">Per-Hapu-Lon</Name>
       <Name language="Estonian">Kairo</Name>
       <Name language="Finnish">Kairo</Name>
       <Name language="French_Old">Le Caire</Name>
       <Name language="German">Kairo</Name>
+      <Name language="Greek_Ancient">Babylon Aigyptou</Name>
+      <Name language="Greek_Medieval">Babylon</Name>
+      <Name language="Hejazi_Arabic">Qáhira</Name>
       <Name language="Hungarian">Kairó</Name>
       <Name language="Icelandic">Kaíró</Name>
       <Name language="Latgalian">Kaira</Name>
+      <Name language="Latin_Old">Babilona Aegyptum</Name>
       <Name language="Lithuanian">Kairas</Name>
+      <Name language="Masmuda">Taqahirt</Name>
       <Name language="Norwegian">Kairo</Name>
       <Name language="Polish">Kair</Name>
       <Name language="Romanian">Cairo</Name>
+      <Name language="Sanhaja">Taqahirt</Name>
+      <Name language="Sicilian_Arabic">Qáhira</Name>
       <Name language="Sicilian">Cairu</Name>
       <Name language="Slovak">Káhira</Name>
       <Name language="Slovene">Kairo</Name>
       <Name language="Swedish">Kairo</Name>
+      <Name language="Tuareg_Tagelmust">Taqahirt</Name>
+      <Name language="Tuareg">Taqahirt</Name>
       <Name language="Turkish">Kahire</Name>
+      <Name language="Zenati">Taqahirt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37518,14 +37590,20 @@
     <Id>isna</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_aswan" order="4">b_isna</GameId>
+      <GameId game="ImperatorRome">574</GameId> <!-- Latopolis -->
     </GameIds>
     <Names>
       <Name language="Castilian">Esna</Name>
       <Name language="Catalan">Esna</Name>
       <Name language="Dutch_Middle">Esna</Name>
+      <Name language="Egyptian_Coptic">Sne</Name>
+      <Name language="Egyptian_Late">Senet</Name>
       <Name language="French_Old">Esna</Name>
       <Name language="German">Esna</Name>
+      <Name language="Greek_Ancient">Lato Polis</Name>
       <Name language="Italian">Esna</Name>
+      <Name language="Latin_Medieval">Latopolis</Name>
+      <Name language="Latin_Old">Latopolis</Name>
       <Name language="Lithuanian">Esna</Name>
       <Name language="Portuguese">Esna</Name>
       <Name language="Swedish">Esna</Name>
@@ -37593,10 +37671,12 @@
       <GameId game="CK2HIP" parent="c_benghazi" order="6">b_susabenghazi</GameId>
     </GameIds>
     <Names>
-      <Name language="Czech">Súsy</Name>
       <Name language="Catalan">Sussa</Name>
+      <Name language="Czech">Súsy</Name>
       <Name language="French_Old">Suse</Name>
+      <Name language="Greek_Medieval">Apollonia</Name>
       <Name language="Hungarian">Szúsza</Name>
+      <Name language="Latin_Medieval">Apollonia</Name>
       <Name language="Lithuanian">Susas</Name>
       <Name language="Polish">Suza</Name>
       <Name language="Slovak">Súsy</Name>
@@ -37607,15 +37687,25 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_tobruk" order="1">b_tobruk</GameId>
       <GameId game="CK2HIP" parent="d_cyrenaica" order="4">c_tobruk</GameId>
+      <GameId game="ImperatorRome">3370</GameId> <!-- Antipyrgos -->
     </GameIds>
     <Names>
       <Name language="Dutch_Middle">Tobroek</Name>
-      <Name language="French_Old">Tobrouk</Name>
-      <Name language="Italian">Tobruch</Name>
-      <Name language="Lithuanian">Tubrukas</Name>
-      <Name language="Norwegian">Tobruch</Name>
       <Name language="Estonian">Tubruq</Name>
+      <Name language="French_Old">Tobrouk</Name>
+      <Name language="Greek_Ancient">Antipyrgos</Name>
+      <Name language="Greek_Medieval">Antipyrgos</Name>
+      <Name language="Italian">Tobruch</Name>
+      <Name language="Latin_Medieval">Antipyrgus</Name>
+      <Name language="Latin_Old">Antipyrgus</Name>
+      <Name language="Lithuanian">Tubrukas</Name>
+      <Name language="Masmuda">Tubruq</Name>
+      <Name language="Norwegian">Tobruch</Name>
+      <Name language="Sanhaja">Tubruq</Name>
+      <Name language="Tuareg_Tagelmust">Tubruq</Name>
+      <Name language="Tuareg">Tubruq</Name>
       <Name language="Welsh">Tobruch</Name>
+      <Name language="Zenati">Tubruq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37633,14 +37723,18 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_el-arish" order="1">b_arish</GameId>
       <GameId game="CK2HIP" parent="d_sinai" order="3">c_el-arish</GameId>
+      <GameId game="ImperatorRome">656</GameId> <!-- Rinokoloura -->
     </GameIds>
     <Names>
       <Name language="Catalan">Al-Arix</Name>
       <Name language="Czech">Aríš</Name>
+      <Name language="Egyptian_Coptic">Hrinokorura</Name>
       <Name language="French_Old">El-Arich</Name>
       <Name language="German">Al-Arisch</Name>
+      <Name language="Greek_Ancient">Rinokoloura</Name>
       <Name language="Greek_Medieval">Rinokoloura</Name>
       <Name language="Latin_Medieval">Rhinocolura</Name>
+      <Name language="Latin_Old">Rhinocolura</Name>
       <Name language="Lithuanian">Arišas</Name>
       <Name language="Polish">Al-Arisz</Name>
       <Name language="Portuguese">Alarixe</Name>
@@ -37691,6 +37785,7 @@
   <LocationEntity>
     <Id>aleppo</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_aleppo" order="1">b_aleppocastle</GameId>
       <GameId game="CK2HIP" parent="c_aleppo" order="1">b_aleppo</GameId>
       <GameId game="CK2HIP" parent="d_aleppo" order="1">c_aleppo</GameId>
     </GameIds>
@@ -37725,8 +37820,8 @@
       <GameId game="CK2HIP" parent="k_syria" order="1">d_aleppo</GameId>
     </GameIds>
     <Names>
-      <Name language="Greek_Medieval">Syria Prima</Name>
-      <Name language="Latin_Medieval">Syria Prima</Name>
+      <Name language="Greek_Medieval">Chalkis</Name>
+      <Name language="Latin_Medieval">Chalcis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37752,14 +37847,21 @@
   <LocationEntity>
     <Id>homs</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_homs" order="5">b_citadelofhoms</GameId>
       <GameId game="CK2HIP" parent="c_homs" order="1">b_homs</GameId>
       <GameId game="CK2HIP" parent="d_homs" order="1">c_homs</GameId>
       <GameId game="CK2HIP" parent="k_syria" order="2">d_homs</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Chamelle</Name>
+      <Name language="French_Old">La Chamelle</Name>
+      <Name language="Greek_Medieval">Emesa</Name>
       <Name language="Hungarian">Homsz</Name>
       <Name language="Latgalian">Himsa</Name>
+      <Name language="Latin_Medieval">Emesa</Name>
       <Name language="Lithuanian">Homsas</Name>
+      <Name language="Norman">Chamelle</Name>
+      <Name language="Norman">La Chamelle</Name>
       <Name language="Turkish">Humus</Name>
     </Names>
   </LocationEntity>
@@ -37800,6 +37902,7 @@
       <GameId game="CK2HIP" parent="c_damascus" order="2">b_damascus</GameId>
       <GameId game="CK2HIP" parent="d_damascus" order="1">c_damascus</GameId>
       <GameId game="CK2HIP" parent="k_syria" order="3">d_damascus</GameId>
+      <GameId game="ImperatorRome">750</GameId> <!-- Damascus -->
     </GameIds>
     <Names>
       <Name language="Aragonese">Domás</Name>
@@ -37818,11 +37921,15 @@
       <Name language="Galician">Damasco</Name>
       <Name language="Georgian">Damasko</Name>
       <Name language="German">Damaskus</Name>
+      <Name language="Greek_Ancient">Damaskos</Name>
+      <Name language="Greek_Medieval">Damaskos</Name>
       <Name language="Hungarian">Damaszkusz</Name>
       <Name language="Icelandic">Damaskus</Name>
       <Name language="Irish">An Damaisc</Name>
       <Name language="Italian">Damasco</Name>
       <Name language="Latgalian">Damaska</Name>
+      <Name language="Latin_Medieval">Damascus</Name>
+      <Name language="Latin_Old">Damascus</Name>
       <Name language="Ligurian">Damasco</Name>
       <Name language="Lithuanian">Damaskas</Name>
       <Name language="Lombard">Damasch</Name>
@@ -46118,8 +46225,10 @@
       <GameId game="CK2HIP" parent="d_napoli" order="1">c_napoli</GameId>
     </GameIds>
     <Names>
+      <Name language="French">Acerra</Name>
       <Name language="Italian">Acerra</Name>
       <Name language="Latin">Acerrae</Name>
+      <Name language="Oscan">Akeru</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -46163,6 +46272,7 @@
     </GameIds>
     <Names>
       <Name language="Greek_Medieval">Amalphe</Name>
+      <Name language="Italian">Amalfi</Name>
       <Name language="Latin">Amalphia</Name>
       <Name language="Lithuanian">Amalfis</Name>
     </Names>
@@ -62314,19 +62424,18 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>amasia</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_armeniacon" order="1">c_amasia</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>amaseia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_amasia" order="1">b_amaseia</GameId>
+      <GameId game="CK2HIP" parent="d_armeniacon" order="1">c_amasia</GameId>
+      <GameId game="ImperatorRome">1819</GameId> <!-- Amaseia -->
     </GameIds>
     <Names>
+      <Name language="French_Old">Amasée</Name>
+      <Name language="Norman">Amasée</Name>
+      <Name language="Oghuz">Amásiyya</Name>
+      <Name language="Turkish_Old">Amasya</Name> <!-- Or Amásiyya -->
+      <Name language="Turkmen_Medieval">Amásiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62357,6 +62466,9 @@
       <GameId game="CK2HIP" parent="c_amasia" order="5">b_komanapontica</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Kumanat</Name>
+      <Name language="Turkish_Old">Kumanat</Name>
+      <Name language="Turkmen_Medieval">Kumanat</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62718,6 +62830,20 @@
       <GameId game="CK2HIP" parent="c_alexandretta" order="2">b_rhosus</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hisn Rusus</Name>
+      <Name language="Arabic_Bedouin">Hisn Rusus</Name>
+      <Name language="Arabic_Egypt">Hisn Rusus</Name>
+      <Name language="Arabic_Levant">Hisn Rusus</Name>
+      <Name language="Arabic_Maghreb">Hisn Rusus</Name>
+      <Name language="Arabic_Yemen">Hisn Rusus</Name>
+      <Name language="Armenian_Middle">Hrosos</Name>
+      <Name language="French_Old">Port Bonnel</Name>
+      <Name language="Hejazi_Arabic">Hisn Rusus</Name>
+      <Name language="Norman">Port Bonnel</Name>
+      <Name language="Oghuz">Arsuz</Name>
+      <Name language="Sicilian_Arabic">Hisn Rusus</Name>
+      <Name language="Turkish_Old">Arsuz</Name>
+      <Name language="Turkmen_Medieval">Arsuz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62726,6 +62852,20 @@
       <GameId game="CK2HIP" parent="c_alexandretta" order="3">b_payas</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bayyas</Name>
+      <Name language="Arabic_Bedouin">Bayyas</Name>
+      <Name language="Arabic_Egypt">Bayyas</Name>
+      <Name language="Arabic_Levant">Bayyas</Name>
+      <Name language="Arabic_Maghreb">Bayyas</Name>
+      <Name language="Arabic_Yemen">Bayyas</Name>
+      <Name language="Armenian_Middle">Payas</Name>
+      <Name language="French_Old">Baiesses</Name>
+      <Name language="Hejazi_Arabic">Bayyas</Name>
+      <Name language="Norman">Baiesses</Name>
+      <Name language="Oghuz">Yakacik</Name>
+      <Name language="Sicilian_Arabic">Bayyas</Name>
+      <Name language="Turkish_Old">Yakacik</Name>
+      <Name language="Turkmen_Medieval">Yakacik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62734,6 +62874,9 @@
       <GameId game="CK2HIP" parent="c_alexandretta" order="4">b_portella</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Sariseki</Name>
+      <Name language="Turkish_Old">Sariseki</Name>
+      <Name language="Turkmen_Medieval">Sariseki</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62742,6 +62885,12 @@
       <GameId game="CK2HIP" parent="c_alexandretta" order="5">b_bagras</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Bagras</Name>
+      <Name language="French_Old">Gaston</Name>
+      <Name language="Norman">Gaston</Name>
+      <Name language="Oghuz">Bakras</Name>
+      <Name language="Turkish_Old">Bakras</Name>
+      <Name language="Turkmen_Medieval">Bakras</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62750,6 +62899,9 @@
       <GameId game="CK2HIP" parent="c_alexandretta" order="6">b_myriandus</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Madenli</Name>
+      <Name language="Turkish_Old">Madenli</Name>
+      <Name language="Turkmen_Medieval">Madenli</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62783,6 +62935,20 @@
       <GameId game="CK2HIP" parent="c_seleukeia" order="1">b_corycus</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qurqus</Name>
+      <Name language="Arabic_Bedouin">Qurqus</Name>
+      <Name language="Arabic_Egypt">Qurqus</Name>
+      <Name language="Arabic_Levant">Qurqus</Name>
+      <Name language="Arabic_Maghreb">Qurqus</Name>
+      <Name language="Arabic_Yemen">Qurqus</Name>
+      <Name language="Armenian_Middle">Kiwrikos</Name>
+      <Name language="French_Old">Curchus</Name>
+      <Name language="Hejazi_Arabic">Qurqus</Name>
+      <Name language="Norman">Curchus</Name>
+      <Name language="Oghuz">Ghorgos</Name>
+      <Name language="Sicilian_Arabic">Qurqus</Name>
+      <Name language="Turkish_Old">Ghorgos</Name>
+      <Name language="Turkmen_Medieval">Ghorgos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62791,6 +62957,10 @@
       <GameId game="CK2HIP" parent="c_seleukeia" order="3">b_lamas</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Lamas</Name>
+      <Name language="Oghuz">Limonlu</Name>
+      <Name language="Turkish_Old">Limonlu</Name>
+      <Name language="Turkmen_Medieval">Limonlu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62799,6 +62969,9 @@
       <GameId game="CK2HIP" parent="c_seleukeia" order="4">b_korasion</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Susanoglu</Name>
+      <Name language="Turkish_Old">Susanoglu</Name>
+      <Name language="Turkmen_Medieval">Susanoglu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62807,6 +62980,18 @@
       <GameId game="CK2HIP" parent="c_seleukeia" order="5">b_novumola</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tokmar</Name>
+      <Name language="Arabic_Bedouin">Tokmar</Name>
+      <Name language="Arabic_Egypt">Tokmar</Name>
+      <Name language="Arabic_Levant">Tokmar</Name>
+      <Name language="Arabic_Maghreb">Tokmar</Name>
+      <Name language="Arabic_Yemen">Tokmar</Name>
+      <Name language="Hejazi_Arabic">Tokmar</Name>
+      <Name language="Kurdish">Tokmar</Name>
+      <Name language="Oghuz">Tokmar</Name>
+      <Name language="Sicilian_Arabic">Tokmar</Name>
+      <Name language="Turkish_Old">Tokmar</Name>
+      <Name language="Turkmen_Medieval">Tokmar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62823,6 +63008,18 @@
       <GameId game="CK2HIP" parent="c_anamur" order="4">b_germanikopolis</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Armanak</Name>
+      <Name language="Arabic_Bedouin">Armanak</Name>
+      <Name language="Arabic_Egypt">Armanak</Name>
+      <Name language="Arabic_Levant">Armanak</Name>
+      <Name language="Arabic_Maghreb">Armanak</Name>
+      <Name language="Arabic_Yemen">Armanak</Name>
+      <Name language="Armenian_Middle">Germanik</Name>
+      <Name language="Hejazi_Arabic">Armanak</Name>
+      <Name language="Oghuz">Ermenek</Name>
+      <Name language="Sicilian_Arabic">Armanak</Name>
+      <Name language="Turkish_Old">Ermenek</Name>
+      <Name language="Turkmen_Medieval">Ermenek</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62831,6 +63028,20 @@
       <GameId game="CK2HIP" parent="c_anamur" order="3">b_anemurium</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ma'muriya</Name>
+      <Name language="Arabic_Bedouin">Ma'muriya</Name>
+      <Name language="Arabic_Egypt">Ma'muriya</Name>
+      <Name language="Arabic_Levant">Ma'muriya</Name>
+      <Name language="Arabic_Maghreb">Ma'muriya</Name>
+      <Name language="Arabic_Yemen">Ma'muriya</Name>
+      <Name language="Armenian_Middle">Anamur</Name>
+      <Name language="French_Old">Stallimuri</Name>
+      <Name language="Hejazi_Arabic">Ma'muriya</Name>
+      <Name language="Norman">Stallimuri</Name>
+      <Name language="Oghuz">Anamur</Name>
+      <Name language="Sicilian_Arabic">Ma'muriya</Name>
+      <Name language="Turkish_Old">Anamur</Name>
+      <Name language="Turkmen_Medieval">Anamur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62839,6 +63050,10 @@
       <GameId game="CK2HIP" parent="c_anamur" order="4">b_antiochiamikra</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Antiok'</Name>
+      <Name language="Oghuz">Güney</Name>
+      <Name language="Turkish_Old">Güney</Name>
+      <Name language="Turkmen_Medieval">Güney</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62847,6 +63062,10 @@
       <GameId game="CK2HIP" parent="c_anamur" order="5">b_mut_seleukeia</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Mud</Name>
+      <Name language="Oghuz">Mut</Name>
+      <Name language="Turkish_Old">Mut</Name>
+      <Name language="Turkmen_Medieval">Mut</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62855,6 +63074,9 @@
       <GameId game="CK2HIP" parent="c_anamur" order="6">b_selinus</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Selinti</Name>
+      <Name language="Turkish_Old">Selinti</Name>
+      <Name language="Turkmen_Medieval">Selinti</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62863,6 +63085,9 @@
       <GameId game="CK2HIP" parent="c_anamur" order="7">b_seguik</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Tekmen</Name>
+      <Name language="Turkish_Old">Tekmen</Name>
+      <Name language="Turkmen_Medieval">Tekmen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62871,6 +63096,11 @@
       <GameId game="CK2HIP" parent="c_tyrnovo" order="2">b_kilifarevo</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Kephálos</Name>
+      <Name language="Oghuz">Kilifar</Name>
+      <Name language="Pecheneg">Kilifar</Name>
+      <Name language="Turkish_Old">Kilifar</Name>
+      <Name language="Turkmen_Medieval">Kilifar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -62879,6 +63109,9 @@
       <GameId game="CK2HIP" parent="c_dorostotum" order="4">b_pliska</GameId>
     </GameIds>
     <Names>
+      <Name language="Gothic_Crimean">Aboba</Name>
+      <Name language="Greek_Medieval">Aboba</Name>
+      <Name language="Latin_Medieval">Aboba</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67370,8 +67603,11 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_kharija" order="1">b_kharija</GameId>
       <GameId game="CK2HIP" parent="d_alwahat" order="1">c_kharija</GameId>
+      <GameId game="ImperatorRome">5504</GameId> <!-- Hibis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Hibis</Name>
+      <Name language="Latin_Medieval">Hibis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67380,8 +67616,11 @@
       <GameId game="CK2HIP" parent="c_dakhila" order="1">b_dakhila</GameId>
       <GameId game="CK2HIP" parent="d_alwahat" order="2">c_dakhila</GameId>
       <GameId game="CK2HIP" parent="" order="11795">d_dakhila</GameId>
+      <GameId game="ImperatorRome">5510</GameId> <!-- Mothis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Mothis</Name>
+      <Name language="Latin_Medieval">Mothis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67407,8 +67646,11 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_bahriya" order="1">b_bahriya</GameId>
       <GameId game="CK2HIP" parent="d_alwahat" order="3">c_bahriya</GameId>
+      <GameId game="ImperatorRome">5995</GameId> <!-- Oasis Parva -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Oasis Mikra</Name>
+      <Name language="Latin_Medieval">Oasis Parva</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67417,22 +67659,24 @@
       <GameId game="CK2HIP" parent="c_fayyum" order="3">b_iqna</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>quattara</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_alwahat" order="5">c_quattara</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Egyptian_Coptic">Kuna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>santariya</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_quattara" order="1">b_santariya</GameId>
+      <GameId game="CK2HIP" parent="d_alwahat" order="5">c_quattara</GameId>
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Sekhetam</Name>
+      <Name language="Greek_Medieval">Ammonion</Name>
+      <Name language="Latin_Medieval">Ammonium</Name>
+      <Name language="Masmuda">Síwa</Name>
+      <Name language="Sanhaja">Síwa</Name>
+      <Name language="Tuareg_Tagelmust">Síwa</Name>
+      <Name language="Tuareg">Síwa</Name>
+      <Name language="Zenati">Síwa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67444,19 +67688,15 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>quena</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_aswan" order="1">c_quena</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>kosseir</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_quena" order="2">b_kosseir</GameId>
+      <GameId game="CK2HIP" parent="d_aswan" order="1">c_quena</GameId>
+      <GameId game="ImperatorRome">580</GameId> <!-- Myos Hormos -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Myos Hormos</Name>
+      <Name language="Latin_Medieval">Myos Hormos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67465,14 +67705,19 @@
       <GameId game="CK2HIP" parent="c_quena" order="3">b_safaga</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Philotera</Name>
+      <Name language="Latin_Medieval">Philotera</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>marsaalam</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_quena" order="4">b_marsaalam</GameId>
+      <GameId game="ImperatorRome">587</GameId> <!-- Nechesia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Nechesia</Name>
+      <Name language="Latin_Medieval">Nechesia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67482,14 +67727,32 @@
       <GameId game="CK2HIP" parent="d_aswan" order="2">c_manfalut</GameId>
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Manbalot</Name>
+      <Name language="Greek_Medieval">Manbalot</Name>
+      <Name language="Latin_Medieval">Manbalot</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>ushmun</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_manfalut" order="3">b_ushmun</GameId>
+      <GameId game="ImperatorRome">549</GameId> <!-- Hermopolis Magna -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Al-Ushmúnayn</Name>
+      <Name language="Arabic_Bedouin">Al-Ushmúnayn</Name>
+      <Name language="Arabic_Egypt">Al-Ushmúnayn</Name>
+      <Name language="Arabic_Levant">Al-Ushmúnayn</Name>
+      <Name language="Arabic_Maghreb">Al-Ushmúnayn</Name>
+      <Name language="Arabic_Yemen">Al-Ushmúnayn</Name>
+      <Name language="Egyptian_Coptic">Shmounein</Name>
+      <Name language="Egyptian_Late">Khemenu</Name>
+      <Name language="Greek_Ancient">Hermou Polis Megale</Name>
+      <Name language="Greek_Medieval">Hermopolis Megas</Name>
+      <Name language="Hejazi_Arabic">Al-Ushmúnayn</Name>
+      <Name language="Latin_Medieval">Hermopolis Magna</Name>
+      <Name language="Latin_Old">Hermopolis Magna</Name>
+      <Name language="Sicilian_Arabic">Al-Ushmúnayn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67497,16 +67760,28 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_ikhmin" order="1">b_ikhmin</GameId>
       <GameId game="CK2HIP" parent="d_aswan" order="3">c_ikhmin</GameId>
+      <GameId game="ImperatorRome">557</GameId> <!-- Panopolis -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Shmin</Name>
+      <Name language="Egyptian_Late">Arty-Heru</Name>
+      <Name language="Greek_Ancient">Panopolis</Name>
+      <Name language="Greek_Medieval">Panopolis</Name>
+      <Name language="Latin_Old">Pano</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>hu</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_ikhmin" order="2">b_hu</GameId>
+      <GameId game="ImperatorRome">562</GameId> <!-- Diospolis -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Late">Hut-Sekhem</Name>
+      <Name language="Greek_Ancient">Diospolis</Name>
+      <Name language="Greek_Medieval">Diospolis Mikra</Name>
+      <Name language="Latin_Medieval">Diospolis Micra</Name>
+      <Name language="Latin_Old">Diospolis Parva</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67514,24 +67789,48 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_qus" order="1">b_qus</GameId>
       <GameId game="CK2HIP" parent="d_aswan" order="4">c_qus</GameId>
+      <GameId game="ImperatorRome">567</GameId> <!-- Apollonopolis Parva -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Late">Kaysit</Name>
+      <Name language="Greek_Ancient">Apollonopolis Mikra</Name>
+      <Name language="Greek_Medieval">Apollinopolis Mikra</Name>
+      <Name language="Latin_Medieval">Apollonopolis Parva</Name>
+      <Name language="Latin_Old">Apollonopolis Parva</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>qina</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_qus" order="2">b_qina</GameId>
+      <GameId game="ImperatorRome">564</GameId> <!-- Kainepolis -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Kone</Name>
+      <Name language="Egyptian_Late">Keneh</Name>
+      <Name language="Greek_Ancient">Kaine</Name>
+      <Name language="Greek_Medieval">Kaine</Name>
+      <Name language="Latin_Old">Caene</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>luxor</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_qus" order="3">b_luxor</GameId>
+      <GameId game="ImperatorRome">569</GameId> <!-- Diospolis Magna -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Ne</Name>
+      <Name language="Egyptian_Late">Waset</Name>
+      <Name language="Greek_Ancient">Thebai Hekatompyloi</Name>
+      <Name language="Greek_Medieval">Thebai</Name>
+      <Name language="Latin_Medieval">Thebae</Name>
+      <Name language="Latin_Old">Thebae Aegyptum</Name>
+      <Name language="Masmuda">Luqsur</Name>
+      <Name language="Sanhaja">Luqsur</Name>
+      <Name language="Tuareg_Tagelmust">Luqsur</Name>
+      <Name language="Tuareg">Luqsur</Name>
+      <Name language="Zenati">Luqsur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67553,6 +67852,8 @@
       <GameId game="CK2HIP" parent="c_qus" order="5">b_quft</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Iustinianopolis</Name>
+      <Name language="Latin_Medieval">Coptos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67560,21 +67861,29 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_asyut" order="1">b_asyut</GameId>
       <GameId game="CK2HIP" parent="d_aswan" order="5">c_asyut</GameId>
+      <GameId game="ImperatorRome">553</GameId> <!-- Lykopolis -->
     </GameIds>
     <Names>
       <Name language="Egyptian_Coptic">Siout</Name>
+      <Name language="Egyptian_Late">Zawty</Name>
+      <Name language="Greek_Ancient">Lykopolis</Name>
       <Name language="Greek_Medieval">Lykopolis</Name>
       <Name language="Latin_Medieval">Lycopolis</Name>
+      <Name language="Latin_Old">Lycon</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>shutb</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_asyut" order="2">b_shutb</GameId>
+      <GameId game="ImperatorRome">555</GameId> <!-- Hypsele -->
     </GameIds>
     <Names>
-      <Name language="Greek_Medieval">Apotheke</Name>
-      <Name language="Latin_Medieval">Apotheke</Name>
+      <Name language="Egyptian_Late">Shashotep</Name>
+      <Name language="Greek_Ancient">Hypselis</Name>
+      <Name language="Greek_Medieval">Hypsele</Name>
+      <Name language="Latin_Medieval">Hypsele</Name>
+      <Name language="Latin_Old">Hypsela</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67583,38 +67892,48 @@
       <GameId game="CK2HIP" parent="c_asyut" order="3">b_butij</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Apotheke</Name>
+      <Name language="Latin_Medieval">Apotheke</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>udfu</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_aswan" order="2">b_udfu</GameId>
+      <GameId game="ImperatorRome">576</GameId> <!-- Apollonopolis Magna -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Atbo</Name>
+      <Name language="Egyptian_Late">Djeba</Name>
+      <Name language="Greek_Ancient">Apollonopolis Megale</Name>
+      <Name language="Greek_Medieval">Apollinopolis Megas</Name>
+      <Name language="Latin_Medieval">Apollonopolis Magna</Name>
+      <Name language="Latin_Old">Apollonopolis Magna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>armant</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_aswan" order="3">b_armant</GameId>
+      <GameId game="ImperatorRome">572</GameId> <!-- Hermonthis -->
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>senoussi</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_cyrenaica" order="1">c_senoussi</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Egyptian_Late">Iunu-Monthu</Name>
+      <Name language="Greek_Ancient">Hermonthis</Name>
+      <Name language="Greek_Medieval">Hermonthis</Name>
+      <Name language="Latin_Medieval">Hermonthis</Name>
+      <Name language="Latin_Old">Hermonthis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>awjila</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_senoussi" order="1">b_awjila</GameId>
+      <GameId game="CK2HIP" parent="d_cyrenaica" order="1">c_senoussi</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Augila</Name>
+      <Name language="Latin_Medieval">Augila</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67629,32 +67948,59 @@
     <Id>ajdabiya</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_ajadabiya" order="1">b_ajdabiya</GameId>
+      <GameId game="ImperatorRome">3343</GameId> <!-- Corniclanum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Korniklanon</Name>
+      <Name language="Latin_Medieval">Corniclanum</Name>
+      <Name language="Latin_Old">Corniclanum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>alaghaila</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_ajadabiya" order="2">b_alaghaila</GameId>
+      <GameId game="ImperatorRome">3339</GameId> <!-- Automalax -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Automalax</Name>
+      <Name language="Latin_Medieval">Anabucis</Name>
+      <Name language="Masmuda">Lagheyla</Name>
+      <Name language="Sanhaja">Lagheyla</Name>
+      <Name language="Tuareg_Tagelmust">Lagheyla</Name>
+      <Name language="Tuareg">Lagheyla</Name>
+      <Name language="Zenati">Lagheyla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>oriana</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_benghazi" order="3">b_oriana</GameId>
+      <GameId game="ImperatorRome">3360</GameId> <!-- Kyrene -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Kyrene</Name>
+      <Name language="Greek_Medieval">Kyrene</Name>
+      <Name language="Latin_Medieval">Cyrene</Name>
+      <Name language="Latin_Old">Cyrene</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>baydabenghazi</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_benghazi" order="4">b_baydabenghazi</GameId>
+      <GameId game="ImperatorRome">3359</GameId> <!-- Balagrae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Balagrai</Name>
+      <Name language="Greek_Medieval">Balagrai</Name>
+      <Name language="Latin_Medieval">Balagrae</Name>
+      <Name language="Latin_Old">Balagrae</Name>
+      <Name language="Masmuda">Lbayda</Name>
+      <Name language="Sanhaja">Lbayda</Name>
+      <Name language="Tuareg_Tagelmust">Lbayda</Name>
+      <Name language="Tuareg">Lbayda</Name>
+      <Name language="Zenati">Lbayda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67663,6 +68009,8 @@
       <GameId game="CK2HIP" parent="c_benghazi" order="5">b_tulmaytath</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Ptolemais</Name>
+      <Name language="Latin_Medieval">Ptolemais</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67703,6 +68051,15 @@
       <GameId game="CK2HIP" parent="k_egypt" order="7">d_sinai</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Síná'</Name>
+      <Name language="Arabic_Bedouin">Síná'</Name>
+      <Name language="Arabic_Egypt">Síná'</Name>
+      <Name language="Arabic_Levant">Síná'</Name>
+      <Name language="Arabic_Maghreb">Síná'</Name>
+      <Name language="Arabic_Yemen">Síná'</Name>
+      <Name language="Egyptian_Coptic">Sina</Name>
+      <Name language="Hejazi_Arabic">Síná'</Name>
+      <Name language="Sicilian_Arabic">Síná'</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67711,14 +68068,23 @@
       <GameId game="CK2HIP" parent="c_eilat" order="2">b_eltormonestary</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Rhaitou</Name>
+      <Name language="Latin_Medieval">Rhaitou</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>farama</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_el-arish" order="2">b_farama</GameId>
+      <GameId game="ImperatorRome">509</GameId> <!-- Pelusium -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Peremun</Name>
+      <Name language="Egyptian_Late">Per-Amun</Name>
+      <Name language="Greek_Ancient">Pilousion</Name>
+      <Name language="Greek_Medieval">Pelousion</Name>
+      <Name language="Latin_Medieval">Pelusium</Name>
+      <Name language="Latin_Old">Pelusium</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67747,14 +68113,8 @@
       <GameId game="CK2HIP" parent="c_aleppo" order="3">b_buzaa</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>aleppocastle</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_aleppo" order="1">b_aleppocastle</GameId>
-    </GameIds>
-    <Names>
+      <Name language="French_Old">Puthaha</Name>
+      <Name language="Norman">Puthaha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67771,14 +68131,22 @@
       <GameId game="CK2HIP" parent="c_manbij" order="1">b_qalatnajm</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Caeciliana</Name>
+      <Name language="Norman">Caeciliana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>balissyria</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_manbij" order="3">b_balissyria</GameId>
+      <GameId game="ImperatorRome">814</GameId> <!-- Barbalissus -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Barbalissos</Name>
+      <Name language="Greek_Medieval">Barbalissos</Name>
+      <Name language="Latin_Medieval">Barbalissos</Name>
+      <Name language="Latin_Old">Barbalissus</Name>
+      <Name language="Syriac_Classical">Beit Bales</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67787,14 +68155,22 @@
       <GameId game="CK2HIP" parent="c_manbij" order="4">b_jarabulus</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Geraple</Name>
+      <Name language="Greek_Medieval">Europos</Name>
+      <Name language="Kurdish">Kaniya Dil</Name>
+      <Name language="Latin_Medieval">Europos</Name>
+      <Name language="Norman">Geraple</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>kafrtab</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_aleppo" order="3">c_kafrtab</GameId>
+      <GameId game="CK2HIP" parent="c_kafrtab" order="4">b_kafr_tab</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Capharda</Name>
+      <Name language="Norman">Capharda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67803,6 +68179,10 @@
       <GameId game="CK2HIP" parent="c_kafrtab" order="1">b_maaratannuman</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">La Marre</Name>
+      <Name language="Greek_Medieval">Arra</Name>
+      <Name language="Latin_Medieval">Arra</Name>
+      <Name language="Norman">La Marre</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67811,14 +68191,14 @@
       <GameId game="CK2HIP" parent="c_kafrtab" order="2">b_bara</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>kafr_tab</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_kafrtab" order="4">b_kafr_tab</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Arabic_Andalusia">al-Bara</Name>
+      <Name language="Arabic_Bedouin">al-Bara</Name>
+      <Name language="Arabic_Egypt">al-Bara</Name>
+      <Name language="Arabic_Levant">al-Bara</Name>
+      <Name language="Arabic_Maghreb">al-Bara</Name>
+      <Name language="Arabic_Yemen">al-Bara</Name>
+      <Name language="Hejazi_Arabic">al-Bara</Name>
+      <Name language="Sicilian_Arabic">al-Bara</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67828,22 +68208,21 @@
       <GameId game="CK2HIP" parent="d_aleppo" order="4">c_hama</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Epiphania</Name>
+      <Name language="Latin_Medieval">Epiphania</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>shayzar</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_hama" order="4">b_shayzar</GameId>
+      <GameId game="ImperatorRome">781</GameId> <!-- Larissa -->
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>citadelofhoms</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_homs" order="5">b_citadelofhoms</GameId>
-    </GameIds>
-    <Names>
+      <Name language="French_Old">Sizara</Name>
+      <Name language="Greek_Medieval">Larissa</Name>
+      <Name language="Norman">Sizara</Name>
+      <Name language="Latin_Medieval">Larissa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67852,6 +68231,8 @@
       <GameId game="CK2HIP" parent="c_palmyra" order="1">b_arak</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Aracha</Name>
+      <Name language="Latin_Medieval">Aracha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67861,6 +68242,8 @@
       <GameId game="CK2HIP" parent="d_homs" order="3">c_salamiyah</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Salamias</Name>
+      <Name language="Latin_Medieval">Salamias</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67869,6 +68252,7 @@
       <GameId game="CK2HIP" parent="c_damascus" order="6">b_marsarkismoenstary</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Monì tìs Agios Sergios</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -14687,17 +14687,22 @@
       <Name language="Greek_Ancient">Byzántion</Name>
       <Name language="Greek_Medieval">Konstantinoupolis</Name>
       <Name language="Hejazi_Arabic">al-Qustantíniyya</Name>
+      <Name language="Hungarian_Old">Konstantinápoly</Name>
+      <Name language="Hungarian">Isztambul</Name>
       <Name language="Icelandic_Old">Miklagarðr</Name>
       <Name language="Irish_Middle_Norse">Miklagarðr</Name>
       <Name language="Kurdish">al-Qustantíniyya</Name>
       <Name language="Latin_Old">Byzantium</Name>
-      <Name language="Latin">Byzantium</Name>
+      <Name language="Latin_Middle">Constantinopolis</Name>
       <Name language="Norse">Miklagarðr</Name>
       <Name language="Norwegian_Old">Miklagarðr</Name>
       <Name language="Oghuz">Kostantiniye</Name>
       <Name language="Pecheneg">Kostantiniye</Name>
       <Name language="Polish_Old">Tsargrad</Name>
-      <Name language="Romanian">Constantinopol</Name>
+      <Name language="Romanian_Before1930">Constantinopol</Name>
+      <Name language="Romanian_BeforeWW1">Constantinopol</Name>
+      <Name language="Romanian_Old">Țarigrad</Name>
+      <Name language="Romanian">Istanbul</Name>
       <Name language="Russian">Tsargrad</Name>
       <Name language="Serbian_Medieval">Tsargrad</Name>
       <Name language="Serbian">Carigrad</Name>
@@ -14707,9 +14712,12 @@
       <Name language="Slovene">Carigrad</Name>
       <Name language="Sorbian">Tsargrad</Name>
       <Name language="Swedish_Old">Miklagarðr</Name>
+      <Name language="Thracian">Lygos</Name>
       <Name language="Thuringian">Konstantinusesburg</Name>
       <Name language="Turkish_Old">Kostantiniye</Name>
+      <Name language="Turkish">İstanbul</Name>
       <Name language="Turkmen_Medieval">Kostantiniye</Name>
+      <Name language="Turkmen_Ottoman">Kostantiniye</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -16883,6 +16883,7 @@
     <Id>chalkis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_euboia" order="1">b_chalkis</GameId>
+      <GameId game="ImperatorRome">407</GameId> <!-- Chalcis -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Halkis</Name>
@@ -16891,9 +16892,11 @@
       <Name language="Croatian">Halkis</Name>
       <Name language="Dalmatian_Medieval">Negroponte</Name>
       <Name language="French_Old">Négrepont</Name>
+      <Name language="Greek_Ancient">Chalkis</Name>
       <Name language="Italian_Central">Negroponte</Name>
       <Name language="Italian_Medieval">Negroponte</Name>
       <Name language="Langobardic">Negroponte</Name>
+      <Name language="Latin_Old">Chalcis</Name>
       <Name language="Ligurian">Negroponte</Name>
       <Name language="Neapolitan">Negroponte</Name>
       <Name language="Norman">Négrepont</Name>
@@ -16914,6 +16917,7 @@
     <Id>karystos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_euboia" order="2">b_karystos</GameId>
+      <GameId game="ImperatorRome">409</GameId> <!-- Karystos -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Karist</Name>
@@ -16921,9 +16925,11 @@
       <Name language="Croatian">Karist</Name>
       <Name language="Dalmatian">Castel Rosso</Name>
       <Name language="French_Old">Caristho</Name>
+      <Name language="Greek_Ancient">Karystos</Name>
       <Name language="Italian_Central">Castel Rosso</Name>
       <Name language="Italian_Medieval">Castel Rosso</Name>
       <Name language="Langobardic">Castel Rosso</Name>
+      <Name language="Latin_Old">Carystus</Name>
       <Name language="Ligurian">Castel Rosso</Name>
       <Name language="Neapolitan">Castel Rosso</Name>
       <Name language="Norman">Caristho</Name>
@@ -16975,7 +16981,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_atheniai" order="7">b_athens</GameId>
       <GameId game="CK2HIP" parent="d_athens" order="3">c_atheniai</GameId>
-      <GameId game="ImperatorRome">416</GameId>
+      <GameId game="ImperatorRome">416</GameId> <!-- Athens -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Atina</Name>
@@ -16984,9 +16990,11 @@
       <Name language="Croatian">Atina</Name>
       <Name language="Dalmatian">Atene</Name>
       <Name language="French_Old">Athènes</Name>
+      <Name language="Greek_Ancient">Athenai</Name>
       <Name language="Italian_Central">Atene</Name>
       <Name language="Italian_Medieval">Atene</Name>
       <Name language="Langobardic">Atene</Name>
+      <Name language="Latin_Old">Athenae</Name>
       <Name language="Ligurian">Atene</Name>
       <Name language="Neapolitan">Atene</Name>
       <Name language="Norman">Athènes</Name>
@@ -17008,6 +17016,7 @@
     <Id>oropos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_atheniai" order="4">b_oropos</GameId>
+      <GameId game="ImperatorRome">413</GameId> <!-- Oropos -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Orop</Name>
@@ -17015,9 +17024,11 @@
       <Name language="Croatian">Orop</Name>
       <Name language="Dalmatian">Ripo</Name>
       <Name language="French_Old">Ripo</Name>
+      <Name language="Greek_Ancient">Oropos</Name>
       <Name language="Italian_Central">Ripo</Name>
       <Name language="Italian_Medieval">Ripo</Name>
       <Name language="Langobardic">Ripo</Name>
+      <Name language="Latin_Old">Oropus</Name>
       <Name language="Ligurian">Ripo</Name>
       <Name language="Neapolitan">Ripo</Name>
       <Name language="Norman">Ripo</Name>
@@ -17069,6 +17080,7 @@
     <Id>eleusis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_atheniai" order="6">b_eleusis</GameId>
+      <GameId game="ImperatorRome">7897</GameId> <!-- Eleusis -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Elefsina</Name>
@@ -17095,6 +17107,7 @@
     <Id>salamis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_atheniai" order="7">b_salamis</GameId>
+      <GameId game="ImperatorRome">331</GameId> <!-- Salamis -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Salamina</Name>
@@ -17319,6 +17332,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_korinthos" order="2">b_corinth</GameId>
       <GameId game="CK2HIP" parent="d_achaia" order="2">c_korinthos</GameId>
+      <GameId game="ImperatorRome">418</GameId> <!-- Korinthos -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Korint</Name>
@@ -17333,9 +17347,11 @@
       <Name language="Finnish">Korintti</Name>
       <Name language="French_Old">Corinthe</Name>
       <Name language="German">Korinth</Name>
+      <Name language="Greek_Ancient">Korinthos</Name>
       <Name language="Italian_Central">Coranto</Name>
       <Name language="Italian_Medieval">Coranto</Name>
       <Name language="Langobardic">Coranto</Name>
+      <Name language="Latin_Old">Corinthus</Name>
       <Name language="Latin">Corinthus</Name>
       <Name language="Ligurian">Coranto</Name>
       <Name language="Neapolitan">Coranto</Name>
@@ -17445,6 +17461,7 @@
     <Id>aegina</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_korinthos" order="5">b_aegina</GameId>
+      <GameId game="ImperatorRome">442</GameId> <!-- Aigina -->
     </GameIds>
     <Names>
       <Name language="Bosnian">Egina</Name>
@@ -17452,9 +17469,11 @@
       <Name language="Croatian">Egina</Name>
       <Name language="Dalmatian">Eguena</Name>
       <Name language="French_Old">Ligene</Name>
+      <Name language="Greek_Ancient">Aigina</Name>
       <Name language="Italian_Central">Eguena</Name>
       <Name language="Italian_Medieval">Eguena</Name>
       <Name language="Langobardic">Eguena</Name>
+      <Name language="Latin_Old">Aegina</Name>
       <Name language="Ligurian">Eguena</Name>
       <Name language="Neapolitan">Eguena</Name>
       <Name language="Norman">Ligene</Name>
@@ -17819,6 +17838,7 @@
       <Name language="Arabic_Egypt">Iqrítish</Name>
       <Name language="Arabic_Levant">Iqrítish</Name>
       <Name language="Arabic_Maghreb">Iqrítish</Name>
+      <Name language="Arabic_Yemen">Iqrítish</Name>
       <Name language="Arpitan">Candie</Name>
       <Name language="Avar_Old">Krit</Name>
       <Name language="Bulgar">Krit</Name>
@@ -17826,6 +17846,7 @@
       <Name language="Dalmatian">Candia</Name>
       <Name language="French_Old">Candie</Name>
       <Name language="German">Kreta</Name>
+      <Name language="Hejazi_Arabic">Iqrítish</Name>
       <Name language="Italian_Central">Candia</Name>
       <Name language="Italian_Medieval">Candia</Name>
       <Name language="Langobardic">Candia</Name>
@@ -17839,6 +17860,7 @@
       <Name language="Polish">Kreta</Name>
       <Name language="Romanian">Creta</Name>
       <Name language="Sardinian">Candia</Name>
+      <Name language="Sicilian_Arabic">Iqrítish</Name>
       <Name language="Sicilian">Candia</Name>
       <Name language="Turkish_Old">Girit</Name>
       <Name language="Turkish">Girit</Name>
@@ -17880,7 +17902,18 @@
       <GameId game="CK2HIP" parent="c_kaneia" order="6">b_paleohora</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Palaeohora</Name>
+      <Name language="Italian_Central">Palaeohora</Name>
+      <Name language="Italian_Medieval">Palaeohora</Name>
+      <Name language="Langobardic">Palaeohora</Name>
+      <Name language="Ligurian">Palaeohora</Name>
+      <Name language="Neapolitan">Palaeohora</Name>
+      <Name language="Sardinian">Palaeohora</Name>
+      <Name language="Sicilian">Palaeohora</Name>
       <Name language="Swedish">Paleochora</Name>
+      <Name language="Tuscan_Medieval">Palaeohora</Name>
+      <Name language="Umbrian_Medieval">Palaeohora</Name>
+      <Name language="Venetian_Medieval">Palaeohora</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -18805,18 +18838,39 @@
       <GameId game="ImperatorRome">4538</GameId> <!-- Chersonesos -->
     </GameIds>
     <Names>
+      <Name language="Bosnian_Medieval">Korsun</Name>
+      <Name language="Bulgarian_Old">Korsun</Name>
       <Name language="Castilian">Jersón</Name>
+      <Name language="Croatian_Medieval">Korsun</Name>
+      <Name language="Czech_Medieval">Cherson</Name>
+      <Name language="Dalmatian_Medieval">Sarsona</Name>
       <Name language="Dutch_Middle">Cherson</Name>
       <Name language="Estonian">Herson</Name>
       <Name language="Finnish">Herson</Name>
       <Name language="German">Cherson</Name>
       <Name language="Greek_Medieval">Cherson</Name>
       <Name language="Hungarian">Herszon</Name>
+      <Name language="Italian_Central">Sarsona</Name>
+      <Name language="Italian_Medieval">Sarsona</Name>
+      <Name language="Langobardic">Sarsona</Name>
       <Name language="Latgalian">Hersona</Name>
+      <Name language="Ligurian">Sarsona</Name>
       <Name language="Lithuanian">Chersonas</Name>
+      <Name language="Neapolitan">Sarsona</Name>
+      <Name language="Polish_Old">Korsun</Name>
       <Name language="Romanian">Herson</Name>
+      <Name language="Russian_Medieval">Korsun</Name>
+      <Name language="Sardinian">Sarsona</Name>
+      <Name language="Serbian_Medieval">Korsun</Name>
+      <Name language="Sicilian">Sarsona</Name>
+      <Name language="Slovak_Medieval">Cherson</Name>
+      <Name language="Slovene_Medieval">Korsun</Name>
+      <Name language="Sorbian">Korsun</Name>
       <Name language="Swedish">Cherson</Name>
       <Name language="Turkish">Herson</Name>
+      <Name language="Tuscan_Medieval">Sarsona</Name>
+      <Name language="Umbrian_Medieval">Sarsona</Name>
+      <Name language="Venetian_Medieval">Sarsona</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -18827,9 +18881,14 @@
     <Names>
       <Name language="Avar_Old">Alushta</Name>
       <Name language="Bashkir">Alushta</Name>
+      <Name language="Circassian">Alushta</Name>
       <Name language="Cuman">Alushta</Name>
       <Name language="Dalmatian">Lusta</Name>
       <Name language="Italian_Central">Lusta</Name>
+      <Name language="Italian_Medieval">Lusta</Name>
+      <Name language="Karluk">Alushta</Name>
+      <Name language="Khazar_Kabar">Alushta</Name>
+      <Name language="Khazar">Alushta</Name>
       <Name language="Kyrgyz">Alushta</Name>
       <Name language="Langobardic">Lusta</Name>
       <Name language="Ligurian">Lusta</Name>
@@ -18859,12 +18918,19 @@
       <Name language="Arabic_Egypt">Dzhalita</Name>
       <Name language="Arabic_Levant">Dzhalita</Name>
       <Name language="Arabic_Maghreb">Dzhalita</Name>
+      <Name language="Arabic_Yemen">Dzhalita</Name>
       <Name language="Avar_Old">Yalta</Name>
       <Name language="Bashkir">Yalta</Name>
+      <Name language="Circassian">Yalta</Name>
       <Name language="Cuman">Yalta</Name>
       <Name language="Dalmatian">Caulita</Name>
       <Name language="Gothic_Crimean">Galita</Name>
+      <Name language="Hejazi_Arabic">Dzhalita</Name>
       <Name language="Italian_Central">Caulita</Name>
+      <Name language="Italian_Medieval">Caulita</Name>
+      <Name language="Karluk">Yalta</Name>
+      <Name language="Khazar_Kabar">Yalta</Name>
+      <Name language="Khazar">Yalta</Name>
       <Name language="Kyrgyz">Yalta</Name>
       <Name language="Langobardic">Caulita</Name>
       <Name language="Ligurian">Caulita</Name>
@@ -18874,6 +18940,7 @@
       <Name language="Pecheneg">Yalta</Name>
       <Name language="Romanian">Ialta</Name>
       <Name language="Sardinian">Caulita</Name>
+      <Name language="Sicilian_Arabic">Dzhalita</Name>
       <Name language="Sicilian">Caulita</Name>
       <Name language="Turkish_Old">Yalta</Name>
       <Name language="Turkmen_Medieval">Yalta</Name>
@@ -18918,12 +18985,19 @@
   <LocationEntity>
     <Id>amisos</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_amisos" order="1">b_kastronamisos</GameId>
       <GameId game="CK2HIP" parent="c_amisos" order="2">b_amisos</GameId>
       <GameId game="CK2HIP" parent="d_armeniacon" order="2">c_amisos</GameId>
+      <GameId game="ImperatorRome">1807</GameId> <!-- Amisos -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Amisos</Name>
       <Name language="Latgalian">Samsuna</Name>
+      <Name language="Latin_Old">Amisus</Name>
       <Name language="Lithuanian">Samsunas</Name>
+      <Name language="Oghuz">Samsun</Name>
+      <Name language="Turkish_Old">Samsun</Name>
+      <Name language="Turkmen_Medieval">Samsun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -18984,9 +19058,13 @@
     <Id>kapan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_teluch" order="1">b_kapan</GameId>
+      <GameId game="ImperatorRome">1616</GameId> <!-- Kapan -->
     </GameIds>
     <Names>
       <Name language="Lithuanian">Kapanas</Name>
+      <Name language="Oghuz">Geben</Name>
+      <Name language="Turkish_Old">Geben</Name>
+      <Name language="Turkmen_Medieval">Geben</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20150,12 +20228,14 @@
       <Name language="Oghuz">Yanbolu</Name>
       <Name language="Pecheneg">Yanbolu</Name>
       <Name language="Romanian">Diampol</Name>
+      <Name language="Sanhaja">Dinibouli</Name>
       <Name language="Serbian">Djampolj</Name>
       <Name language="Sicilian_Arabic">Dinibouli</Name>
       <Name language="Slovene">Djampolj</Name>
       <Name language="Tuareg">Dinibouli</Name>
       <Name language="Turkish_Old">Yanbolu</Name>
       <Name language="Turkmen_Medieval">Yanbolu</Name>
+      <Name language="Zenati">Dinibouli</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -20389,6 +20469,7 @@
       <Name language="Dutch_Middle">Taubenberg</Name>
       <Name language="Franconian_Lorraine">Taubenberg</Name>
       <Name language="Frankish_Low">Taubenberg</Name>
+      <Name language="Frankish">Taubenberg</Name>
       <Name language="German_Middle_High">Taubenberg</Name>
       <Name language="German_Middle_Low">Taubenberg</Name>
       <Name language="German_Old_Low">Taubenberg</Name>
@@ -36037,10 +36118,50 @@
       <GameId game="CK2HIP" parent="d_dalmatia" order="4">c_zadar</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Zara</Name>
+      <Name language="Arabic_Andalusia">Jadhara</Name>
+      <Name language="Arabic_Bedouin">Jadhara</Name>
+      <Name language="Arabic_Egypt">Jadhara</Name>
+      <Name language="Arabic_Levant">Jadhara</Name>
+      <Name language="Arabic_Maghreb">Jadhara</Name>
+      <Name language="Arabic_Yemen">Jadhara</Name>
       <Name language="Aragonese">Chadra</Name>
-      <Name language="Slovene">Zader</Name>
+      <Name language="Arpitan">Jadres</Name>
+      <Name language="Bavarian_Medieval">Zara</Name>
+      <Name language="Dalmatian_Medieval">Zara</Name>
+      <Name language="Dutch_Middle">Zara</Name>
+      <Name language="Frankish_Low">Zara</Name>
+      <Name language="Frankish">Zara</Name>
+      <Name language="French_Old">Jadres</Name>
+      <Name language="German_Middle_High">Zara</Name>
+      <Name language="German_Middle_Low">Zara</Name>
+      <Name language="German_Old_Low">Zara</Name>
+      <Name language="Gothic_Crimean">Diadora</Name>
+      <Name language="Greek_Medieval">Diadora</Name>
+      <Name language="Hejazi_Arabic">Jadhara</Name>
+      <Name language="Hungarian_Old_Early">Zara</Name>
+      <Name language="Hungarian_Old">Zára</Name>
+      <Name language="Italian_Central">Zara</Name>
+      <Name language="Italian_Medieval">Zara</Name>
+      <Name language="Langobardic">Zara</Name>
       <Name language="Latgalian">Zadara</Name>
+      <Name language="Latin_Medieval">Iadera</Name>
+      <Name language="Ligurian">Zara</Name>
       <Name language="Lithuanian">Zadaras</Name>
+      <Name language="Neapolitan">Zara</Name>
+      <Name language="Norman">Jadres</Name>
+      <Name language="Sanhaja">Jadhara</Name>
+      <Name language="Sardinian">Zara</Name>
+      <Name language="Sicilian_Arabic">Jadhara</Name>
+      <Name language="Sicilian">Zara</Name>
+      <Name language="Slovene">Zader</Name>
+      <Name language="Szekely_Old">Zára</Name>
+      <Name language="Thuringian_Medieval">Zara</Name>
+      <Name language="Tuareg">Jadhara</Name>
+      <Name language="Tuscan_Medieval">Jatara</Name>
+      <Name language="Umbrian_Medieval">Zara</Name>
+      <Name language="Venetian_Medieval">Jatara</Name>
+      <Name language="Zenati">Jadhara</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -36716,6 +36837,8 @@
     </GameIds>
     <Names>
       <Name language="French_Old">El Giof</Name>
+      <Name language="Greek_Medieval">Arabia Petraea</Name>
+      <Name language="Latin_Medieval">Arabia Petraea</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -36856,6 +36979,12 @@
       <GameId game="CK2HIP" parent="d_oman" order="3">c_muscat</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Masqat</Name>
+      <Name language="Arabic_Bedouin">Masqat</Name>
+      <Name language="Arabic_Egypt">Masqat</Name>
+      <Name language="Arabic_Levant">Masqat</Name>
+      <Name language="Arabic_Maghreb">Masqat</Name>
+      <Name language="Arabic_Yemen">Masqat</Name>
       <Name language="Arpitan">Mascate</Name>
       <Name language="Breton_Middle">Masqat</Name>
       <Name language="Castilian">Mascate</Name>
@@ -36867,6 +36996,7 @@
       <Name language="French_Old">Mascate</Name>
       <Name language="Galician">Mascate</Name>
       <Name language="German">Maskat</Name>
+      <Name language="Hejazi_Arabic">Masqat</Name>
       <Name language="Hungarian">Maszkat</Name>
       <Name language="Icelandic">Múskat</Name>
       <Name language="Italian">Mascate</Name>
@@ -36879,6 +37009,7 @@
       <Name language="Occitan">Mascate</Name>
       <Name language="Polish">Maskat</Name>
       <Name language="Portuguese">Mascate</Name>
+      <Name language="Sicilian_Arabic">Masqat</Name>
       <Name language="Slovak">Maskat</Name>
       <Name language="Swedish">Muskat</Name>
       <Name language="Turkish">Maskat</Name>
@@ -37232,7 +37363,10 @@
       <GameId game="CK2HIP" parent="c_cairo" order="2">b_fustat</GameId>
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Phystaton</Name>
       <Name language="French_Old">Fostat</Name>
+      <Name language="Greek_Medieval">Phystaton</Name>
+      <Name language="Latin_Medieval">Phystaton</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -37887,6 +38021,7 @@
     <Id>jericho</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_beersheb" order="3">b_jericho</GameId>
+      <GameId game="ImperatorRome">684</GameId> <!-- Jericho -->
     </GameIds>
     <Names>
       <Name language="Aragonese">Chericó</Name>
@@ -37896,12 +38031,17 @@
       <Name language="Catalan">Jericó</Name>
       <Name language="Croatian">Jerihon</Name>
       <Name language="Danish">Jeriko</Name>
+      <Name language="Estonian">Jeeriko</Name>
       <Name language="Finnish">Jeriko</Name>
       <Name language="Galician">Xericó</Name>
+      <Name language="Greek_Ancient">Hierichous</Name>
+      <Name language="Greek_Medieval">Ierichó</Name>
       <Name language="Hungarian">Jerikó</Name>
       <Name language="Irish">Ireachó</Name>
       <Name language="Italian">Gerico</Name>
       <Name language="Latgalian">Jerika</Name>
+      <Name language="Latin_Medieval">Iericho</Name>
+      <Name language="Latin_Old">Iericho</Name>
       <Name language="Lithuanian">Jerichas</Name>
       <Name language="Norwegian">Jeriko</Name>
       <Name language="Polish">Jerycho</Name>
@@ -37909,7 +38049,6 @@
       <Name language="Romanian">Ierihon</Name>
       <Name language="Swedish">Jeriko</Name>
       <Name language="Turkish">Eriha</Name>
-      <Name language="Estonian">Jeeriko</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38900,30 +39039,49 @@
     <Names>
       <Name language="Armenian">Anglia</Name>
       <Name language="Basque">Ingalaterra</Name>
-      <Name language="Czech">Anglie</Name>
+      <Name language="Breton_Middle">Lloegyr</Name>
       <Name language="Bulgarian">Anglija</Name>
-      <Name language="Slovene">Anglija</Name>
       <Name language="Castilian">Inglaterra</Name>
       <Name language="Catalan">Anglaterra</Name>
+      <Name language="Cornish_Middle">Lloegyr</Name>
       <Name language="Croatian">Engleska</Name>
+      <Name language="Cumbric">Lloegyr</Name>
+      <Name language="Czech">Anglie</Name>
+      <Name language="Danish_Middle">Ænglandi</Name>
       <Name language="Dutch_Middle">Engeland</Name>
+      <Name language="English_Middle">Engelond</Name>
+      <Name language="English_Old_Norse">Englaland</Name>
+      <Name language="English_Old">Englaland</Name>
+      <Name language="Estonian">Inglismaa</Name>
+      <Name language="French_Old">Angleterre</Name>
+      <Name language="Gothic">Ænglandi</Name>
+      <Name language="Greek_Medieval">Britannia</Name>
       <Name language="Hungarian">Anglia</Name>
+      <Name language="Irish_Middle_Norse">Ænglandi</Name>
+      <Name language="Irish_Middle">Lloegyr</Name>
       <Name language="Italian">Inghilterra</Name>
-      <Name language="Sami">Englanti</Name>
       <Name language="Latgalian">Anglija</Name>
+      <Name language="Latin_Medieval">Britanniae</Name>
+      <Name language="Latin">Brtannia</Name> <!-- Or Britannia Magna -->
       <Name language="Lithuanian">Anglija</Name>
       <Name language="Livonian">Englanti</Name>
+      <Name language="Norman">Angliétèrre</Name>
+      <Name language="Norse">Ænglandi</Name>
+      <Name language="Norwegian_Old">Ænglandi</Name>
       <Name language="Pictish">Lloegyr</Name>
       <Name language="Polish">Anglia</Name>
-      <Name language="Sorbian">Anglia</Name>
       <Name language="Portuguese">Inglaterra</Name>
       <Name language="Prussian_Old">Englija</Name>
-      <Name language="Latin">Brtannia</Name> <!-- Or Britannia Magna -->
       <Name language="Romanian">Anglia</Name>
       <Name language="Russian">Angliya</Name>
+      <Name language="Sami">Englanti</Name>
+      <Name language="Scottish_Gaelic">Lloegyr</Name>
       <Name language="Serbian">Engleska</Name>
+      <Name language="Slovene">Anglija</Name>
+      <Name language="Sorbian">Anglia</Name>
+      <Name language="Swedish_Old">Ænglandi</Name>
       <Name language="Turkish">Ingiltere</Name>
-      <Name language="Estonian">Inglismaa</Name>
+      <Name language="Welsh_Middle">Lloegyr</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38946,7 +39104,17 @@
       <GameId game="CK2HIP" parent="c_winchester" order="1">b_southampton</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Hamvik</Name>
+      <Name language="English_Old_Norse">Hamwic</Name>
+      <Name language="English_Old">Hamwic</Name>
+      <Name language="Gothic">Hamvik</Name>
+      <Name language="Icelandic_Old">Hamvik</Name>
+      <Name language="Irish_Middle_Norse">Hamvik</Name>
       <Name language="Latin">Clausentum</Name>
+      <Name language="Norman">Hantonne</Name>
+      <Name language="Norse">Hamvik</Name>
+      <Name language="Norwegian_Old">Hamvik</Name>
+      <Name language="Swedish_Old">Hamvik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -49530,6 +49698,7 @@
     </GameIds>
     <Names>
       <Name language="English_Old_Norse">Baius</Name>
+      <Name language="Greek_Medieval">Baiocassion</Name>
       <Name language="Latin_Late">Augustodurum</Name>
       <Name language="Latin_Medieval">Baiocassium</Name>
       <Name language="Latin">Baiocae</Name>
@@ -49550,20 +49719,15 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>coustance</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_normandy" order="5">c_coustance</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Romanian">Constanța</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>coutances</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_coustance" order="1">b_coutances</GameId>
+      <GameId game="CK2HIP" parent="d_normandy" order="5">c_coustance</GameId>
+      <GameId game="ImperatorRome">3635</GameId> <!-- Constantia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Konstantia</Name>
+      <Name language="Latin_Medieval">Constantia</Name>
       <Name language="Romanian">Constanța</Name>
     </Names>
   </LocationEntity>
@@ -49589,11 +49753,14 @@
     <Id>cherbourg</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_coustance" order="5">b_cherbourg</GameId>
+      <GameId game="ImperatorRome">2134</GameId> <!-- Coriallum -->
     </GameIds>
     <Names>
-      <Name language="English_Old_Norse">Kiæresburh</Name>
       <Name language="Castilian">Cherburgo</Name>
+      <Name language="English_Old_Norse">Kiæresburh</Name>
       <Name language="Galician">Cherburgo</Name>
+      <Name language="Greek_Medieval">Coriallon</Name>
+      <Name language="Latin_Medieval">Coriallum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -49749,11 +49916,13 @@
       <GameId game="CK2HIP" parent="k_france" order="8">d_orleans</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Kenabon</Name>
       <Name language="Latgalian">Orleãna</Name>
+      <Name language="Latin_Medieval">Cenabum</Name>
+      <Name language="Latin">Aurelianum</Name>
       <Name language="Lithuanian">Orleanas</Name>
       <Name language="Polish">Orlean</Name>
       <Name language="Portuguese">Orleães</Name>
-      <Name language="Latin">Aurelianum</Name>
       <Name language="Venetian">Orliens</Name>
     </Names>
   </LocationEntity>
@@ -49807,10 +49976,13 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_chartres" order="1">b_chartres</GameId>
       <GameId game="CK2HIP" parent="d_blois" order="1">c_chartres</GameId>
+      <GameId game="ImperatorRome">2441</GameId> <!-- Autricum -->
     </GameIds>
     <Names>
       <Name language="Breton_Middle">Chartrez</Name>
+      <Name language="Greek_Medieval">Autrikon</Name>
       <Name language="Latgalian">Šartra</Name>
+      <Name language="Latin_Medieval">Autricum</Name>
       <Name language="Lithuanian">Šartras</Name>
     </Names>
   </LocationEntity>
@@ -49870,9 +50042,12 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_bourges" order="3">b_bourges</GameId>
       <GameId game="CK2HIP" parent="d_berry" order="1">c_bourges</GameId>
+      <GameId game="ImperatorRome">2347</GameId> <!-- Avaricum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Avaricum</Name>
       <Name language="Latgalian">Burža</Name>
+      <Name language="Latin_Medieval">Avaricum</Name>
       <Name language="Lithuanian">Buržas</Name>
       <Name language="Occitan">Borges</Name>
     </Names>
@@ -49934,9 +50109,10 @@
       <GameId game="CK2HIP" parent="k_france" order="11">d_nevers</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Nevirnum</Name>
+      <Name language="Latin_Medieval">Nevirnum</Name>
       <Name language="Lithuanian">Neveras</Name>
       <Name language="Occitan">Nivèrns</Name>
-      <Name language="Latin">Nevirensis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -49981,9 +50157,12 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_auxerre" order="1">b_auxerre</GameId>
       <GameId game="CK2HIP" parent="d_nevers" order="3">c_auxerre</GameId>
+      <GameId game="ImperatorRome">2353</GameId> <!-- Autessiodurum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Autessiodurum</Name>
       <Name language="Latgalian">Oksera</Name>
+      <Name language="Latin_Medieval">Autessiodurum</Name>
       <Name language="Lithuanian">Oseras</Name>
       <Name language="Occitan">Aussèrra</Name>
     </Names>
@@ -49998,29 +50177,19 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>archreims</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="k_france" order="12">d_archreims</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Czech">Remeš</Name>
-      <Name language="Latgalian">Reimsa</Name>
-      <Name language="Lithuanian">Reimsas</Name>
-      <Name language="Occitan">Rems</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>reims</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_reims" order="1">b_reims</GameId>
       <GameId game="CK2HIP" parent="d_archreims" order="1">c_reims</GameId>
+      <GameId game="CK2HIP" parent="k_france" order="12">d_archreims</GameId>
     </GameIds>
     <Names>
       <Name language="Czech">Remeš</Name>
+      <Name language="Greek_Medieval">Remos</Name>
       <Name language="Latgalian">Reimsa</Name>
+      <Name language="Latin_Medieval">Remos</Name>
       <Name language="Lithuanian">Reimsas</Name>
       <Name language="Occitan">Rems</Name>
-      <Name language="Latin">Durocotorum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -50038,7 +50207,6 @@
   <LocationEntity>
     <Id>champagne</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_champagne" order="1">c_champagne</GameId>
       <GameId game="CK2HIP" parent="k_france" order="13">d_champagne</GameId>
     </GameIds>
     <Names>
@@ -50053,8 +50221,12 @@
     <Id>troyes</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_champagne" order="1">b_troyes</GameId>
+      <GameId game="CK2HIP" parent="d_champagne" order="1">c_champagne</GameId>
+      <GameId game="ImperatorRome">2449</GameId> <!-- Augustobona -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Augoustobona</Name>
+      <Name language="Latin_Medieval">Augustobona</Name>
       <Name language="Lithuanian">Trua</Name>
       <Name language="Occitan">Tròias</Name>
     </Names>
@@ -50072,8 +50244,12 @@
     <Id>meaux</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_brie" order="1">b_meaux</GameId>
+      <GameId game="CK2HIP" parent="d_champagne" order="2">c_brie</GameId>
+      <GameId game="ImperatorRome">2447</GameId> <!-- Iatinon -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Iatinon</Name>
+      <Name language="Latin_Medieval">Iatinum</Name>
       <Name language="Lithuanian">Mo</Name>
     </Names>
   </LocationEntity>
@@ -50262,9 +50438,13 @@
     <Id>soissons</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_valois" order="3">b_soissons</GameId>
+      <GameId game="ImperatorRome">2452</GameId> <!-- Seussonia # Augusta Suessionum -->
     </GameIds>
     <Names>
       <Name language="Lithuanian">Suasonas</Name>
+      <Name language="Greek_Medieval">Augousta Suessionum</Name>
+      <Name language="Latin_Medieval">Augusta Suessionum</Name>
+      <Name language="Latin_Old">Seussonia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -50274,15 +50454,6 @@
     </GameIds>
     <Names>
       <Name language="Latin">Noviomium</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>senliscastle</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_valois" order="5">b_senliscastle</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Latin">Augustomagnus Castra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54310,7 +54481,18 @@
       <GameId game="CK2HIP" parent="k_andalusia" order="10">d_mallorca</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mayúrqa</Name>
+      <Name language="Arabic_Bedouin">Mayúrqa</Name>
+      <Name language="Arabic_Egypt">Mayúrqa</Name>
+      <Name language="Arabic_Levant">Mayúrqa</Name>
+      <Name language="Arabic_Maghreb">Mayúrqa</Name>
+      <Name language="Arabic_Yemen">Mayúrqa</Name>
+      <Name language="Basque">Maiorka</Name>
+      <Name language="French_Old">Majorque</Name>
+      <Name language="Hejazi_Arabic">Mayúrqa</Name>
       <Name language="Latin">Balearica</Name>
+      <Name language="Portuguese">Maiorca</Name>
+      <Name language="Sicilian_Arabic">Mayúrqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54319,8 +54501,18 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="5">b_santaponsa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sanat Busa</Name>
+      <Name language="Arabic_Bedouin">Sanat Busa</Name>
+      <Name language="Arabic_Egypt">Sanat Busa</Name>
+      <Name language="Arabic_Levant">Sanat Busa</Name>
+      <Name language="Arabic_Maghreb">Sanat Busa</Name>
+      <Name language="Arabic_Yemen">Sanat Busa</Name>
+      <Name language="Catalan_Medieval">Santa Ponça</Name>
+      <Name language="French_Old">Sainte Ponse</Name>
       <Name language="German">Santa Ponça</Name>
+      <Name language="Hejazi_Arabic">Sanat Busa</Name>
       <Name language="Romanian">Sfânta Ponția</Name> <!-- Translated -->
+      <Name language="Sicilian_Arabic">Sanat Busa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54329,7 +54521,19 @@
       <GameId game="CK2HIP" parent="c_menorca" order="1">b_ciutadella</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Madína Minúrqa</Name>
+      <Name language="Arabic_Bedouin">Madína Minúrqa</Name>
+      <Name language="Arabic_Egypt">Madína Minúrqa</Name>
+      <Name language="Arabic_Levant">Madína Minúrqa</Name>
+      <Name language="Arabic_Maghreb">Madína Minúrqa</Name>
+      <Name language="Arabic_Yemen">Madína Minúrqa</Name>
+      <Name language="Castilian">Ciudadela</Name>
       <Name language="French_Old">Ciudadela</Name>
+      <Name language="Greek_Medieval">Iamo</Name>
+      <Name language="Hejazi_Arabic">Madína Minúrqa</Name>
+      <Name language="Latin_Medieval">Iamo</Name>
+      <Name language="Portuguese">Ciutadela</Name>
+      <Name language="Sicilian_Arabic">Madína Minúrqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54338,30 +54542,47 @@
       <GameId game="CK2HIP" parent="c_menorca" order="4">b_santaagueda</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sent-Agayz</Name>
+      <Name language="Arabic_Bedouin">Sent-Agayz</Name>
+      <Name language="Arabic_Egypt">Sent-Agayz</Name>
+      <Name language="Arabic_Levant">Sent-Agayz</Name>
+      <Name language="Arabic_Maghreb">Sent-Agayz</Name>
+      <Name language="Arabic_Yemen">Sent-Agayz</Name>
+      <Name language="Basque">Santa Agata</Name>
       <Name language="Castilian">Santa Águe</Name>
+      <Name language="Catalan_Medieval">Santa Àgueda</Name>
+      <Name language="French_Old">Sainte Agathe</Name>
+      <Name language="Galician">Santa Ádega</Name>
+      <Name language="Hejazi_Arabic">Sent-Agayz</Name>
       <Name language="Romanian">Sfânta Agata</Name> <!-- Tranlsated -->
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>spanish_galicia</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="e_spain" order="7">k_spanish_galicia</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Castilian">Galitzia</Name>
-      <Name language="German">Galicien</Name>
-      <Name language="Gothic">Gallaecia</Name>
-      <Name language="Lombard">Gallaecia</Name>
+      <Name language="Sicilian_Arabic">Sent-Agayz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>galicia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="k_spanish_galicia" order="1">d_galicia</GameId>
+      <GameId game="CK2HIP" parent="e_spain" order="7">k_spanish_galicia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Jillíqiyya</Name>
+      <Name language="Arabic_Bedouin">Jillíqiyya</Name>
+      <Name language="Arabic_Egypt">Jillíqiyya</Name>
+      <Name language="Arabic_Levant">Jillíqiyya</Name>
+      <Name language="Arabic_Maghreb">Jillíqiyya</Name>
+      <Name language="Arabic_Yemen">Jillíqiyya</Name>
+      <Name language="Basque">Galizia</Name>
       <Name language="Castilian">Galitzia</Name>
-      <Name language="German">Galizien</Name>
+      <Name language="Catalan_Medieval">Galícia</Name>
+      <Name language="French_Old">Galice</Name>
+      <Name language="German">Galicien</Name> <!-- Or Galizien -->
+      <Name language="Gothic">Gallaecia</Name>
+      <Name language="Greek_Medieval">Kallaikia</Name>
+      <Name language="Hejazi_Arabic">Jillíqiyya</Name>
+      <Name language="Latin_Medieval">Gallaecia</Name>
+      <Name language="Lombard">Gallaecia</Name>
+      <Name language="Portuguese">Galiza</Name>
+      <Name language="Sicilian_Arabic">Jillíqiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54369,13 +54590,28 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_santiago" order="1">b_santiago</GameId>
       <GameId game="CK2HIP" parent="d_galicia" order="1">c_santiago</GameId>
+      <GameId game="ImperatorRome">1139</GameId> <!-- Assegonia -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shant Yáqub</Name>
+      <Name language="Arabic_Bedouin">Shant Yáqub</Name>
+      <Name language="Arabic_Egypt">Shant Yáqub</Name>
+      <Name language="Arabic_Levant">Shant Yáqub</Name>
+      <Name language="Arabic_Maghreb">Shant Yáqub</Name>
+      <Name language="Arabic_Yemen">Shant Yáqub</Name>
+      <Name language="Aragonese">Sant Chaime</Name>
+      <Name language="Basque">Done Jakue</Name>
+      <Name language="Catalan_Medieval">Sant Jaume</Name>
+      <Name language="French_Old">Saint-Jacques</Name>
       <Name language="Greek_Medieval">Assegonia</Name>
+      <Name language="Hejazi_Arabic">Shant Yáqub</Name>
       <Name language="Latgalian">Santjago</Name>
       <Name language="Latin">Assegonia</Name>
+      <Name language="Leonese">Santiagu</Name>
       <Name language="Lithuanian">Santjago</Name>
       <Name language="Occitan">Compostèla</Name>
+      <Name language="Portuguese">Sant'Iago</Name>
+      <Name language="Sicilian_Arabic">Shant Yáqub</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54384,8 +54620,18 @@
       <GameId game="CK2HIP" parent="c_santiago" order="2">b_pontevedra</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bunnibira</Name>
+      <Name language="Arabic_Bedouin">Bunnibira</Name>
+      <Name language="Arabic_Egypt">Bunnibira</Name>
+      <Name language="Arabic_Levant">Bunnibira</Name>
+      <Name language="Arabic_Maghreb">Bunnibira</Name>
+      <Name language="Arabic_Yemen">Bunnibira</Name>
+      <Name language="Basque">Pontebedra</Name>
+      <Name language="French_Old">Pontvieux</Name>
       <Name language="Greek_Medieval">Duos Pontes</Name>
+      <Name language="Hejazi_Arabic">Bunnibira</Name>
       <Name language="Latin">Duos Pontes</Name>
+      <Name language="Sicilian_Arabic">Bunnibira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54394,9 +54640,23 @@
       <GameId game="CK2HIP" parent="c_santiago" order="3">b_tuy</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tuddi</Name>
+      <Name language="Arabic_Bedouin">Tuddi</Name>
+      <Name language="Arabic_Egypt">Tuddi</Name>
+      <Name language="Arabic_Levant">Tuddi</Name>
+      <Name language="Arabic_Maghreb">Tuddi</Name>
+      <Name language="Arabic_Yemen">Tuddi</Name>
+      <Name language="Aragonese">Tui</Name>
+      <Name language="Basque">Tui</Name>
+      <Name language="Catalan_Medieval">Tui</Name>
+      <Name language="French_Old">Tui</Name>
+      <Name language="Galician">Tui</Name>
       <Name language="Greek_Medieval">Castellum Tude</Name>
-      <Name language="Norwegian">Tuj</Name>
+      <Name language="Hejazi_Arabic">Tuddi</Name>
       <Name language="Latin">Castellum Tude</Name>
+      <Name language="Norwegian">Tuj</Name>
+      <Name language="Portuguese">Tui</Name>
+      <Name language="Sicilian_Arabic">Tuddi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54405,10 +54665,19 @@
       <GameId game="CK2HIP" parent="c_santiago" order="4">b_vigo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Biqqu</Name>
+      <Name language="Arabic_Bedouin">Biqqu</Name>
+      <Name language="Arabic_Egypt">Biqqu</Name>
+      <Name language="Arabic_Levant">Biqqu</Name>
+      <Name language="Arabic_Maghreb">Biqqu</Name>
+      <Name language="Arabic_Yemen">Biqqu</Name>
+      <Name language="Basque">Bigo</Name>
       <Name language="Greek_Medieval">Burbida Magna</Name>
+      <Name language="Hejazi_Arabic">Biqqu</Name>
       <Name language="Latgalian">Bigo</Name>
-      <Name language="Lithuanian">Vigas</Name>
       <Name language="Latin">Burbida Magna</Name>
+      <Name language="Lithuanian">Vigas</Name>
+      <Name language="Sicilian_Arabic">Biqqu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54451,8 +54720,16 @@
       <GameId game="CK2HIP" parent="c_coruna" order="4">b_ferrol</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Fiyyrul</Name>
+      <Name language="Arabic_Bedouin">Fiyyrul</Name>
+      <Name language="Arabic_Egypt">Fiyyrul</Name>
+      <Name language="Arabic_Levant">Fiyyrul</Name>
+      <Name language="Arabic_Maghreb">Fiyyrul</Name>
+      <Name language="Arabic_Yemen">Fiyyrul</Name>
       <Name language="Greek_Medieval">Coelernos</Name>
+      <Name language="Hejazi_Arabic">Fiyyrul</Name>
       <Name language="Latin">Coelernos</Name>
+      <Name language="Sicilian_Arabic">Fiyyrul</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54462,18 +54739,41 @@
       <GameId game="CK2HIP" parent="d_galicia" order="3">c_lugo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Luq</Name>
+      <Name language="Arabic_Bedouin">Luq</Name>
+      <Name language="Arabic_Egypt">Luq</Name>
+      <Name language="Arabic_Levant">Luq</Name>
+      <Name language="Arabic_Maghreb">Luq</Name>
+      <Name language="Arabic_Yemen">Luq</Name>
       <Name language="Greek_Medieval">Lucus Augusti</Name>
+      <Name language="Hejazi_Arabic">Luq</Name>
       <Name language="Latin">Lucus Augusti</Name>
+      <Name language="Sicilian_Arabic">Luq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>villalba</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_lugo" order="2">b_villalba</GameId>
+      <GameId game="ImperatorRome">1302</GameId> <!-- Ocelum -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Abiad al-Qariya</Name>
+      <Name language="Arabic_Bedouin">Abiad al-Qariya</Name>
+      <Name language="Arabic_Egypt">Abiad al-Qariya</Name>
+      <Name language="Arabic_Levant">Abiad al-Qariya</Name>
+      <Name language="Arabic_Maghreb">Abiad al-Qariya</Name>
+      <Name language="Arabic_Yemen">Abiad al-Qariya</Name>
+      <Name language="Aragonese">Vilalba</Name>
+      <Name language="Basque">Herrizuria</Name>
+      <Name language="Catalan_Medieval">Vilalba</Name>
+      <Name language="French_Old">Villalbe</Name>
+      <Name language="Galician">Vilalba</Name>
       <Name language="Greek_Medieval">Ocelum</Name>
+      <Name language="Hejazi_Arabic">Abiad al-Qariya</Name>
       <Name language="Latin">Ocelum</Name>
+      <Name language="Portuguese">Vilalba</Name>
+      <Name language="Sicilian_Arabic">Abiad al-Qariya</Name>
       <Name language="Sicilian">Villarba</Name>
     </Names>
   </LocationEntity>
@@ -54483,8 +54783,21 @@
       <GameId game="CK2HIP" parent="c_lugo" order="3">b_mondonedo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mund'unn</Name>
+      <Name language="Arabic_Bedouin">Mund'unn</Name>
+      <Name language="Arabic_Egypt">Mund'unn</Name>
+      <Name language="Arabic_Levant">Mund'unn</Name>
+      <Name language="Arabic_Maghreb">Mund'unn</Name>
+      <Name language="Arabic_Yemen">Mund'unn</Name>
+      <Name language="Aragonese">Mondonyedo</Name>
+      <Name language="Catalan_Medieval">Mondonyedo</Name>
+      <Name language="French_Old">Mondognède</Name>
       <Name language="Greek_Medieval">Cariaca</Name>
+      <Name language="Hejazi_Arabic">Mund'unn</Name>
       <Name language="Latin">Cariaca</Name>
+      <Name language="Leonese">Mondoñéu</Name>
+      <Name language="Portuguese">Mondonhedo</Name>
+      <Name language="Sicilian_Arabic">Mund'unn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55817,12 +56130,32 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>oroumieh</Id>
+    <Id>oromieh</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_oromieh" order="1">b_oroumieh</GameId>
+      <GameId game="CK2HIP" parent="d_azerbaijan" order="3">c_oromieh</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Urmiya</Name>
+      <Name language="Arabic_Bedouin">Urmiya</Name>
+      <Name language="Arabic_Egypt">Urmiya</Name>
+      <Name language="Arabic_Levant">Urmiya</Name>
+      <Name language="Arabic_Maghreb">Urmiya</Name>
+      <Name language="Arabic_Yemen">Urmiya</Name>
+      <Name language="Armenian_Middle">Vormi</Name>
+      <Name language="Daylami">Urúmí</Name>
+      <Name language="Greek_Medieval">Ourmia</Name>
+      <Name language="Hejazi_Arabic">Urmiya</Name>
+      <Name language="Kurdish">Urmê</Name>
       <Name language="Latin">Oromieh</Name>
+      <Name language="Oghuz">Urmiye</Name>
+      <Name language="Persian_Middle">Urúmí</Name>
+      <Name language="Persian">Urúmí</Name>
+      <Name language="Sicilian_Arabic">Urmiya</Name>
+      <Name language="Syriac_Classical">Urmiyâ</Name>
+      <Name language="Tajiki">Urúmí</Name>
+      <Name language="Turkish_Old">Urmiye</Name>
+      <Name language="Turkmen_Medieval">Urmiye</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56819,12 +57152,66 @@
       <GameId game="CK2HIP" parent="c_olvia" order="3">b_odessa</GameId>
     </GameIds>
     <Names>
+      <Name language="Alan">Tyras</Name>
+      <Name language="Alemannic_Medieval">Ginestra</Name>
+      <Name language="Aragonese">Ginestra</Name>
+      <Name language="Arberian">Tyras</Name>
+      <Name language="Armenian_Middle">Tyras</Name>
+      <Name language="Arpitan">Ginestra</Name>
+      <Name language="Avar_Old">Hocabey</Name>
+      <Name language="Bashkir">Hocabey</Name>
+      <Name language="Basque">Ginestra</Name>
+      <Name language="Bavarian_Medieval">Ginestra</Name>
       <Name language="Bosnian">Crnograd</Name>
+      <Name language="Bulgar">Hacibey</Name>
       <Name language="Bulgarian">Cernograd</Name>
-      <Name language="Slovene">Crnograd</Name>
+      <Name language="Castilian">Ginestra</Name>
+      <Name language="Catalan_Medieval">Ginestra</Name>
+      <Name language="Circassian">Hocabey</Name>
       <Name language="Croatian">Crnograd</Name>
+      <Name language="Cuman">Hacibey</Name>
+      <Name language="Danish_Middle">Ginestra</Name>
+      <Name language="English_Middle">Ginestra</Name>
+      <Name language="Frankish_Low">Ginestra</Name>
+      <Name language="Frankish">Ginestra</Name>
+      <Name language="French_Old">Ginestra</Name>
+      <Name language="Georgian">Tyras</Name>
+      <Name language="German_Middle_High">Ginestra</Name>
+      <Name language="German_Middle_Low">Ginestra</Name>
+      <Name language="German_Old_Low">Ginestra</Name>
+      <Name language="Gothic_Crimean">Tyras</Name>
+      <Name language="Gothic">Ginestra</Name>
+      <Name language="Greek_Medieval">Tyras</Name>
+      <Name language="Italian_Central">Ginestra</Name>
+      <Name language="Italian_Medieval">Ginestra</Name>
+      <Name language="Khazar_Kabar">Hocabey</Name>
+      <Name language="Khazar">Hocabey</Name>
+      <Name language="Khitan">Hacibey</Name>
+      <Name language="Kyrgyz">Hacibey</Name>
+      <Name language="Langobardic">Ginestra</Name>
       <Name language="Latin">Tyras</Name>
+      <Name language="Leonese">Ginestra</Name>
+      <Name language="Ligurian">Ginestra</Name>
+      <Name language="Lithuanian_Medieval">Chadžibeju</Name>
+      <Name language="Mongol_Proto">Hacibey</Name>
+      <Name language="Neapolitan">Ginestra</Name>
+      <Name language="Norman">Ginestra</Name>
+      <Name language="Norwegian_Old">Ginestra</Name>
+      <Name language="Occitan_Old">Ginestra</Name>
+      <Name language="Oghuz">Hocabey</Name>
+      <Name language="Pecheneg">Hocabey</Name>
+      <Name language="Sardinian">Ginestra</Name>
       <Name language="Serbian">Crnograd</Name>
+      <Name language="Sicilian">Ginestra</Name>
+      <Name language="Slovene">Crnograd</Name>
+      <Name language="Swedish_Old">Ginestra</Name>
+      <Name language="Thuringian_Medieval">Ginestra</Name>
+      <Name language="Turkish_Old">Hocabey</Name>
+      <Name language="Turkmen_Medieval">Hocabey</Name>
+      <Name language="Tuscan_Medieval">Ginestra</Name>
+      <Name language="Umbrian_Medieval">Ginestra</Name>
+      <Name language="Uyghur">Hacibey</Name>
+      <Name language="Venetian_Medieval">Ginestra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56860,10 +57247,15 @@
     <Names>
       <Name language="Bosnian">Braslav</Name>
       <Name language="Bulgarian">Braslav</Name>
-      <Name language="Slovene">Braslav</Name>
       <Name language="Croatian">Braslav</Name>
+      <Name language="Czech_Medieval">Braclav</Name>
+      <Name language="Lithuanian_Medieval">Braclavas</Name>
+      <Name language="Polish_Old">Braclaw</Name>
       <Name language="Romanian">Brațlav</Name>
       <Name language="Serbian">Braslav</Name>
+      <Name language="Slovak_Medieval">Braclav</Name>
+      <Name language="Slovene">Braslav</Name>
+      <Name language="Sorbian">Braclaw</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58477,6 +58869,9 @@
       <GameId game="CK2HIP" parent="c_arcadia" order="1">b_nikli</GameId>
     </GameIds>
     <Names>
+      <Name language="Arpitan">Nicles</Name>
+      <Name language="French_Old">Nicles</Name>
+      <Name language="Norman">Nicles</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58485,6 +58880,9 @@
       <GameId game="CK2HIP" parent="c_arcadia" order="2">b_veligosti</GameId>
     </GameIds>
     <Names>
+      <Name language="Arpitan">Veligourt</Name>
+      <Name language="French_Old">Veligourt</Name>
+      <Name language="Norman">Veligourt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58493,6 +58891,13 @@
       <GameId game="CK2HIP" parent="c_arcadia" order="3">b_akova</GameId>
     </GameIds>
     <Names>
+      <Name language="Arpitan">Mategriffon</Name>
+      <Name language="French_Old">Mategriffon</Name>
+      <Name language="Norman">Mategriffon</Name>
+      <Name language="Oghuz">Ak Ova</Name>
+      <Name language="Pecheneg">Ak Ova</Name>
+      <Name language="Turkish_Old">Ak Ova</Name>
+      <Name language="Turkmen_Medieval">Ak Ova</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58615,22 +59020,46 @@
       <GameId game="CK2HIP" parent="c_paphlagonia" order="1">b_kastamonu</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Castra Comneni</Name>
+      <Name language="French_Old">Castra Comnene</Name>
+      <Name language="Italian_Central">Castra Comneni</Name>
+      <Name language="Italian_Medieval">Castra Comneni</Name>
+      <Name language="Langobardic">Castra Comneni</Name>
+      <Name language="Ligurian">Castra Comneni</Name>
+      <Name language="Neapolitan">Castra Comneni</Name>
+      <Name language="Norman">Castra Comnene</Name>
+      <Name language="Oghuz">Kastamoni</Name>
+      <Name language="Sardinian">Castra Comneni</Name>
+      <Name language="Sicilian">Castra Comneni</Name>
+      <Name language="Turkish_Old">Kastamoni</Name>
+      <Name language="Turkmen_Medieval">Kastamoni</Name>
+      <Name language="Tuscan_Medieval">Castra Comneni</Name>
+      <Name language="Umbrian_Medieval">Castra Comneni</Name>
+      <Name language="Venetian_Medieval">Castra Comneni</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>dadybra</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_paphlagonia" order="2">b_dadybra</GameId>
+      <GameId game="ImperatorRome">210</GameId> <!-- Dadybra -->
     </GameIds>
     <Names>
+      <Name language="Oghuz">Borlí</Name>
+      <Name language="Turkish_Old">Borlí</Name>
+      <Name language="Turkmen_Medieval">Borlí</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>pompeiopolis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_paphlagonia" order="3">b_pompeiopolis</GameId>
+      <GameId game="ImperatorRome">1827</GameId> <!-- Pompeiopolis -->
     </GameIds>
     <Names>
+      <Name language="Oghuz">Tasköprü</Name>
+      <Name language="Turkish_Old">Tasköprü</Name>
+      <Name language="Turkmen_Medieval">Tasköprü</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58640,6 +59069,9 @@
       <GameId game="CK2HIP" parent="d_paphlagonia" order="2">c_amastris</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Amasra</Name>
+      <Name language="Turkish_Old">Amasra</Name>
+      <Name language="Turkmen_Medieval">Amasra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58648,6 +59080,9 @@
       <GameId game="CK2HIP" parent="c_amastris" order="2">b_ionopolis</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Inebolu</Name>
+      <Name language="Turkish_Old">Inebolu</Name>
+      <Name language="Turkmen_Medieval">Inebolu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58656,6 +59091,9 @@
       <GameId game="CK2HIP" parent="c_amastris" order="3">b_parthenios</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Bartúní</Name>
+      <Name language="Turkish_Old">Bartúní</Name>
+      <Name language="Turkmen_Medieval">Bartúní</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58664,6 +59102,9 @@
       <GameId game="CK2HIP" parent="c_amastris" order="4">b_kotyron</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Cide</Name>
+      <Name language="Turkish_Old">Cide</Name>
+      <Name language="Turkmen_Medieval">Cide</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58680,6 +59121,9 @@
       <GameId game="CK2HIP" parent="c_herakleia" order="2">b_tion</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Filyos</Name>
+      <Name language="Turkish_Old">Filyos</Name>
+      <Name language="Turkmen_Medieval">Filyos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58688,6 +59132,9 @@
       <GameId game="CK2HIP" parent="c_herakleia" order="3">b_prousias</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Düzce</Name>
+      <Name language="Turkish_Old">Düzce</Name>
+      <Name language="Turkmen_Medieval">Düzce</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58704,6 +59151,9 @@
       <GameId game="CK2HIP" parent="c_vithynion" order="1">b_modrene</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Muturnu</Name>
+      <Name language="Turkish_Old">Muturnu</Name>
+      <Name language="Turkmen_Medieval">Muturnu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -58712,6 +59162,9 @@
       <GameId game="CK2HIP" parent="c_vithynion" order="2">b_flaviopolis</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Geredei Bolí</Name>
+      <Name language="Turkish_Old">Geredei Bolí</Name>
+      <Name language="Turkmen_Medieval">Geredei Bolí</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59169,8 +59622,14 @@
     <Id>thyateira</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_thyateira" order="1">b_thyateira</GameId>
+      <GameId game="ImperatorRome">274</GameId> <!-- Thyateira -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Thyateira</Name>
+      <Name language="Latin_Old">Thyatira</Name>
+      <Name language="Oghuz">Ak Hisar</Name>
+      <Name language="Turkish_Old">Ak Hisar</Name>
+      <Name language="Turkmen_Medieval">Ak Hisar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59564,6 +60023,30 @@
       <GameId game="CK2HIP" parent="d_optimatoi" order="1">c_nikomedeia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Niqmúdiyah</Name>
+      <Name language="Arabic_Bedouin">Niqmúdiyah</Name>
+      <Name language="Arabic_Egypt">Niqmúdiyah</Name>
+      <Name language="Arabic_Levant">Niqmúdiyah</Name>
+      <Name language="Arabic_Maghreb">Niqmúdiyah</Name>
+      <Name language="Arabic_Yemen">Niqmúdiyah</Name>
+      <Name language="Dalmatian_Medieval">Nicomedia</Name>
+      <Name language="French_Old">Nicomédie</Name>
+      <Name language="Hejazi_Arabic">Niqmúdiyah</Name>
+      <Name language="Italian_Central">Nicomedia</Name>
+      <Name language="Italian_Medieval">Nicomedia</Name>
+      <Name language="Langobardic">Nicomedia</Name>
+      <Name language="Ligurian">Nicomedia</Name>
+      <Name language="Neapolitan">Nicomedia</Name>
+      <Name language="Norman">Nicomédie</Name>
+      <Name language="Oghuz">Iznikmid</Name>
+      <Name language="Sardinian">Nicomedia</Name>
+      <Name language="Sicilian_Arabic">Niqmúdiyah</Name>
+      <Name language="Sicilian">Nicomedia</Name>
+      <Name language="Turkish_Old">Iznikmid</Name>
+      <Name language="Turkmen_Medieval">Iznikmid</Name>
+      <Name language="Tuscan_Medieval">Nicomedia</Name>
+      <Name language="Umbrian_Medieval">Nicomedia</Name>
+      <Name language="Venetian_Medieval">Nicomedia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59572,6 +60055,9 @@
       <GameId game="CK2HIP" parent="c_nikomedeia" order="2">b_praenetos</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Karamürsel</Name>
+      <Name language="Turkish_Old">Karamürsel</Name>
+      <Name language="Turkmen_Medieval">Karamürsel</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59580,6 +60066,11 @@
       <GameId game="CK2HIP" parent="c_nikomedeia" order="3">b_daphnousia</GameId>
     </GameIds>
     <Names>
+      <Name language="French_Old">Daphnusie</Name>
+      <Name language="Norman">Daphnusie</Name>
+      <Name language="Oghuz">Kandira</Name>
+      <Name language="Turkish_Old">Kandira</Name>
+      <Name language="Turkmen_Medieval">Kandira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59588,6 +60079,9 @@
       <GameId game="CK2HIP" parent="c_nikomedeia" order="4">b_kibotos</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Hersek</Name>
+      <Name language="Turkish_Old">Hersek</Name>
+      <Name language="Turkmen_Medieval">Hersek</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59596,6 +60090,9 @@
       <GameId game="CK2HIP" parent="c_nikomedeia" order="6">b_niketiata</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Gekivize</Name>
+      <Name language="Turkish_Old">Gekivize</Name>
+      <Name language="Turkmen_Medieval">Gekivize</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59928,6 +60425,9 @@
       <GameId game="CK2HIP" parent="c_galatia" order="4">b_basilika_therma</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Terzili</Name>
+      <Name language="Turkish_Old">Terzili</Name>
+      <Name language="Turkmen_Medieval">Terzili</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -59936,6 +60436,14 @@
       <GameId game="CK2HIP" parent="k_anatolia" order="2">d_cappadocia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qabádhaq</Name>
+      <Name language="Arabic_Bedouin">Qabádhaq</Name>
+      <Name language="Arabic_Egypt">Qabádhaq</Name>
+      <Name language="Arabic_Levant">Qabádhaq</Name>
+      <Name language="Arabic_Maghreb">Qabádhaq</Name>
+      <Name language="Arabic_Yemen">Qabádhaq</Name>
+      <Name language="Hejazi_Arabic">Qabádhaq</Name>
+      <Name language="Sicilian_Arabic">Qabádhaq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60145,6 +60653,12 @@
       <GameId game="CK2HIP" parent="d_sebasteia" order="1">c_sebastia</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Sebasta</Name>
+      <Name language="French_Old">Sébaste</Name>
+      <Name language="Norman">Sébaste</Name>
+      <Name language="Oghuz">Sivas</Name>
+      <Name language="Turkish_Old">Sivas</Name>
+      <Name language="Turkmen_Medieval">Sivas</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60161,6 +60675,10 @@
       <GameId game="CK2HIP" parent="c_sebastia" order="3">b_verisa</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Bolis</Name>
+      <Name language="Oghuz">Bolus</Name>
+      <Name language="Turkish_Old">Bolus</Name>
+      <Name language="Turkmen_Medieval">Bolus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60875,6 +61393,42 @@
       <GameId game="CK2HIP" parent="d_cherson" order="1">c_theodosia</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Tepsen</Name>
+      <Name language="Bashkir">Tepsen</Name>
+      <Name language="Bosnian_Medieval">Kaffa</Name>
+      <Name language="Bulgar">Tepsen</Name>
+      <Name language="Bulgarian_Old">Kaffa</Name>
+      <Name language="Circassian">Tepsen</Name>
+      <Name language="Croatian_Medieval">Kaffa</Name>
+      <Name language="Cuman">Kefe</Name>
+      <Name language="Czech_Medieval">Kaffa</Name>
+      <Name language="Dalmatian_Medieval">Caffa</Name>
+      <Name language="Italian_Central">Caffa</Name>
+      <Name language="Italian_Medieval">Caffa</Name>
+      <Name language="Karluk">Tepsen</Name>
+      <Name language="Khazar_Kabar">Tepsen</Name>
+      <Name language="Khazar">Tepsen</Name>
+      <Name language="Kyrgyz">Kefe</Name>
+      <Name language="Langobardic">Caffa</Name>
+      <Name language="Ligurian">Cafà</Name>
+      <Name language="Mongol_Proto">Kefe</Name>
+      <Name language="Neapolitan">Caffa</Name>
+      <Name language="Oghuz">Tepsen</Name>
+      <Name language="Pecheneg">Tepsen</Name>
+      <Name language="Polish_Old">Kaffa</Name>
+      <Name language="Russian_Medieval">Kaffa</Name>
+      <Name language="Sardinian">Caffa</Name>
+      <Name language="Serbian_Medieval">Kaffa</Name>
+      <Name language="Sicilian">Caffa</Name>
+      <Name language="Slovak_Medieval">Kaffa</Name>
+      <Name language="Slovene_Medieval">Kaffa</Name>
+      <Name language="Sorbian">Kaffa</Name>
+      <Name language="Turkish_Old">Kefe</Name>
+      <Name language="Turkmen_Medieval">Tepsen</Name>
+      <Name language="Tuscan_Medieval">Caffa</Name>
+      <Name language="Umbrian_Medieval">Caffa</Name>
+      <Name language="Uyghur">Kefe</Name>
+      <Name language="Venetian_Medieval">Caffa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60883,6 +61437,42 @@
       <GameId game="CK2HIP" parent="c_theodosia" order="2">b_sukdak</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Sudaq</Name>
+      <Name language="Bashkir">Sudaq</Name>
+      <Name language="Bosnian_Medieval">Surož</Name>
+      <Name language="Bulgar">Sudaq</Name>
+      <Name language="Bulgarian_Old">Surož</Name>
+      <Name language="Circassian">Sudaq</Name>
+      <Name language="Croatian_Medieval">Surož</Name>
+      <Name language="Cuman">Sudaq</Name>
+      <Name language="Czech_Medieval">Surož</Name>
+      <Name language="Dalmatian_Medieval">Soldaia</Name>
+      <Name language="Italian_Central">Soldaia</Name>
+      <Name language="Italian_Medieval">Soldaia</Name>
+      <Name language="Karluk">Sudaq</Name>
+      <Name language="Khazar_Kabar">Sudaq</Name>
+      <Name language="Khazar">Sudaq</Name>
+      <Name language="Kyrgyz">Sudaq</Name>
+      <Name language="Langobardic">Soldaia</Name>
+      <Name language="Ligurian">Soldaia</Name>
+      <Name language="Mongol_Proto">Sudaq</Name>
+      <Name language="Neapolitan">Soldaia</Name>
+      <Name language="Oghuz">Sudaq</Name>
+      <Name language="Pecheneg">Sudaq</Name>
+      <Name language="Polish_Old">Surož</Name>
+      <Name language="Russian_Medieval">Surož</Name>
+      <Name language="Sardinian">Soldaia</Name>
+      <Name language="Serbian_Medieval">Surož</Name>
+      <Name language="Sicilian">Soldaia</Name>
+      <Name language="Slovak_Medieval">Surož</Name>
+      <Name language="Slovene_Medieval">Surož</Name>
+      <Name language="Sorbian">Surož</Name>
+      <Name language="Turkish_Old">Sudak</Name>
+      <Name language="Turkmen_Medieval">Sudaq</Name>
+      <Name language="Tuscan_Medieval">Soldaia</Name>
+      <Name language="Umbrian_Medieval">Soldaia</Name>
+      <Name language="Uyghur">Sudaq</Name>
+      <Name language="Venetian_Medieval">Soldaia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60891,14 +61481,73 @@
       <GameId game="CK2HIP" parent="c_theodosia" order="4">b_partenit</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bartania</Name>
+      <Name language="Arabic_Bedouin">Bartania</Name>
+      <Name language="Arabic_Egypt">Bartania</Name>
+      <Name language="Arabic_Levant">Bartania</Name>
+      <Name language="Arabic_Maghreb">Bartania</Name>
+      <Name language="Arabic_Yemen">Bartania</Name>
+      <Name language="Avar_Old">Brt-nit</Name>
+      <Name language="Bashkir">Brt-nit</Name>
+      <Name language="Circassian">Brt-nit</Name>
+      <Name language="Cuman">Bartinit</Name>
+      <Name language="Dalmatian_Medieval">Pertinice</Name>
+      <Name language="Hejazi_Arabic">Bartania</Name>
+      <Name language="Italian_Central">Pertinice</Name>
+      <Name language="Italian_Medieval">Pertinice</Name>
+      <Name language="Karluk">Brt-nit</Name>
+      <Name language="Khazar_Kabar">Brt-nit</Name>
+      <Name language="Khazar">Brt-nit</Name>
+      <Name language="Kyrgyz">Bartinit</Name>
+      <Name language="Langobardic">Pertinice</Name>
+      <Name language="Ligurian">Pertinice</Name>
+      <Name language="Mongol_Proto">Bartinit</Name>
+      <Name language="Neapolitan">Pertinice</Name>
+      <Name language="Oghuz">Bartinit</Name>
+      <Name language="Pecheneg">Bartinit</Name>
+      <Name language="Russian_Medieval">Partenit</Name>
+      <Name language="Sardinian">Pertinice</Name>
+      <Name language="Sicilian_Arabic">Bartania</Name>
+      <Name language="Sicilian">Pertinice</Name>
+      <Name language="Turkish_Old">Bartinit</Name>
+      <Name language="Turkmen_Medieval">Bartinit</Name>
+      <Name language="Tuscan_Medieval">Pertinice</Name>
+      <Name language="Umbrian_Medieval">Pertinice</Name>
+      <Name language="Uyghur">Bartinit</Name>
+      <Name language="Venetian_Medieval">Pertinice</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>mangup</Id>
+    <Id>theodoro</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_theodoro" order="1">b_mangup</GameId>
+      <GameId game="CK2HIP" parent="d_cherson" order="2">c_theodoro</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Mangup</Name>
+      <Name language="Bashkir">Mangup</Name>
+      <Name language="Circassian">Mangup</Name>
+      <Name language="Cuman">Mangup</Name>
+      <Name language="Gothic_Crimean">Theodoro</Name>
+      <Name language="Italian_Central">Theodoro</Name>
+      <Name language="Italian_Medieval">Theodoro</Name>
+      <Name language="Karluk">Mangup</Name>
+      <Name language="Khazar_Kabar">Mangup</Name>
+      <Name language="Khazar">Mangup</Name>
+      <Name language="Kyrgyz">Mangup</Name>
+      <Name language="Langobardic">Theodoro</Name>
+      <Name language="Ligurian">Theodoro</Name>
+      <Name language="Mongol_Proto">Mangup</Name>
+      <Name language="Neapolitan">Theodoro</Name>
+      <Name language="Oghuz">Mangup</Name>
+      <Name language="Pecheneg">Mangup</Name>
+      <Name language="Sardinian">Theodoro</Name>
+      <Name language="Sicilian">Theodoro</Name>
+      <Name language="Turkish_Old">Mangup</Name>
+      <Name language="Turkmen_Medieval">Mangup</Name>
+      <Name language="Tuscan_Medieval">Theodoro</Name>
+      <Name language="Umbrian_Medieval">Theodoro</Name>
+      <Name language="Uyghur">Mangup</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60907,6 +61556,17 @@
       <GameId game="CK2HIP" parent="c_theodoro" order="2">b_funa</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Funa</Name>
+      <Name language="Italian_Central">Funa</Name>
+      <Name language="Italian_Medieval">Funa</Name>
+      <Name language="Langobardic">Funa</Name>
+      <Name language="Ligurian">Funa</Name>
+      <Name language="Neapolitan">Funa</Name>
+      <Name language="Sardinian">Funa</Name>
+      <Name language="Sicilian">Funa</Name>
+      <Name language="Tuscan_Medieval">Funa</Name>
+      <Name language="Umbrian_Medieval">Funa</Name>
+      <Name language="Venetian_Medieval">Funa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60915,6 +61575,20 @@
       <GameId game="CK2HIP" parent="c_theodoro" order="3">b_inkerman</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Inkerman</Name>
+      <Name language="Bashkir">Inkerman</Name>
+      <Name language="Circassian">Inkerman</Name>
+      <Name language="Cuman">Inkerman</Name>
+      <Name language="Karluk">Inkerman</Name>
+      <Name language="Khazar_Kabar">Inkerman</Name>
+      <Name language="Khazar">Inkerman</Name>
+      <Name language="Kyrgyz">Inkerman</Name>
+      <Name language="Mongol_Proto">Inkerman</Name>
+      <Name language="Oghuz">Inkerman</Name>
+      <Name language="Pecheneg">Inkerman</Name>
+      <Name language="Turkish_Old">Inkerman</Name>
+      <Name language="Turkmen_Medieval">Inkerman</Name>
+      <Name language="Uyghur">Inkerman</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60923,6 +61597,31 @@
       <GameId game="CK2HIP" parent="c_cherson" order="2">b_balaklava</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Baliqlava</Name>
+      <Name language="Bashkir">Baliqlava</Name>
+      <Name language="Circassian">Baliqlava</Name>
+      <Name language="Cuman">Balikayya</Name>
+      <Name language="Dalmatian_Medieval">Cembalo</Name>
+      <Name language="Italian_Central">Cembalo</Name>
+      <Name language="Italian_Medieval">Cembalo</Name>
+      <Name language="Karluk">Balikayya</Name>
+      <Name language="Khazar_Kabar">Baliqlava</Name>
+      <Name language="Khazar">Baliqlava</Name>
+      <Name language="Kyrgyz">Balikayya</Name>
+      <Name language="Langobardic">Cembalo</Name>
+      <Name language="Ligurian">Cembalo</Name>
+      <Name language="Mongol_Proto">Balikayya</Name>
+      <Name language="Neapolitan">Cembalo</Name>
+      <Name language="Oghuz">Baliklava</Name>
+      <Name language="Pecheneg">Baliklava</Name>
+      <Name language="Sardinian">Cembalo</Name>
+      <Name language="Sicilian">Cembalo</Name>
+      <Name language="Turkish_Old">Baliklava</Name>
+      <Name language="Turkmen_Medieval">Baliklava</Name>
+      <Name language="Tuscan_Medieval">Cembalo</Name>
+      <Name language="Umbrian_Medieval">Cembalo</Name>
+      <Name language="Uyghur">Balikayya</Name>
+      <Name language="Venetian_Medieval">Cembalo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60931,6 +61630,17 @@
       <GameId game="CK2HIP" parent="c_cherson" order="4">b_foros</GameId>
     </GameIds>
     <Names>
+      <Name language="Dalmatian_Medieval">Fovi</Name>
+      <Name language="Italian_Central">Fovi</Name>
+      <Name language="Italian_Medieval">Fovi</Name>
+      <Name language="Langobardic">Fovi</Name>
+      <Name language="Ligurian">Fovi</Name>
+      <Name language="Neapolitan">Fovi</Name>
+      <Name language="Sardinian">Fovi</Name>
+      <Name language="Sicilian">Fovi</Name>
+      <Name language="Tuscan_Medieval">Fovi</Name>
+      <Name language="Umbrian_Medieval">Fovi</Name>
+      <Name language="Venetian_Medieval">Fovi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60939,6 +61649,31 @@
       <GameId game="CK2HIP" parent="c_cherson" order="5">b_gurzuf</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Gurzuf</Name>
+      <Name language="Bashkir">Gurzuf</Name>
+      <Name language="Circassian">Gurzuf</Name>
+      <Name language="Cuman">Gurzuf</Name>
+      <Name language="Dalmatian_Medieval">Gorzona</Name>
+      <Name language="Italian_Central">Gorzona</Name>
+      <Name language="Italian_Medieval">Gorzona</Name>
+      <Name language="Karluk">Gurzuf</Name>
+      <Name language="Khazar_Kabar">Gurzuf</Name>
+      <Name language="Khazar">Gurzuf</Name>
+      <Name language="Kyrgyz">Gurzuf</Name>
+      <Name language="Langobardic">Gorzona</Name>
+      <Name language="Ligurian">Gruzuli</Name>
+      <Name language="Mongol_Proto">Gurzuf</Name>
+      <Name language="Neapolitan">Gorzona</Name>
+      <Name language="Oghuz">Gurzuf</Name>
+      <Name language="Pecheneg">Gurzuf</Name>
+      <Name language="Sardinian">Gorzona</Name>
+      <Name language="Sicilian">Gorzona</Name>
+      <Name language="Turkish_Old">Gurzuf</Name>
+      <Name language="Turkmen_Medieval">Gurzuf</Name>
+      <Name language="Tuscan_Medieval">Gorzona</Name>
+      <Name language="Umbrian_Medieval">Gorzona</Name>
+      <Name language="Uyghur">Gurzuf</Name>
+      <Name language="Venetian_Medieval">Gorzona</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60971,6 +61706,9 @@
       <GameId game="CK2HIP" parent="c_amasia" order="3">b_zela</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Zile</Name>
+      <Name language="Turkish_Old">Zile</Name>
+      <Name language="Turkmen_Medieval">Zile</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60979,6 +61717,9 @@
       <GameId game="CK2HIP" parent="c_amasia" order="4">b_ibora</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Iverönü</Name>
+      <Name language="Turkish_Old">Iverönü</Name>
+      <Name language="Turkmen_Medieval">Iverönü</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -60990,29 +61731,29 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>kastronamisos</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_amisos" order="1">b_kastronamisos</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>sinope</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_sinope" order="1">b_kastronsinope</GameId>
       <GameId game="CK2HIP" parent="c_sinope" order="2">b_sinope</GameId>
       <GameId game="CK2HIP" parent="d_armeniacon" order="3">c_sinope</GameId>
+      <GameId game="ImperatorRome">1812</GameId> <!-- Sinope -->
     </GameIds>
     <Names>
+      <Name language="Oghuz">Sinob</Name>
+      <Name language="Turkish_Old">Sinob</Name>
+      <Name language="Turkmen_Medieval">Sinob</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>leontopolis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_sinope" order="3">b_leontopolis</GameId>
+      <GameId game="ImperatorRome">504</GameId> <!-- Leontopolis -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Late">Taremu</Name>
+      <Name language="Greek_Ancient">Leontopolis</Name>
+      <Name language="Latin_Old">Leontos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61022,22 +61763,33 @@
       <GameId game="CK2HIP" parent="d_armeniacon" order="4">c_eukhaita</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Çorum</Name>
+      <Name language="Turkish_Old">Çorum</Name>
+      <Name language="Turkmen_Medieval">Çorum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>asklepios</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_eukhaita" order="1">b_asklepios</GameId>
+      <GameId game="ImperatorRome">203</GameId> <!-- Asklepios -->
     </GameIds>
     <Names>
+      <Name language="Oghuz">Iskilip</Name>
+      <Name language="Turkish_Old">Iskilip</Name>
+      <Name language="Turkmen_Medieval">Iskilip</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>andrapa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_eukhaita" order="3">b_andrapa</GameId>
+      <GameId game="ImperatorRome">1824</GameId> <!-- Andrapa -->
     </GameIds>
     <Names>
+      <Name language="Oghuz">Vezirköprü</Name>
+      <Name language="Turkish_Old">Vezirköprü</Name>
+      <Name language="Turkmen_Medieval">Vezirköprü</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61045,12 +61797,18 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_tarsos" order="2">b_tarsos</GameId>
       <GameId game="CK2HIP" parent="d_armenia_minor" order="1">c_tarsos</GameId>
+      <GameId game="ImperatorRome">1883</GameId> <!-- Tarsus -->
     </GameIds>
     <Names>
       <Name language="Armenian_Middle">Darson</Name>
       <Name language="French_Old">Tarse</Name>
+      <Name language="Greek_Ancient_Seleukia">Antiocheia Kydnos</Name>
+      <Name language="Greek_Ancient">Tarsos</Name>
+      <Name language="Latin_Old">Tarsus</Name>
       <Name language="Norman">Tarse</Name>
       <Name language="Oghuz">Tarsus</Name>
+      <Name language="Phoenician">Tarshish</Name>
+      <Name language="Punic">Tarshish</Name>
       <Name language="Turkish_Old">Tarsus</Name>
       <Name language="Turkmen_Medieval">Tarsus</Name>
     </Names>
@@ -61061,6 +61819,12 @@
       <GameId game="CK2HIP" parent="c_tarsos" order="1">b_lampron</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Lamprun</Name>
+      <Name language="French_Old">Les Embruns</Name>
+      <Name language="Norman">Les Embruns</Name>
+      <Name language="Oghuz">Namrun</Name>
+      <Name language="Turkish_Old">Namrun</Name>
+      <Name language="Turkmen_Medieval">Namrun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61291,6 +62055,20 @@
       <GameId game="CK2HIP" parent="c_teluch" order="2">b_marash</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mar'ash</Name>
+      <Name language="Arabic_Bedouin">Mar'ash</Name>
+      <Name language="Arabic_Egypt">Mar'ash</Name>
+      <Name language="Arabic_Levant">Mar'ash</Name>
+      <Name language="Arabic_Maghreb">Mar'ash</Name>
+      <Name language="Arabic_Yemen">Mar'ash</Name>
+      <Name language="Armenian_Middle">Maraš</Name>
+      <Name language="French_Old">Mariscum</Name>
+      <Name language="Hejazi_Arabic">Mar'ash</Name>
+      <Name language="Norman">Mariscum</Name>
+      <Name language="Oghuz">Maras</Name>
+      <Name language="Sicilian_Arabic">Mar'ash</Name>
+      <Name language="Turkish_Old">Maras</Name>
+      <Name language="Turkmen_Medieval">Maras</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61299,6 +62077,10 @@
       <GameId game="CK2HIP" parent="c_teluch" order="3">b_zeytun</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Zeytoun</Name>
+      <Name language="Oghuz">Süleymanli</Name>
+      <Name language="Turkish_Old">Süleymanli</Name>
+      <Name language="Turkmen_Medieval">Süleymanli</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61509,11 +62291,21 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>pomorie</Id>
+    <Id>anchialos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_mesembria" order="4">b_pomorie</GameId>
+      <GameId game="ImperatorRome">481</GameId> <!-- Anchialos -->
     </GameIds>
     <Names>
+      <Name language="Gothic_Crimean">Anchialos</Name>
+      <Name language="Greek_Ancient">Anchialos</Name>
+      <Name language="Greek_Medieval">Anchialos</Name>
+      <Name language="Latin_Medieval">Anchialus</Name>
+      <Name language="Latin_Old">Anchialus</Name>
+      <Name language="Oghuz">Ahyolu</Name>
+      <Name language="Pecheneg">Ahyolu</Name>
+      <Name language="Turkish_Old">Ahyolu</Name>
+      <Name language="Turkmen_Medieval">Ahyolu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61522,6 +62314,13 @@
       <GameId game="CK2HIP" parent="c_mesembria" order="6">b_debelt</GameId>
     </GameIds>
     <Names>
+      <Name language="Gothic_Crimean">Debeltos</Name>
+      <Name language="Greek_Medieval">Debeltos</Name>
+      <Name language="Latin_Medieval">Deultum</Name>
+      <Name language="Oghuz">Yakezli</Name>
+      <Name language="Pecheneg">Yakezli</Name>
+      <Name language="Turkish_Old">Yakezli</Name>
+      <Name language="Turkmen_Medieval">Yakezli</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61530,6 +62329,12 @@
       <GameId game="CK2HIP" parent="c_mesembria" order="7">b_rusokastro</GameId>
     </GameIds>
     <Names>
+      <Name language="Gothic_Crimean">Rusokastrón</Name>
+      <Name language="Greek_Medieval">Rusokastrón</Name>
+      <Name language="Oghuz">Rus Kasri</Name>
+      <Name language="Pecheneg">Rus Kasri</Name>
+      <Name language="Turkish_Old">Rus Kasri</Name>
+      <Name language="Turkmen_Medieval">Rus Kasri</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -61615,16 +62420,28 @@
     <Id>ram_branicevo</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_branicevo" order="2">b_ram_branicevo</GameId>
+      <GameId game="ImperatorRome">4827</GameId> <!-- Lederata -->
     </GameIds>
     <Names>
+      <Name language="Gothic_Crimean">Lederata</Name>
+      <Name language="Greek_Medieval">Lederata</Name>
+      <Name language="Latin_Medieval">Lederata</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>cuprija_ravno</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_branicevo" order="4">b_cuprija_ravno</GameId>
+      <GameId game="ImperatorRome">4203</GameId> <!-- Horreum Margi -->
     </GameIds>
     <Names>
+      <Name language="Gothic_Crimean">Géfyra</Name>
+      <Name language="Greek_Medieval">Géfyra</Name>
+      <Name language="Latin_Medieval">Horreum Margi</Name>
+      <Name language="Oghuz">Köpri</Name>
+      <Name language="Pecheneg">Köpri</Name>
+      <Name language="Turkish_Old">Köpri</Name>
+      <Name language="Turkmen_Medieval">Köpri</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65847,8 +66664,15 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_itfih" order="1">b_itfih</GameId>
       <GameId game="CK2HIP" parent="d_cairo" order="5">c_itfih</GameId>
+      <GameId game="ImperatorRome">538</GameId> <!-- Aphroditopolis -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Tpeh</Name>
+      <Name language="Egyptian_Late">Tepihu</Name>
+      <Name language="Greek_Ancient">Aphroditoupolis</Name>
+      <Name language="Greek_Medieval">Aphroditoupolis</Name>
+      <Name language="Latin_Medieval">Aphroditopolis</Name>
+      <Name language="Latin_Old">Aphroditopolis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65857,6 +66681,8 @@
       <GameId game="CK2HIP" parent="c_itfih" order="2">b_busir</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Bousiris</Name>
+      <Name language="Latin_Medieval">Bousiris</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65865,6 +66691,9 @@
       <GameId game="CK2HIP" parent="c_itfih" order="3">b_lahun</GameId>
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Lehone</Name>
+      <Name language="Greek_Medieval">Ptolemais Hormou</Name>
+      <Name language="Latin_Medieval">Ptolemais Hormou</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65872,16 +66701,29 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_bahnasa" order="1">b_bahnasa</GameId>
       <GameId game="CK2HIP" parent="d_cairo" order="6">c_bahnasa</GameId>
+      <GameId game="ImperatorRome">545</GameId> <!-- Oxyrhynchus -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Coptic">Pemdje</Name>
+      <Name language="Egyptian_Late">Per-Medjed</Name>
+      <Name language="Greek_Ancient">Oxyrynchos</Name>
+      <Name language="Greek_Medieval">Oxyrynchos</Name>
+      <Name language="Latin_Medieval">Oxirinchus</Name> <!-- Or Oxyrhynchus -->
+      <Name language="Latin_Old">Oxirinchus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>alqays</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_bahnasa" order="3">b_alqays</GameId>
+      <GameId game="ImperatorRome">546</GameId> <!-- Kynopolis -->
     </GameIds>
     <Names>
+      <Name language="Egyptian_Late">Saka</Name>
+      <Name language="Greek_Ancient">Kynopolis</Name>
+      <Name language="Greek_Medieval">Kynopolis</Name>
+      <Name language="Latin_Medieval">Cynopolis</Name>
+      <Name language="Latin_Old">Canum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65890,6 +66732,8 @@
       <GameId game="CK2HIP" parent="c_bahnasa" order="5">b_ahnas</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Heracleopolis Megas</Name>
+      <Name language="Latin_Medieval">Heracleopolis Magna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -65917,6 +66761,16 @@
       <GameId game="CK2HIP" parent="c_dakhila" order="2">b_farfarun</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Farfárun</Name>
+      <Name language="Arabic_Bedouin">Farfárun</Name>
+      <Name language="Arabic_Egypt">Farfárun</Name>
+      <Name language="Arabic_Levant">Farfárun</Name>
+      <Name language="Arabic_Maghreb">Farfárun</Name>
+      <Name language="Arabic_Yemen">Farfárun</Name>
+      <Name language="Greek_Medieval">Trinytheos</Name>
+      <Name language="Hejazi_Arabic">Farfárun</Name>
+      <Name language="Latin_Medieval">Trinytheos</Name>
+      <Name language="Sicilian_Arabic">Farfárun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66244,6 +67098,18 @@
       <GameId game="CK2HIP" parent="c_aleppo" order="2">b_zardana</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Atarib</Name>
+      <Name language="Arabic_Bedouin">al-Atarib</Name>
+      <Name language="Arabic_Egypt">al-Atarib</Name>
+      <Name language="Arabic_Levant">al-Atarib</Name>
+      <Name language="Arabic_Maghreb">al-Atarib</Name>
+      <Name language="Arabic_Yemen">al-Atarib</Name>
+      <Name language="French_Old">Cerepum</Name>
+      <Name language="Greek_Medieval">Cerepum</Name>
+      <Name language="Hejazi_Arabic">al-Atarib</Name>
+      <Name language="Latin_Medieval">Cerepum</Name>
+      <Name language="Norman">Cerepum</Name>
+      <Name language="Sicilian_Arabic">al-Atarib</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66494,6 +67360,16 @@
       <GameId game="CK2HIP" parent="c_amman" order="3">b_salt</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">as-Salt</Name>
+      <Name language="Arabic_Bedouin">as-Salt</Name>
+      <Name language="Arabic_Egypt">as-Salt</Name>
+      <Name language="Arabic_Levant">as-Salt</Name>
+      <Name language="Arabic_Maghreb">as-Salt</Name>
+      <Name language="Arabic_Yemen">as-Salt</Name>
+      <Name language="Greek_Medieval">Saltus</Name>
+      <Name language="Hejazi_Arabic">as-Salt</Name>
+      <Name language="Latin_Medieval">Saltus</Name>
+      <Name language="Sicilian_Arabic">as-Salt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66564,8 +67440,11 @@
     <Id>bethsan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_beersheb" order="1">b_bethsan</GameId>
+      <GameId game="ImperatorRome">673</GameId> <!-- Scythopolis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Skythopolis</Name>
+      <Name language="Latin_Medieval">Scythopolis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -66574,22 +67453,30 @@
       <GameId game="CK2HIP" parent="c_beersheb" order="2">b_nablus</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>st_abraham</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_jerusalem" order="3">c_hebron</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Medieval">Neapolis</Name>
+      <Name language="Latin_Medieval">Neapolis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>hebron</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_hebron" order="1">b_hebron</GameId>
+      <GameId game="CK2HIP" parent="d_jerusalem" order="3">c_hebron</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Khalíl</Name>
+      <Name language="Arabic_Bedouin">al-Khalíl</Name>
+      <Name language="Arabic_Egypt">al-Khalíl</Name>
+      <Name language="Arabic_Levant">al-Khalíl</Name>
+      <Name language="Arabic_Maghreb">al-Khalíl</Name>
+      <Name language="Arabic_Yemen">al-Khalíl</Name>
+      <Name language="Greek_Medieval">Hebrón</Name>
+      <Name language="Hejazi_Arabic">al-Khalíl</Name>
+      <Name language="Latin_Medieval">Hebron</Name>
+      <Name language="Sanhaja">al-Khalíl</Name>
+      <Name language="Sicilian_Arabic">al-Khalíl</Name>
+      <Name language="Tuareg">al-Khalíl</Name>
+      <Name language="Zenati">al-Khalíl</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -74089,28 +74976,29 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>brie</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_champagne" order="2">c_brie</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>sens</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_champagne" order="4">c_sens</GameId>
       <GameId game="CK2HIP" parent="c_sens" order="1">b_sens</GameId>
+      <GameId game="ImperatorRome">2448</GameId> <!-- Agedincum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Agedincum</Name>
+      <Name language="Latin_Medieval">Agedincum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>senlis</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_valois" order="5">b_senliscastle</GameId>
       <GameId game="CK2HIP" parent="c_valois" order="5">b_senlis</GameId>
+      <GameId game="ImperatorRome">2445</GameId> <!-- Augustomagus -->
     </GameIds>
     <Names>
+      <Name language="Celtic_Gallic">Silvanectum</Name>
+      <Name language="Greek_Medieval">Augoustomagos</Name>
+      <Name language="Latin_Medieval">Augustomagus</Name>
+      <Name language="Latin_Old">Silvanectum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79018,8 +79906,25 @@
     <Id>mahon</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_menorca" order="2">b_mahon</GameId>
+      <GameId game="ImperatorRome">1469</GameId> <!-- Mago -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Magun</Name>
+      <Name language="Arabic_Bedouin">Magun</Name>
+      <Name language="Arabic_Egypt">Magun</Name>
+      <Name language="Arabic_Levant">Magun</Name>
+      <Name language="Arabic_Maghreb">Magun</Name>
+      <Name language="Arabic_Yemen">Magun</Name>
+      <Name language="Aragonese">Maó</Name>
+      <Name language="Basque">Mao</Name>
+      <Name language="Castilian">Mahón</Name>
+      <Name language="Catalan_Medieval">Maó</Name>
+      <Name language="French_Old">Mahon</Name>
+      <Name language="Greek_Medieval">Mago</Name>
+      <Name language="Hejazi_Arabic">Magun</Name>
+      <Name language="Latin_Medieval">Mago</Name>
+      <Name language="Portuguese">Mahão</Name>
+      <Name language="Sicilian_Arabic">Magun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79028,6 +79933,17 @@
       <GameId game="CK2HIP" parent="c_menorca" order="3">b_alaior</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Ayyur</Name>
+      <Name language="Arabic_Bedouin">al-Ayyur</Name>
+      <Name language="Arabic_Egypt">al-Ayyur</Name>
+      <Name language="Arabic_Levant">al-Ayyur</Name>
+      <Name language="Arabic_Maghreb">al-Ayyur</Name>
+      <Name language="Arabic_Yemen">al-Ayyur</Name>
+      <Name language="Castilian">Alayor</Name>
+      <Name language="French_Old">Alayor</Name>
+      <Name language="Hejazi_Arabic">al-Ayyur</Name>
+      <Name language="Leonese">Alayor</Name>
+      <Name language="Sicilian_Arabic">al-Ayyur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79036,6 +79952,21 @@
       <GameId game="CK2HIP" parent="c_menorca" order="5">b_esmercadal</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">as-Mirqat</Name>
+      <Name language="Arabic_Bedouin">as-Mirqat</Name>
+      <Name language="Arabic_Egypt">as-Mirqat</Name>
+      <Name language="Arabic_Levant">as-Mirqat</Name>
+      <Name language="Arabic_Maghreb">as-Mirqat</Name>
+      <Name language="Arabic_Yemen">as-Mirqat</Name>
+      <Name language="Basque">Merkadal</Name>
+      <Name language="Castilian">Mercadal</Name>
+      <Name language="Catalan_Medieval">Es Mercadal</Name>
+      <Name language="French_Old">Mercadal</Name>
+      <Name language="Galician">Mercadal</Name>
+      <Name language="Hejazi_Arabic">as-Mirqat</Name>
+      <Name language="Leonese">Mercadal</Name>
+      <Name language="Portuguese">Mercadal</Name>
+      <Name language="Sicilian_Arabic">as-Mirqat</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79044,6 +79975,21 @@
       <GameId game="CK2HIP" parent="c_menorca" order="6">b_santlluis</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Luys</Name>
+      <Name language="Arabic_Bedouin">Luys</Name>
+      <Name language="Arabic_Egypt">Luys</Name>
+      <Name language="Arabic_Levant">Luys</Name>
+      <Name language="Arabic_Maghreb">Luys</Name>
+      <Name language="Arabic_Yemen">Luys</Name>
+      <Name language="Aragonese">Sant Loís</Name>
+      <Name language="Basque">San Luis</Name>
+      <Name language="Castilian">San Luis</Name>
+      <Name language="French_Old">Saint Louis</Name>
+      <Name language="Galician">San Lois</Name>
+      <Name language="Hejazi_Arabic">Luys</Name>
+      <Name language="Leonese">San Luis</Name>
+      <Name language="Portuguese">São Luís</Name>
+      <Name language="Sicilian_Arabic">Luys</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79052,6 +79998,22 @@
       <GameId game="CK2HIP" parent="c_menorca" order="7">b_escastell</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Hisn</Name>
+      <Name language="Arabic_Bedouin">al-Hisn</Name>
+      <Name language="Arabic_Egypt">al-Hisn</Name>
+      <Name language="Arabic_Levant">al-Hisn</Name>
+      <Name language="Arabic_Maghreb">al-Hisn</Name>
+      <Name language="Arabic_Yemen">al-Hisn</Name>
+      <Name language="Aragonese">Escastiello</Name>
+      <Name language="Basque">Esgaztelua</Name>
+      <Name language="Castilian">Villacarlos</Name>
+      <Name language="Catalan_Medieval">Es Castell</Name>
+      <Name language="French_Old">Échatel</Name>
+      <Name language="Galician">Escastelo</Name>
+      <Name language="Hejazi_Arabic">al-Hisn</Name>
+      <Name language="Leonese">Escastiellu</Name>
+      <Name language="Portuguese">Escastelo</Name>
+      <Name language="Sicilian_Arabic">al-Hisn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79060,6 +80022,22 @@
       <GameId game="CK2HIP" parent="c_santiago" order="5">b_vilagarcia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Arusha</Name>
+      <Name language="Arabic_Bedouin">Arusha</Name>
+      <Name language="Arabic_Egypt">Arusha</Name>
+      <Name language="Arabic_Levant">Arusha</Name>
+      <Name language="Arabic_Maghreb">Arusha</Name>
+      <Name language="Arabic_Yemen">Arusha</Name>
+      <Name language="Aragonese">Vilagarcía d'Arosa</Name>
+      <Name language="Basque">Gartziaherria Arosa</Name>
+      <Name language="Castilian">Villagarcía de Arosa</Name>
+      <Name language="Catalan_Medieval">Vilagarcía d'Arosa</Name>
+      <Name language="French_Old">Garciville d'Arousse</Name>
+      <Name language="Galician">Vilagarcía de Arousa</Name>
+      <Name language="Hejazi_Arabic">Arusha</Name>
+      <Name language="Leonese">Villagarcía d'Arosa</Name>
+      <Name language="Portuguese">Vilagarcía de Arousa</Name>
+      <Name language="Sicilian_Arabic">Arusha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79121,14 +80099,14 @@
       <GameId game="CK2HIP" parent="c_lugo" order="4">b_sarria</GameId>
     </GameIds>
     <Names>
-      <Name language="Arabic_Andalusia">Luq</Name>
-      <Name language="Arabic_Bedouin">Luq</Name>
-      <Name language="Arabic_Egypt">Luq</Name>
-      <Name language="Arabic_Levant">Luq</Name>
-      <Name language="Arabic_Maghreb">Luq</Name>
-      <Name language="Arabic_Yemen">Luq</Name>
-      <Name language="Hejazi_Arabic">Luq</Name>
-      <Name language="Sicilian_Arabic">Luq</Name>
+      <Name language="Arabic_Andalusia">Sehrya</Name>
+      <Name language="Arabic_Bedouin">Sehrya</Name>
+      <Name language="Arabic_Egypt">Sehrya</Name>
+      <Name language="Arabic_Levant">Sehrya</Name>
+      <Name language="Arabic_Maghreb">Sehrya</Name>
+      <Name language="Arabic_Yemen">Sehrya</Name>
+      <Name language="Hejazi_Arabic">Sehrya</Name>
+      <Name language="Sicilian_Arabic">Sehrya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79137,6 +80115,14 @@
       <GameId game="CK2HIP" parent="c_lugo" order="5">b_ribadeo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ribbaduwa</Name>
+      <Name language="Arabic_Bedouin">Ribbaduwa</Name>
+      <Name language="Arabic_Egypt">Ribbaduwa</Name>
+      <Name language="Arabic_Levant">Ribbaduwa</Name>
+      <Name language="Arabic_Maghreb">Ribbaduwa</Name>
+      <Name language="Arabic_Yemen">Ribbaduwa</Name>
+      <Name language="Hejazi_Arabic">Ribbaduwa</Name>
+      <Name language="Sicilian_Arabic">Ribbaduwa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80288,8 +81274,20 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_leon" order="2">c_zamora</GameId>
       <GameId game="CK2HIP" parent="c_zamora" order="1">b_zamora</GameId>
+      <GameId game="ImperatorRome">1043</GameId> <!-- Ocelum Duri -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shamúra</Name>
+      <Name language="Arabic_Bedouin">Shamúra</Name>
+      <Name language="Arabic_Egypt">Shamúra</Name>
+      <Name language="Arabic_Levant">Shamúra</Name>
+      <Name language="Arabic_Maghreb">Shamúra</Name>
+      <Name language="Arabic_Yemen">Shamúra</Name>
+      <Name language="Greek_Medieval">Okelon</Name>
+      <Name language="Hejazi_Arabic">Shamúra</Name>
+      <Name language="Latin_Medieval">Ocelum Duri</Name>
+      <Name language="Portuguese">Samora</Name>
+      <Name language="Sicilian_Arabic">Shamúra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82027,10 +83025,10 @@
     <Names>
       <Name language="Greek_Ancient">Rhagai</Name>
       <Name language="Greek_Medieval">Ragai</Name>
-      <Name language="Latin_Old">Rhagae</Name>
       <Name language="Latin_Medieval">Rhagae</Name>
-      <Name language="persia">Rey</Name>
+      <Name language="Latin_Old">Rhagae</Name>
       <Name language="Persian_Middle">Rag</Name>
+      <Name language="Persian_Old">Rey</Name>
       <Name language="Syriac_Classical">Beth Raziqaye</Name>
     </Names>
   </LocationEntity>
@@ -82168,6 +83166,7 @@
       <GameId game="CK2HIP" order="11812">d_hormuz</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Ohrmazd</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82176,6 +83175,14 @@
       <GameId game="CK2HIP" parent="c_hormuz" order="6">b_kishqeshmi</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qays</Name>
+      <Name language="Arabic_Bedouin">Qays</Name>
+      <Name language="Arabic_Egypt">Qays</Name>
+      <Name language="Arabic_Levant">Qays</Name>
+      <Name language="Arabic_Maghreb">Qays</Name>
+      <Name language="Arabic_Yemen">Qays</Name>
+      <Name language="Hejazi_Arabic">Qays</Name>
+      <Name language="Sicilian_Arabic">Qays</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82193,22 +83200,24 @@
       <GameId game="CK2HIP" parent="d_ahwaz" order="1">c_ahwaz</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>sus</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_ahwaz" order="2">c_sus</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Persian_Middle">Ohrmazd-Ardashir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sus-khuzestani</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_sus" order="1">b_sus-khuzestani</GameId>
+      <GameId game="CK2HIP" parent="d_ahwaz" order="2">c_sus</GameId>
+      <GameId game="ImperatorRome">946</GameId> <!-- Shushan -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Sousa</Name>
+      <Name language="Greek_Medieval">Sousa</Name>
+      <Name language="Latin_Medieval">Susa</Name>
+      <Name language="Latin_Old">Susa</Name>
+      <Name language="Persian_Middle">Shush</Name>
+      <Name language="Persian_Old">Shush</Name>
+      <Name language="Syriac_Classical">Shush</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82217,6 +83226,7 @@
       <GameId game="CK2HIP" parent="c_sus" order="3">b_karkha</GameId>
     </GameIds>
     <Names>
+      <Name language="Syriac_Classical">Karkha dh'Ledhan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82226,6 +83236,7 @@
       <GameId game="CK2HIP" parent="d_luristan" order="2">c_shapurkhwast</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Shapur Khwast</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82271,19 +83282,21 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>oromieh</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_azerbaijan" order="3">c_oromieh</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>khoy</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_oromieh" order="2">b_khoy</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hawi</Name>
+      <Name language="Arabic_Bedouin">Hawi</Name>
+      <Name language="Arabic_Egypt">Hawi</Name>
+      <Name language="Arabic_Levant">Hawi</Name>
+      <Name language="Arabic_Maghreb">Hawi</Name>
+      <Name language="Arabic_Yemen">Hawi</Name>
+      <Name language="Armenian_Middle">Her</Name>
+      <Name language="Hejazi_Arabic">Hawi</Name>
+      <Name language="Kurdish">Xove</Name>
+      <Name language="Sicilian_Arabic">Hawi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82292,6 +83305,14 @@
       <GameId game="CK2HIP" parent="c_oromieh" order="3">b_osnuye</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ushnú</Name>
+      <Name language="Arabic_Bedouin">Ushnú</Name>
+      <Name language="Arabic_Egypt">Ushnú</Name>
+      <Name language="Arabic_Levant">Ushnú</Name>
+      <Name language="Arabic_Maghreb">Ushnú</Name>
+      <Name language="Arabic_Yemen">Ushnú</Name>
+      <Name language="Hejazi_Arabic">Ushnú</Name>
+      <Name language="Sicilian_Arabic">Ushnú</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82300,6 +83321,7 @@
       <GameId game="CK2HIP" parent="c_oromieh" order="2">b_salmas</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Salmast</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82308,23 +83330,27 @@
       <GameId game="CK2HIP" parent="c_muqan" order="2">b_pilsovar</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Paytakaran</Name>
+      <Name language="Oghuz">Pilsovar</Name>
+      <Name language="Syriac_Classical">Paidangaran</Name>
+      <Name language="Turkish_Old">Pilsovar</Name>
+      <Name language="Turkmen_Medieval">Pilsovar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>kumis</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_kumis" order="1">b_damghan</GameId>
       <GameId game="CK2HIP" parent="d_kumis" order="1">c_kumis</GameId>
       <GameId game="CK2HIP" parent="k_daylam" order="5">d_kumis</GameId>
+      <GameId game="ImperatorRome">3439</GameId> <!-- Qumis -->
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>damghan</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_kumis" order="1">b_damghan</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Ancient">Hekatompylos</Name>
+      <Name language="Greek_Medieval">Hekatompylos</Name>
+      <Name language="Greek_Medieval">Hekatompylos</Name>
+      <Name language="Latin_Old">Hecatompylos</Name>
+      <Name language="Persian_Middle">Komish</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82333,23 +83359,29 @@
       <GameId game="CK2HIP" parent="e_persia" order="3">k_khorasan</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Khwarasan</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>nishapur_region</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_khorasan" order="1">d_nishapur</GameId>
+    </GameIds>
+    <FallbackLocations>
+      <LocationId>nishapur</LocationId>
+    </FallbackLocations>
+    <Names>
+      <Name language="Persian_Middle">Abarshahr</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>nishapur</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="k_khorasan" order="1">d_nishapur</GameId>
+      <GameId game="CK2HIP" parent="c_nishapur" order="1">b_neshapur</GameId>
       <GameId game="CK2HIP" parent="d_nishapur" order="1">c_nishapur</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>neshapur</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_nishapur" order="1">b_neshapur</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Persian_Middle">Nev-Shapur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82357,8 +83389,24 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_nishapur" order="3">c_tus</GameId>
       <GameId game="CK2HIP" parent="c_tus" order="1">b_tus</GameId>
+      <GameId game="ImperatorRome">3454</GameId> <!-- Tusa -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Tusa</Name>
+      <Name language="Latin_Medieval">Tusa</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>merv_region</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_khorasan" order="3">d_merv</GameId>
+    </GameIds>
+    <FallbackLocations>
+      <LocationId>merv</LocationId>
+    </FallbackLocations>
+    <Names>
+      <Name language="Greek_Medieval">Margiane</Name>
+      <Name language="Latin_Medieval">Margiana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82366,9 +83414,11 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_merv" order="1">b_merv</GameId>
       <GameId game="CK2HIP" parent="d_merv" order="1">c_merv</GameId>
-      <GameId game="CK2HIP" parent="k_khorasan" order="3">d_merv</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Antiokheia Margiane</Name>
+      <Name language="Persian_Middle">Marv</Name>
+      <Name language="Latin_Medieval">Antiochia Margiana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82377,6 +83427,7 @@
       <GameId game="CK2HIP" parent="c_abivard" order="3">b_nasa</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Mithrdatkert</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82384,8 +83435,13 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_badghis" order="1">b_herat</GameId>
       <GameId game="CK2HIP" parent="k_khorasan" order="4">d_herat</GameId>
+      <GameId game="ImperatorRome">6558</GameId> <!-- Alexandria Ariorum -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Alexandreia Areiois</Name>
+      <Name language="Greek_Medieval">Alexandreia Areion</Name>
+      <Name language="Latin_Medieval">Alexandria in Ariana</Name>
+      <Name language="Latin_Old">Alexandria Ariorum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82394,6 +83450,21 @@
       <GameId game="CK2HIP" parent="d_herat" order="1">c_badghis</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Baktriane</Name>
+      <Name language="Latin_Medieval">Bactriana</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>balkh_region</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="k_khorasan" order="6">d_balkh</GameId>
+    </GameIds>
+    <FallbackLocations>
+      <LocationId>balkh</LocationId>
+    </FallbackLocations>
+    <Names>
+      <Name language="Greek_Medieval">Baktra</Name>
+      <Name language="Latin_Medieval">Bactra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82401,9 +83472,14 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_balkh" order="1">b_balkh</GameId>
       <GameId game="CK2HIP" parent="d_balkh" order="1">c_balkh</GameId>
-      <GameId game="CK2HIP" parent="k_khorasan" order="6">d_balkh</GameId>
+      <GameId game="ImperatorRome">6678</GameId> <!-- Bactra -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Baktra</Name>
+      <Name language="Greek_Medieval">Baktra</Name>
+      <Name language="Latin_Medieval">Bactra</Name>
+      <Name language="Latin_Old">Bactra</Name>
+      <Name language="Persian_Middle">Bakhdhi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82420,6 +83496,10 @@
       <GameId game="CK2HIP" parent="k_mavarannahr" order="1">d_soghd</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Sogdiane</Name>
+      <Name language="Latin_Medieval">Sogdiana</Name>
+      <Name language="Persian_Middle">Sogestan</Name>
+      <Name language="Sogdian">Soghd</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82427,8 +83507,24 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_soghd" order="2">c_samarqand</GameId>
       <GameId game="CK2HIP" parent="c_samarqand" order="2">b_samarqand</GameId>
+      <GameId game="ImperatorRome">6682</GameId> <!-- Marakanda -->
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Semizkänd</Name>
+      <Name language="Bashkir">Semizkänd</Name>
+      <Name language="Bulgar">Semizkänd</Name>
+      <Name language="Cuman">Semizkänd</Name>
+      <Name language="Greek_Medieval">Marakanda</Name>
+      <Name language="Karluk">Semizkänd</Name>
+      <Name language="Khazar_Kabar">Semizkänd</Name>
+      <Name language="Khazar">Semizkänd</Name>
+      <Name language="Kyrgyz">Semizkänd</Name>
+      <Name language="Latin_Medieval">Maracanda</Name>
+      <Name language="Oghuz">Semizkänd</Name>
+      <Name language="Pecheneg">Semizkänd</Name>
+      <Name language="Turkish_Old">Semizkänd</Name>
+      <Name language="Turkmen_Medieval">Semizkänd</Name>
+      <Name language="Uyghur">Semizkänd</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82436,8 +83532,13 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_ferghana" order="1">c_khojand</GameId>
       <GameId game="CK2HIP" parent="c_khojand" order="1">b_khojand</GameId>
+      <GameId game="ImperatorRome">6704</GameId> <!-- Alexandria Eschate -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Alexandreia Eschate</Name>
+      <Name language="Greek_Medieval">Alexandreia Eschate</Name>
+      <Name language="Latin_Medieval">Alexandria Eschate</Name>
+      <Name language="Latin_Old">Alexandria Eschate</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82446,6 +83547,19 @@
       <GameId game="CK2HIP" parent="c_ferghana" order="1">b_uzgend</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Özkänd</Name>
+      <Name language="Bashkir">Özkänd</Name>
+      <Name language="Bulgar">Özkänd</Name>
+      <Name language="Cuman">Özkänd</Name>
+      <Name language="Karluk">Özkänd</Name>
+      <Name language="Khazar_Kabar">Özkänd</Name>
+      <Name language="Khazar">Özkänd</Name>
+      <Name language="Kyrgyz">Özkänd</Name>
+      <Name language="Oghuz">Özkänd</Name>
+      <Name language="Pecheneg">Özkänd</Name>
+      <Name language="Turkish_Old">Özkänd</Name>
+      <Name language="Turkmen_Medieval">Özkänd</Name>
+      <Name language="Uyghur">Özkänd</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -87573,6 +88687,31 @@
       <GameId game="CK2HIP" parent="d_itil" order="3">c_semender</GameId>
     </GameIds>
     <Names>
+      <Name language="Alan">Msndr</Name>
+      <Name language="Arabic_Andalusia">Samandar</Name>
+      <Name language="Arabic_Bedouin">Samandar</Name>
+      <Name language="Arabic_Egypt">Samandar</Name>
+      <Name language="Arabic_Levant">Samandar</Name>
+      <Name language="Arabic_Maghreb">Samandar</Name>
+      <Name language="Arabic_Yemen">Samandar</Name>
+      <Name language="Arberian">Zabender</Name>
+      <Name language="Armenian_Middle">Msndr</Name>
+      <Name language="Balochi">Samandar</Name>
+      <Name language="Daylami">Samandar</Name>
+      <Name language="Georgian">Msndr</Name>
+      <Name language="Gothic_Crimean">Zabender</Name>
+      <Name language="Greek_Medieval">Zabender</Name>
+      <Name language="Hejazi_Arabic">Samandar</Name>
+      <Name language="Kurdish">Samandar</Name>
+      <Name language="Pashto">Samandar</Name>
+      <Name language="Persian_Middle">Samandar</Name>
+      <Name language="Persian">Samandar</Name>
+      <Name language="Sanhaja">Samandar</Name>
+      <Name language="Sicilian_Arabic">Samandar</Name>
+      <Name language="Tajiki">Samandar</Name>
+      <Name language="Tuareg">Samandar</Name>
+      <Name language="Turkmen_Medieval">Samandar</Name>
+      <Name language="Zenati">Samandar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -87581,6 +88720,25 @@
       <GameId game="CK2HIP" parent="c_semender" order="1">b_balanjar</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Balanjar</Name>
+      <Name language="Arabic_Bedouin">Balanjar</Name>
+      <Name language="Arabic_Egypt">Balanjar</Name>
+      <Name language="Arabic_Levant">Balanjar</Name>
+      <Name language="Arabic_Maghreb">Balanjar</Name>
+      <Name language="Arabic_Yemen">Balanjar</Name>
+      <Name language="Balochi">Balanjar</Name>
+      <Name language="Daylami">Balanjar</Name>
+      <Name language="Hejazi_Arabic">Balanjar</Name>
+      <Name language="Kurdish">Balanjar</Name>
+      <Name language="Pashto">Balanjar</Name>
+      <Name language="Persian_Middle">Balanjar</Name>
+      <Name language="Persian">Balanjar</Name>
+      <Name language="Sanhaja">Balanjar</Name>
+      <Name language="Sicilian_Arabic">Balanjar</Name>
+      <Name language="Tajiki">Balanjar</Name>
+      <Name language="Tuareg">Balanjar</Name>
+      <Name language="Turkmen_Medieval">Balanjar</Name>
+      <Name language="Zenati">Balanjar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88745,6 +89903,20 @@
       <GameId game="CK2HIP" parent="c_nyland" order="1">b_porvoo</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Porvoo</Name>
+      <Name language="Finnish">Porvoo</Name>
+      <Name language="Karelian">Porvoo</Name>
+      <Name language="Khanty">Porvoo</Name>
+      <Name language="Komi">Porvoo</Name>
+      <Name language="Latgalian">Porvoo</Name>
+      <Name language="Lithuanian_Medieval">Porvoo</Name>
+      <Name language="Livonian">Porvoo</Name>
+      <Name language="Mari">Porvoo</Name>
+      <Name language="Moksha">Porvoo</Name>
+      <Name language="Prussian_Old">Porvoo</Name>
+      <Name language="Sami">Porvoo</Name>
+      <Name language="Samoyed">Porvoo</Name>
+      <Name language="Vepsian_Medieval">Porvoo</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88753,6 +89925,20 @@
       <GameId game="CK2HIP" parent="c_nyland" order="2">b_lohja</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Lohja</Name>
+      <Name language="Finnish">Lohja</Name>
+      <Name language="Karelian">Lohja</Name>
+      <Name language="Khanty">Lohja</Name>
+      <Name language="Komi">Lohja</Name>
+      <Name language="Latgalian">Lohja</Name>
+      <Name language="Lithuanian_Medieval">Lohja</Name>
+      <Name language="Livonian">Lohja</Name>
+      <Name language="Mari">Lohja</Name>
+      <Name language="Moksha">Lohja</Name>
+      <Name language="Prussian_Old">Lohja</Name>
+      <Name language="Sami">Lohja</Name>
+      <Name language="Samoyed">Lohja</Name>
+      <Name language="Vepsian_Medieval">Lohja</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88761,6 +89947,20 @@
       <GameId game="CK2HIP" parent="c_nyland" order="3">b_kirkkonummi</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Kirkkonummi</Name>
+      <Name language="Finnish">Kirkkonummi</Name>
+      <Name language="Karelian">Kirkkonummi</Name>
+      <Name language="Khanty">Kirkkonummi</Name>
+      <Name language="Komi">Kirkkonummi</Name>
+      <Name language="Latgalian">Kirkkonummi</Name>
+      <Name language="Lithuanian_Medieval">Kirkkonummi</Name>
+      <Name language="Livonian">Kirkkonummi</Name>
+      <Name language="Mari">Kirkkonummi</Name>
+      <Name language="Moksha">Kirkkonummi</Name>
+      <Name language="Prussian_Old">Kirkkonummi</Name>
+      <Name language="Sami">Kirkkonummi</Name>
+      <Name language="Samoyed">Kirkkonummi</Name>
+      <Name language="Vepsian_Medieval">Kirkkonummi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88769,6 +89969,20 @@
       <GameId game="CK2HIP" parent="c_nyland" order="4">b_raseborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Raaseporin</Name>
+      <Name language="Finnish">Raaseporin</Name>
+      <Name language="Karelian">Raaseporin</Name>
+      <Name language="Khanty">Raaseporin</Name>
+      <Name language="Komi">Raaseporin</Name>
+      <Name language="Latgalian">Raaseporin</Name>
+      <Name language="Lithuanian_Medieval">Raaseporin</Name>
+      <Name language="Livonian">Raaseporin</Name>
+      <Name language="Mari">Raaseporin</Name>
+      <Name language="Moksha">Raaseporin</Name>
+      <Name language="Prussian_Old">Raaseporin</Name>
+      <Name language="Sami">Raaseporin</Name>
+      <Name language="Samoyed">Raaseporin</Name>
+      <Name language="Vepsian_Medieval">Raaseporin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88777,6 +89991,21 @@
       <GameId game="CK2HIP" parent="c_nyland" order="5">b_jukarsborg</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Junkarsburgh</Name>
+      <Name language="Estonian">Junkarsborg</Name>
+      <Name language="Finnish">Junkarsborg</Name>
+      <Name language="Karelian">Junkarsborg</Name>
+      <Name language="Khanty">Junkarsborg</Name>
+      <Name language="Komi">Junkarsborg</Name>
+      <Name language="Latgalian">Junkarsborg</Name>
+      <Name language="Lithuanian_Medieval">Junkarsborg</Name>
+      <Name language="Livonian">Junkarsborg</Name>
+      <Name language="Mari">Junkarsborg</Name>
+      <Name language="Moksha">Junkarsborg</Name>
+      <Name language="Prussian_Old">Junkarsborg</Name>
+      <Name language="Sami">Junkarsborg</Name>
+      <Name language="Samoyed">Junkarsborg</Name>
+      <Name language="Vepsian_Medieval">Junkarsborg</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88785,6 +90014,20 @@
       <GameId game="CK2HIP" parent="c_nyland" order="6">b_siuntio</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Siuntio</Name>
+      <Name language="Finnish">Siuntio</Name>
+      <Name language="Karelian">Siuntio</Name>
+      <Name language="Khanty">Siuntio</Name>
+      <Name language="Komi">Siuntio</Name>
+      <Name language="Latgalian">Siuntio</Name>
+      <Name language="Lithuanian_Medieval">Siuntio</Name>
+      <Name language="Livonian">Siuntio</Name>
+      <Name language="Mari">Siuntio</Name>
+      <Name language="Moksha">Siuntio</Name>
+      <Name language="Prussian_Old">Siuntio</Name>
+      <Name language="Sami">Siuntio</Name>
+      <Name language="Samoyed">Siuntio</Name>
+      <Name language="Vepsian_Medieval">Siuntio</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88793,6 +90036,20 @@
       <GameId game="CK2HIP" parent="c_nyland" order="7">b_sjundbyn</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Sjundbyn</Name>
+      <Name language="Finnish">Sjundbyn</Name>
+      <Name language="Karelian">Sjundbyn</Name>
+      <Name language="Khanty">Sjundbyn</Name>
+      <Name language="Komi">Sjundbyn</Name>
+      <Name language="Latgalian">Sjundbyn</Name>
+      <Name language="Lithuanian_Medieval">Sjundbyn</Name>
+      <Name language="Livonian">Sjundbyn</Name>
+      <Name language="Mari">Sjundbyn</Name>
+      <Name language="Moksha">Sjundbyn</Name>
+      <Name language="Prussian_Old">Sjundbyn</Name>
+      <Name language="Sami">Sjundbyn</Name>
+      <Name language="Samoyed">Sjundbyn</Name>
+      <Name language="Vepsian_Medieval">Sjundbyn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88801,6 +90058,21 @@
       <GameId game="CK2HIP" parent="d_finland" order="3">c_tavasts</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Häme</Name>
+      <Name language="Finnish">Häme</Name>
+      <Name language="Karelian">Häme</Name>
+      <Name language="Khanty">Häme</Name>
+      <Name language="Komi">Häme</Name>
+      <Name language="Latgalian">Häme</Name>
+      <Name language="Lithuanian_Medieval">Häme</Name>
+      <Name language="Livonian">Häme</Name>
+      <Name language="Mari">Häme</Name>
+      <Name language="Moksha">Häme</Name>
+      <Name language="Prussian_Old">Häme</Name>
+      <Name language="Russian_Medieval">Yam</Name>
+      <Name language="Sami">Häme</Name>
+      <Name language="Samoyed">Häme</Name>
+      <Name language="Vepsian_Medieval">Häme</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88809,6 +90081,21 @@
       <GameId game="CK2HIP" parent="c_tavasts" order="2">b_hakoisten</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Hagaburgh</Name>
+      <Name language="Estonian">Hakoisten</Name>
+      <Name language="Finnish">Hakoisten</Name>
+      <Name language="Karelian">Hakoisten</Name>
+      <Name language="Khanty">Hakoisten</Name>
+      <Name language="Komi">Hakoisten</Name>
+      <Name language="Latgalian">Hakoisten</Name>
+      <Name language="Lithuanian_Medieval">Hakoisten</Name>
+      <Name language="Livonian">Hakoisten</Name>
+      <Name language="Mari">Hakoisten</Name>
+      <Name language="Moksha">Hakoisten</Name>
+      <Name language="Prussian_Old">Hakoisten</Name>
+      <Name language="Sami">Hakoisten</Name>
+      <Name language="Samoyed">Hakoisten</Name>
+      <Name language="Vepsian_Medieval">Hakoisten</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88817,6 +90104,7 @@
       <GameId game="CK2HIP" parent="c_tavasts" order="2">b_vanaja</GameId>
     </GameIds>
     <Names>
+      <Name language="Russian_Medieval">Vanai</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88825,6 +90113,21 @@
       <GameId game="CK2HIP" parent="c_tavasts" order="5">b_hameenlinna</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Hämeenlinna</Name>
+      <Name language="Finnish">Hämeenlinna</Name>
+      <Name language="Karelian">Hämeenlinna</Name>
+      <Name language="Khanty">Hämeenlinna</Name>
+      <Name language="Komi">Hämeenlinna</Name>
+      <Name language="Latgalian">Hämeenlinna</Name>
+      <Name language="Lithuanian_Medieval">Hämeenlinna</Name>
+      <Name language="Livonian">Hämeenlinna</Name>
+      <Name language="Mari">Hämeenlinna</Name>
+      <Name language="Moksha">Hämeenlinna</Name>
+      <Name language="Norse">Taffwestaborg</Name>
+      <Name language="Prussian_Old">Hämeenlinna</Name>
+      <Name language="Sami">Hämeenlinna</Name>
+      <Name language="Samoyed">Hämeenlinna</Name>
+      <Name language="Vepsian_Medieval">Hämeenlinna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88833,6 +90136,20 @@
       <GameId game="CK2HIP" parent="c_tavasts" order="6">b_vesilahti</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Vesilahti</Name>
+      <Name language="Finnish">Vesilahti</Name>
+      <Name language="Karelian">Vesilahti</Name>
+      <Name language="Khanty">Vesilahti</Name>
+      <Name language="Komi">Vesilahti</Name>
+      <Name language="Latgalian">Vesilahti</Name>
+      <Name language="Lithuanian_Medieval">Vesilahti</Name>
+      <Name language="Livonian">Vesilahti</Name>
+      <Name language="Mari">Vesilahti</Name>
+      <Name language="Moksha">Vesilahti</Name>
+      <Name language="Prussian_Old">Vesilahti</Name>
+      <Name language="Sami">Vesilahti</Name>
+      <Name language="Samoyed">Vesilahti</Name>
+      <Name language="Vepsian_Medieval">Vesilahti</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88841,6 +90158,20 @@
       <GameId game="CK2HIP" parent="c_tavasts" order="7">b_lahti</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Lathi</Name>
+      <Name language="Finnish">Lathi</Name>
+      <Name language="Karelian">Lathi</Name>
+      <Name language="Khanty">Lathi</Name>
+      <Name language="Komi">Lathi</Name>
+      <Name language="Latgalian">Lathi</Name>
+      <Name language="Lithuanian_Medieval">Lathi</Name>
+      <Name language="Livonian">Lathi</Name>
+      <Name language="Mari">Lathi</Name>
+      <Name language="Moksha">Lathi</Name>
+      <Name language="Prussian_Old">Lathi</Name>
+      <Name language="Sami">Lathi</Name>
+      <Name language="Samoyed">Lathi</Name>
+      <Name language="Vepsian_Medieval">Lathi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88849,6 +90180,20 @@
       <GameId game="CK2HIP" parent="d_finland" order="4">c_satakunta</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Satakunta</Name>
+      <Name language="Finnish">Satakunta</Name>
+      <Name language="Karelian">Satakunta</Name>
+      <Name language="Khanty">Satakunta</Name>
+      <Name language="Komi">Satakunta</Name>
+      <Name language="Latgalian">Satakunta</Name>
+      <Name language="Lithuanian_Medieval">Satakunta</Name>
+      <Name language="Livonian">Satakunta</Name>
+      <Name language="Mari">Satakunta</Name>
+      <Name language="Moksha">Satakunta</Name>
+      <Name language="Prussian_Old">Satakunta</Name>
+      <Name language="Sami">Satakunta</Name>
+      <Name language="Samoyed">Satakunta</Name>
+      <Name language="Vepsian_Medieval">Satakunta</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88857,6 +90202,20 @@
       <GameId game="CK2HIP" parent="c_satakunta" order="1">b_pori</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Pori</Name>
+      <Name language="Finnish">Pori</Name>
+      <Name language="Karelian">Pori</Name>
+      <Name language="Khanty">Pori</Name>
+      <Name language="Komi">Pori</Name>
+      <Name language="Latgalian">Pori</Name>
+      <Name language="Lithuanian_Medieval">Pori</Name>
+      <Name language="Livonian">Pori</Name>
+      <Name language="Mari">Pori</Name>
+      <Name language="Moksha">Pori</Name>
+      <Name language="Prussian_Old">Pori</Name>
+      <Name language="Sami">Pori</Name>
+      <Name language="Samoyed">Pori</Name>
+      <Name language="Vepsian_Medieval">Pori</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88865,6 +90224,20 @@
       <GameId game="CK2HIP" parent="c_satakunta" order="2">b_liinmaa</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Liinmaa</Name>
+      <Name language="Finnish">Liinmaa</Name>
+      <Name language="Karelian">Liinmaa</Name>
+      <Name language="Khanty">Liinmaa</Name>
+      <Name language="Komi">Liinmaa</Name>
+      <Name language="Latgalian">Liinmaa</Name>
+      <Name language="Lithuanian_Medieval">Liinmaa</Name>
+      <Name language="Livonian">Liinmaa</Name>
+      <Name language="Mari">Liinmaa</Name>
+      <Name language="Moksha">Liinmaa</Name>
+      <Name language="Prussian_Old">Liinmaa</Name>
+      <Name language="Sami">Liinmaa</Name>
+      <Name language="Samoyed">Liinmaa</Name>
+      <Name language="Vepsian_Medieval">Liinmaa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -94188,14 +95561,6 @@
     <Id>vazelon</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_trapezous" order="2">b_vazelon</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>theodoro</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_cherson" order="2">c_theodoro</GameId>
     </GameIds>
     <Names>
     </Names>

--- a/titles.xml
+++ b/titles.xml
@@ -24784,6 +24784,15 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>krajna</Id>
+    <GameIds>
+      <GameId game="CK3">c_krajna</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish">Krajna</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>wielkopolska</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="k_poland" order="2">d_greater_poland</GameId>
@@ -24880,6 +24889,8 @@
     <Id>wschowa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_poznanskie" order="3">b_wschowa</GameId>
+      <GameId game="CK3">b_wschowa</GameId>
+      <GameId game="CK3">c_wschowska</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Fraustadt</Name>
@@ -24895,6 +24906,7 @@
       <Name language="German_Old_Low">Fraustadt</Name>
       <Name language="Latgalian">Vshova</Name>
       <Name language="Lithuanian">Vshova</Name>
+      <Name language="Polish">Wschowa</Name>
       <Name language="Serbian">Vešov</Name>
       <Name language="Slovene">Vešov</Name>
       <Name language="Thuringian">Fraustadt</Name>
@@ -24965,6 +24977,7 @@
     <Id>koscian</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_poznanskie" order="2">b_koscian</GameId>
+      <GameId game="CK3">b_koscian</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Kosten</Name>
@@ -24980,6 +24993,7 @@
       <Name language="German_Old_Low">Kosten</Name>
       <Name language="Latgalian">Koscjana</Name>
       <Name language="Lithuanian">Koscianas</Name>
+      <Name language="Polish">Kościan</Name>
       <Name language="Serbian">Košcjan</Name>
       <Name language="Slovene">Košcjan</Name>
       <Name language="Thuringian">Kosten</Name>
@@ -25050,7 +25064,7 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>srem_wielkopolska</Id>
+    <Id>srem</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_gnieznienskie" order="2">b_srem_wielkopolska</GameId>
     </GameIds>
@@ -25066,6 +25080,7 @@
       <Name language="German_Middle_High">Schrimm</Name>
       <Name language="German_Middle_Low">Schrimm</Name>
       <Name language="German_Old_Low">Schrimm</Name>
+      <Name language="Polish">Śrem</Name>
       <Name language="Serbian">Šrem</Name>
       <Name language="Slovene">Šrem</Name>
       <Name language="Thuringian">Schrimm</Name>

--- a/titles.xml
+++ b/titles.xml
@@ -2925,6 +2925,7 @@
     <Id>zlotow</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_poznanskie" order="7">b_zlotow</GameId>
+      <GameId game="CK3">b_zlotow</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Flatow</Name>
@@ -2946,6 +2947,7 @@
       <Name language="Latin_Medieval">Vulatovum</Name>
       <Name language="Latin">Zlotovia</Name>
       <Name language="Latvian">Zlotova</Name>
+      <Name language="Polish">Złotów</Name>
       <Name language="Polish">Złotów</Name>
       <Name language="Serbian">Zlotuv</Name>
       <Name language="Slovene">Zlotuv</Name>
@@ -25155,6 +25157,7 @@
     <Id>znin</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_gnieznienskie" order="3">b_znin</GameId>
+      <GameId game="CK3">b_znin</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Schinen</Name>
@@ -25170,6 +25173,7 @@
       <Name language="German_Old_Low">Schinen</Name>
       <Name language="Latgalian">Žnina</Name>
       <Name language="Lithuanian">Žninas</Name>
+      <Name language="Polish_Old">Żnin</Name>
       <Name language="Serbian">Žnjin</Name>
       <Name language="Slovene">Žnjin</Name>
       <Name language="Thuringian">Schinen</Name>
@@ -25462,9 +25466,9 @@
     <Id>mazovia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="k_poland" order="3">d_mazovia</GameId>
+      <GameId game="CK3">d_mazovia</GameId>
     </GameIds>
     <Names>
-      <Name language="Alemannic">Masovia</Name>
       <Name language="Alemannic">Masowien</Name>
       <Name language="Bavarian_Medieval">Masowien</Name>
       <Name language="Czech_Medieval">Mazovsko</Name>
@@ -25492,6 +25496,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_plock" order="1">b_plock</GameId>
       <GameId game="CK2HIP" parent="d_mazovia" order="1">c_plock</GameId>
+      <GameId game="CK3">b_plock</GameId>
+      <GameId game="CK3">c_plocka</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Plotzk</Name>
@@ -25504,7 +25510,23 @@
       <Name language="German_Old_Low">Plotzk</Name>
       <Name language="Latgalian">Plocka</Name>
       <Name language="Lithuanian">Plockas</Name>
+      <Name language="Polish">Płock</Name>
       <Name language="Thuringian">Plotzk</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>zawkrze</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="c_plock" order="5">b_szrensk</GameId>
+      <GameId game="CK3">b_zawkrze</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Bosnian">Šrenjsk</Name>
+      <Name language="Bulgarian">Šrensk</Name>
+      <Name language="Croatian">Šrenjsk</Name>
+      <Name language="Polish">Szreńsk</Name>
+      <Name language="Serbian">Šrenjsk</Name>
+      <Name language="Slovene">Šrenjsk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25525,6 +25547,7 @@
     <Id>ciechanow</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_plock" order="3">b_ciechanow</GameId>
+      <GameId game="CK3">b_ciechanow</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Zechenau</Name>
@@ -25540,6 +25563,7 @@
       <Name language="German_Old_Low">Zechenau</Name>
       <Name language="Latgalian">Cehanova</Name>
       <Name language="Lithuanian">Cechanuvas</Name>
+      <Name language="Polish">Ciechanów</Name>
       <Name language="Serbian">Cehanov</Name>
       <Name language="Slovene">Cehanov</Name>
       <Name language="Thuringian">Zechenau</Name>
@@ -25549,6 +25573,7 @@
     <Id>wyszogrod_mazovia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_plock" order="4">b_wyszogrod_mazovia</GameId>
+      <GameId game="CK3">b_wyszgorod</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Hohenburg</Name>
@@ -25563,22 +25588,10 @@
       <Name language="German_Middle_Low">Hohenburg</Name>
       <Name language="German_Old_Low">Hohenburg</Name>
       <Name language="Latgalian">Višogroda</Name>
+      <Name language="Polish">Wyszogród</Name>
       <Name language="Serbian">Višegrad</Name>
       <Name language="Slovene">Višegrad</Name>
       <Name language="Thuringian">Hohenburg</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>szrensk</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_plock" order="5">b_szrensk</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Bosnian">Šrenjsk</Name>
-      <Name language="Bulgarian">Šrensk</Name>
-      <Name language="Slovene">Šrenjsk</Name>
-      <Name language="Croatian">Šrenjsk</Name>
-      <Name language="Serbian">Šrenjsk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25757,14 +25770,17 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_czersk" order="1">b_czersk</GameId>
       <GameId game="CK2HIP" parent="d_mazovia" order="3">c_czersk</GameId>
+      <GameId game="CK3">b_czersk</GameId>
+      <GameId game="CK3">c_czerska</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Cirnsk</Name>
       <Name language="Bulgarian">Cirnsk</Name>
-      <Name language="Slovene">Cirnsk</Name>
       <Name language="Croatian">Cirnsk</Name>
       <Name language="Latgalian">Cirnska</Name>
+      <Name language="Polish">Czersk</Name>
       <Name language="Serbian">Cirnsk</Name>
+      <Name language="Slovene">Cirnsk</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25785,51 +25801,55 @@
     <Id>warszawa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_czersk" order="3">b_warszawa</GameId>
+      <GameId game="CK3">b_warszawa</GameId>
     </GameIds>
     <Names>
       <Name language="Arpitan">Varsovie</Name>
       <Name language="Basque">Barsobia</Name>
-      <Name language="Czech">Varšava</Name>
       <Name language="Breton_Middle">Varsovia</Name>
       <Name language="Bulgarian">Varševa</Name>
-      <Name language="Slovene">Varševa</Name>
       <Name language="Castilian">Varsovia</Name>
       <Name language="Catalan">Varsòvia</Name>
       <Name language="Croatian">Varševa</Name>
+      <Name language="Czech">Varšava</Name>
       <Name language="Dutch_Middle">Warschau</Name>
+      <Name language="Estonian">Varssavi</Name>
       <Name language="Finnish">Varsova</Name>
       <Name language="French_Old">Varsovie</Name>
       <Name language="Galician">Varsovia</Name>
+      <Name language="German_Middle_Low">Warschau</Name>
+      <Name language="German_Old_Low">Warschau</Name>
       <Name language="German">Warschau</Name>
       <Name language="Hungarian">Varsó</Name>
       <Name language="Icelandic">Varsjá</Name>
       <Name language="Irish">Vársá</Name>
       <Name language="Italian">Varsavia</Name>
-      <Name language="Lithuanian">Varšuva</Name>
-      <Name language="German_Middle_Low">Warschau</Name>
-      <Name language="German_Old_Low">Warschau</Name>
-      <Name language="Neapolitan">Varsavia</Name>
-      <Name language="Portuguese">Varsóvia</Name>
       <Name language="Latin">Varsovia</Name>
+      <Name language="Lithuanian">Varšuva</Name>
+      <Name language="Neapolitan">Varsavia</Name>
+      <Name language="Polish">Warszawa</Name>
+      <Name language="Portuguese">Varsóvia</Name>
       <Name language="Romanian">Varșovia</Name>
       <Name language="Sicilian">Varsavia</Name>
       <Name language="Slovak">Varšava</Name>
+      <Name language="Slovene">Varševa</Name>
       <Name language="Turkish">Varsova</Name>
-      <Name language="Estonian">Varssavi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>liw</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_czersk" order="4">b_liw</GameId>
+      <GameId game="CK3">b_liw</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Liv</Name>
       <Name language="Bulgarian">Liv</Name>
-      <Name language="Slovene">Liv</Name>
       <Name language="Croatian">Liv</Name>
       <Name language="Lithuanian">Livo</Name>
+      <Name language="Polish">Liw</Name>
       <Name language="Serbian">Liv</Name>
+      <Name language="Slovene">Liv</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -25849,13 +25869,24 @@
     <Id>brodno</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_czersk" order="6">b_brodno</GameId>
+      <GameId game="CK3">b_brodno</GameId>
     </GameIds>
     <Names>
       <Name language="Bosnian">Brodno</Name>
       <Name language="Bulgarian">Brodno</Name>
-      <Name language="Slovene">Brodno</Name>
       <Name language="Croatian">Brodno</Name>
+      <Name language="Polish">Bródno</Name>
       <Name language="Serbian">Brodno</Name>
+      <Name language="Slovene">Brodno</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>garwolin</Id>
+    <GameIds>
+      <GameId game="CK3">b_garwolin</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Polish">Garwolin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -64944,6 +64975,7 @@
     <Id>naklo</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_poznanskie" order="4">b_naklo</GameId>
+      <GameId game="CK3">b_naklo</GameId>
     </GameIds>
     <Names>
       <Name language="Alemannic">Nakel</Name>
@@ -64954,6 +64986,7 @@
       <Name language="German_Middle_High">Nakel</Name>
       <Name language="German_Middle_Low">Nakel</Name>
       <Name language="German_Old_Low">Nakel</Name>
+      <Name language="Polish_Old">Nakło</Name>
       <Name language="Thuringian">Nakel</Name>
     </Names>
   </LocationEntity>
@@ -88017,8 +88050,12 @@
     <GameIds>
       <GameId game="CK2HIP" parent="k_pomerania" order="6">d_lubusz</GameId>
       <GameId game="CK2HIP" parent="c_lubusz" order="2">b_lubusz</GameId>
+      <GameId game="CK3">b_lebus</GameId>
+      <GameId game="CK3">c_lubusz</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Lebus</Name>
+      <Name language="Bavarian_Medieval">Lebus</Name>
       <Name language="Bosnian_Medieval">Lubusz</Name>
       <Name language="Bulgarian_Old">Lubusz</Name>
       <Name language="Croatian_Medieval">Lubusz</Name>
@@ -88028,6 +88065,7 @@
       <Name language="Norse">Lebus</Name>
       <Name language="Norwegian_Old">Lebus</Name>
       <Name language="Polish_Old">Lubusz</Name>
+      <Name language="Polish">Lubusz</Name>
       <Name language="Russian_Medieval">Lubusz</Name>
       <Name language="Serbian_Medieval">Lubusz</Name>
       <Name language="Slovak_Medieval">Lubuš</Name>
@@ -88060,19 +88098,45 @@
     <Id>frankfurt_oder</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_lubusz" order="2">b_frankfurt_oder</GameId>
+      <GameId game="CK3">b_oderfrankfurt</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic">Oderfrankfurt</Name>
+      <Name language="Bavarian_Medieval">Oderfrankfurt</Name>
       <Name language="Bosnian_Medieval">Zliwitz</Name>
       <Name language="Bulgarian_Old">Zliwitz</Name>
       <Name language="Croatian_Medieval">Zliwitz</Name>
       <Name language="Czech_Medieval">Zlivec</Name>
       <Name language="German_Middle_High">Frankfurt an der Oder</Name>
       <Name language="Polish_Old">Zliviecz</Name>
+      <Name language="Polish">Zliwitz</Name>
       <Name language="Russian_Medieval">Zliwitz</Name>
       <Name language="Serbian_Medieval">Zliwitz</Name>
       <Name language="Slovak_Medieval">Zlivec</Name>
       <Name language="Slovene_Medieval">Zliwitz</Name>
       <Name language="Sorbian">Zliwitz</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sulecin</Id>
+    <GameIds>
+      <GameId game="CK3">b_sulecin</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Alemannic">Zielenzig</Name>
+      <Name language="Bavarian_Medieval">Zielenzig</Name>
+      <Name language="Polish_Old">Sulęcin</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>rzepin</Id>
+    <GameIds>
+      <GameId game="CK3">b_rzepin</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Alemannic">Reppen</Name>
+      <Name language="Bavarian_Medieval">Reppen</Name>
+      <Name language="Polish_Old">Rzepin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -13971,20 +13971,20 @@
       <GameId game="CK3">d_aegean_islands</GameId>
     </GameIds>
     <Names>
-      <Name language="Dalmatian_Medieval">dell'arcipelago</Name>
+      <Name language="Dalmatian_Medieval">Isole Egee</Name>
       <Name language="English">Aegean Islands</Name>
       <Name language="Greek_Medieval">Aigaiou Pelàgous</Name>
-      <Name language="Italian_Central">dell'arcipelago</Name>
-      <Name language="Italian_Medieval">dell'arcipelago</Name>
-      <Name language="Langobardic">dell'arcipelago</Name>
-      <Name language="Ligurian">dell'arcipelago</Name>
-      <Name language="Neapolitan">dell'arcipelago</Name>
+      <Name language="Italian_Central">Isole Egee</Name>
+      <Name language="Italian_Medieval">Isole Egee</Name>
+      <Name language="Langobardic">Isole Egee</Name>
+      <Name language="Ligurian">Isole Egee</Name>
+      <Name language="Neapolitan">Isole Egee</Name>
       <Name language="Romanian">Insulele Egee</Name>
-      <Name language="Sardinian">dell'arcipelago</Name>
-      <Name language="Sicilian">dell'arcipelago</Name>
-      <Name language="Tuscan_Medieval">dell'arcipelago</Name>
-      <Name language="Umbrian_Medieval">dell'arcipelago</Name>
-      <Name language="Venetian_Medieval">dell'arcipelago</Name>
+      <Name language="Sardinian">Isole Egee</Name>
+      <Name language="Sicilian">Isole Egee</Name>
+      <Name language="Tuscan_Medieval">Isole Egee</Name>
+      <Name language="Umbrian_Medieval">Isole Egee</Name>
+      <Name language="Venetian_Medieval">Isole Egee</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38350,27 +38350,53 @@
   <LocationEntity>
     <Id>antioch</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_antiocheia" order="4">b_harenc</GameId>
       <GameId game="CK2HIP" parent="c_antiocheia" order="1">b_antiocheia</GameId>
       <GameId game="CK2HIP" parent="d_antioch" order="1">c_antiocheia</GameId>
       <GameId game="CK2HIP" parent="k_antioch" order="2">d_antioch</GameId>
       <GameId game="CK2HIP" parent="e_arabia" order="7">k_antioch</GameId>
     </GameIds>
     <Names>
+      <Name language="Alan">Antiokeias</Name>
+      <Name language="Amharic">Ansokya</Name>
+      <Name language="Arabic_Andalusia">Antakiya</Name>
+      <Name language="Arabic_Bedouin">Antakiya</Name>
+      <Name language="Arabic_Egypt">Antakiya</Name>
+      <Name language="Arabic_Levant">Antakiya</Name>
+      <Name language="Arabic_Maghreb">Antakiya</Name>
+      <Name language="Arabic_Yemen">Antakiya</Name>
+      <Name language="Arberian">Antiokeias</Name>
+      <Name language="Armenian_Middle">Antiok</Name>
+      <Name language="Armenian_Middle">Antiokla</Name>
       <Name language="Castilian">Antioquía</Name>
       <Name language="Catalan">Antioquia</Name>
       <Name language="Czech">Antiochie</Name>
       <Name language="Danish">Antiokia</Name>
       <Name language="Dutch_Middle">Antiochië</Name>
       <Name language="Finnish">Antiokia</Name>
+      <Name language="French_Old">Antioche</Name>
+      <Name language="Georgian">Antiok</Name>
+      <Name language="Greek_Medieval">Antiokheia</Name>
+      <Name language="Hejazi_Arabic">Antakiya</Name>
       <Name language="Hungarian">Antiochia</Name>
       <Name language="Italian">Antiochia</Name>
       <Name language="Latin">Antiochia</Name>
+      <Name language="Masmuda">Antakiya</Name>
+      <Name language="Norman">Antioche</Name>
       <Name language="Oghuz">Antakiya</Name>
       <Name language="Pecheneg">Antakiya</Name>
       <Name language="Portuguese">Antioquia</Name>
       <Name language="Romanian">Antiohia</Name>
+      <Name language="Sanhaja">Antakiya</Name>
+      <Name language="Sicilian_Arabic">Antakiya</Name>
+      <Name language="Syriac_Classical">Antiokia</Name>
+      <Name language="Tuareg_Tagelmust">Antakiya</Name>
+      <Name language="Tuareg">Antakiya</Name>
+      <Name language="Turkish_Old">Antakiya</Name>
       <Name language="Turkish">Antakiya</Name>
+      <Name language="Turkmen_Medieval">Antakiya</Name>
       <Name language="Turkmen">Antakiya</Name>
+      <Name language="Zenati">Antakiya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38408,29 +38434,57 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
+    <Id>phoenicia</Id>
+    <GameIds>
+    </GameIds>
+    <Names>
+      <Name language="Greek_Medieval">Phoiníkes</Name>
+      <Name language="Latin_Medieval">Phoenice</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
     <Id>tripoli</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tripoli" order="2">b_citadeloftripoli</GameId>
       <GameId game="CK2HIP" parent="c_tripoli" order="1">b_syrtripoli</GameId>
       <GameId game="CK2HIP" parent="d_tripoli" order="4">c_tripoli</GameId>
       <GameId game="CK2HIP" parent="k_antioch" order="3">d_tripoli</GameId>
+      <GameId game="ImperatorRome">769</GameId> <!-- Tripolis -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tarábulus</Name>
+      <Name language="Arabic_Bedouin">Tarábulus</Name>
+      <Name language="Arabic_Egypt">Tarábulus</Name>
+      <Name language="Arabic_Levant">Tarábulus</Name>
+      <Name language="Arabic_Maghreb">Tarábulus</Name>
+      <Name language="Arabic_Yemen">Tarábulus</Name>
       <Name language="Czech">Tripolis</Name>
       <Name language="Dutch_Middle">Tripolis</Name>
       <Name language="Frisian_Old">Tripoly</Name>
       <Name language="German">Tripolis</Name>
+      <Name language="Greek_Ancient">Tripolis</Name>
+      <Name language="Greek_Medieval">Tripolis</Name>
+      <Name language="Hejazi_Arabic">Tarábulus</Name>
       <Name language="Irish">Tripilí</Name>
       <Name language="Latgalian">Tripole</Name>
+      <Name language="Latin_Old">Tripoli</Name>
       <Name language="Lithuanian">Tripolis</Name>
       <Name language="Lombard">Tripul</Name>
+      <Name language="Masmuda">Tarábulus</Name>
       <Name language="Occitan">Trípol</Name>
+      <Name language="Phoenician">Athar</Name>
       <Name language="Polish">Trypolis</Name>
+      <Name language="Punic">Athar</Name>
       <Name language="Romanian">Tripoli</Name>
+      <Name language="Sanhaja">Tarábulus</Name>
+      <Name language="Sicilian_Arabic">Tarábulus</Name>
       <Name language="Sicilian">Trìpuli</Name>
       <Name language="Slovak">Tripolis</Name>
       <Name language="Somali">Triboli</Name>
+      <Name language="Tuareg_Tagelmust">Tarábulus</Name>
+      <Name language="Tuareg">Tarábulus</Name>
       <Name language="Turkish">Trablus</Name>
+      <Name language="Zenati">Tarábulus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -38439,16 +38493,37 @@
       <GameId game="CK2HIP" parent="c_tripoli" order="3">b_citdaelofsaintgilles</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at Sanjil</Name>
+      <Name language="Arabic_Bedouin">Qal'at Sanjil</Name>
+      <Name language="Arabic_Egypt">Qal'at Sanjil</Name>
+      <Name language="Arabic_Levant">Qal'at Sanjil</Name>
+      <Name language="Arabic_Maghreb">Qal'at Sanjil</Name>
+      <Name language="Arabic_Yemen">Qal'at Sanjil</Name>
+      <Name language="Hejazi_Arabic">Qal'at Sanjil</Name>
+      <Name language="Masmuda">Qal'at Sanjil</Name>
       <Name language="Romanian">Sfântul Egidiu</Name> <!-- Historical? Translated -->
+      <Name language="Sanhaja">Qal'at Sanjil</Name>
+      <Name language="Sicilian_Arabic">Qal'at Sanjil</Name>
+      <Name language="Tuareg_Tagelmust">Qal'at Sanjil</Name>
+      <Name language="Tuareg">Qal'at Sanjil</Name>
+      <Name language="Zenati">Qal'at Sanjil</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>gibelet</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_gibelet" order="1">b_gibeletcastle</GameId>
       <GameId game="CK2HIP" parent="c_gibelet" order="2">b_gibelet</GameId>
       <GameId game="CK2HIP" parent="d_tripoli" order="5">c_gibelet</GameId>
+      <GameId game="ImperatorRome">766</GameId> <!-- Byblos -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Jebail</Name>
+      <Name language="Arabic_Bedouin">Jebail</Name>
+      <Name language="Arabic_Egypt">Jebail</Name>
+      <Name language="Arabic_Levant">Jebail</Name>
+      <Name language="Arabic_Maghreb">Jebail</Name>
+      <Name language="Arabic_Yemen">Jebail</Name>
       <Name language="Bosnian">Biblos</Name>
       <Name language="Bulgarian">Biblos</Name>
       <Name language="Castilian">Biblos</Name>
@@ -38459,15 +38534,28 @@
       <Name language="Finnish">Byblos</Name>
       <Name language="French_Old">Byblos</Name>
       <Name language="German">Byblos</Name>
+      <Name language="Greek_Ancient">Byblos</Name>
+      <Name language="Greek_Medieval">Byblos</Name>
+      <Name language="Hejazi_Arabic">Jebail</Name>
       <Name language="Hungarian">Büblosz</Name>
       <Name language="Italian">Biblo</Name>
+      <Name language="Latin_Medieval">Byblus</Name>
+      <Name language="Latin_Old">Byblus</Name>
+      <Name language="Masmuda">Jebail</Name>
       <Name language="Norwegian">Jbeil</Name>
+      <Name language="Phoenician">Gebal</Name>
       <Name language="Polish">Byblos</Name>
       <Name language="Portuguese">Biblos</Name>
+      <Name language="Punic">Gebal</Name>
+      <Name language="Sanhaja">Jebail</Name>
       <Name language="Serbian">Biblos</Name>
+      <Name language="Sicilian_Arabic">Jebail</Name>
       <Name language="Slovene">Biblos</Name>
       <Name language="Swedish">Byblos</Name>
+      <Name language="Tuareg_Tagelmust">Jebail</Name>
+      <Name language="Tuareg">Jebail</Name>
       <Name language="Turkish">Biblos</Name>
+      <Name language="Zenati">Jebail</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54248,6 +54336,12 @@
       <GameId game="CK2HIP" parent="e_spain" order="10">k_granada</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Gharnáta</Name>
+      <Name language="Arabic_Bedouin">Gharnáta</Name>
+      <Name language="Arabic_Egypt">Gharnáta</Name>
+      <Name language="Arabic_Levant">Gharnáta</Name>
+      <Name language="Arabic_Maghreb">Gharnáta</Name>
+      <Name language="Arabic_Yemen">Gharnáta</Name>
       <Name language="Aragonese">Grenada</Name>
       <Name language="Bosnian">Grenada</Name>
       <Name language="Bulgarian">Grenada</Name>
@@ -54256,14 +54350,23 @@
       <Name language="Czech">Grenada</Name>
       <Name language="Estonian">Grenada</Name>
       <Name language="French_Old">Grenade</Name>
+      <Name language="Greek_Medieval">Illiberis</Name>
+      <Name language="Hejazi_Arabic">Gharnáta</Name>
       <Name language="Hungarian">Grenada</Name>
       <Name language="Latgalian">Grenada</Name>
+      <Name language="Latin_Medieval">Iliberri</Name>
       <Name language="Latin">Granata</Name>
       <Name language="Lithuanian">Grenada</Name>
+      <Name language="Masmuda">Gharnáta</Name>
       <Name language="Occitan">Grenada</Name>
       <Name language="Polish">Grenada</Name>
+      <Name language="Sanhaja">Gharnáta</Name>
       <Name language="Serbian">Grenada</Name>
+      <Name language="Sicilian_Arabic">Gharnáta</Name>
       <Name language="Slovene">Grenada</Name>
+      <Name language="Tuareg_Tagelmust">Gharnáta</Name>
+      <Name language="Tuareg">Gharnáta</Name>
+      <Name language="Zenati">Gharnáta</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54272,7 +54375,25 @@
       <GameId game="CK2HIP" parent="c_granada" order="6">b_almunyecar</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Munaqqab</Name>
+      <Name language="Arabic_Bedouin">al-Munaqqab</Name>
+      <Name language="Arabic_Egypt">al-Munaqqab</Name>
+      <Name language="Arabic_Levant">al-Munaqqab</Name>
+      <Name language="Arabic_Maghreb">al-Munaqqab</Name>
+      <Name language="Arabic_Yemen">al-Munaqqab</Name>
+      <Name language="Aragonese">Almunyécar</Name>
+      <Name language="Basque">Almuñekar</Name>
+      <Name language="Catalan_Medieval">Almunyécar</Name>
+      <Name language="French_Old">Almugnécar</Name>
+      <Name language="Hejazi_Arabic">al-Munaqqab</Name>
       <Name language="Latin">Sexi Firmum Iulium</Name>
+      <Name language="Masmuda">al-Munaqqab</Name>
+      <Name language="Portuguese">Almunhécar</Name>
+      <Name language="Sanhaja">al-Munaqqab</Name>
+      <Name language="Sicilian_Arabic">al-Munaqqab</Name>
+      <Name language="Tuareg_Tagelmust">al-Munaqqab</Name>
+      <Name language="Tuareg">al-Munaqqab</Name>
+      <Name language="Zenati">al-Munaqqab</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54281,7 +54402,24 @@
       <GameId game="CK2HIP" parent="c_granada" order="7">b_loja</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Lawsha</Name>
+      <Name language="Arabic_Bedouin">Lawsha</Name>
+      <Name language="Arabic_Egypt">Lawsha</Name>
+      <Name language="Arabic_Levant">Lawsha</Name>
+      <Name language="Arabic_Maghreb">Lawsha</Name>
+      <Name language="Arabic_Yemen">Lawsha</Name>
       <Name language="Castilian">Loxa</Name>
+      <Name language="Catalan_Medieval">Lòxa</Name>
+      <Name language="French_Old">Loxe</Name>
+      <Name language="Galician">Loxa</Name>
+      <Name language="Hejazi_Arabic">Lawsha</Name>
+      <Name language="Leonese">Loxa</Name>
+      <Name language="Masmuda">Lawsha</Name>
+      <Name language="Sanhaja">Lawsha</Name>
+      <Name language="Sicilian_Arabic">Lawsha</Name>
+      <Name language="Tuareg_Tagelmust">Lawsha</Name>
+      <Name language="Tuareg">Lawsha</Name>
+      <Name language="Zenati">Lawsha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54290,23 +54428,63 @@
       <GameId game="CK2HIP" parent="c_cordoba" order="1">b_cordoba</GameId>
       <GameId game="CK2HIP" parent="d_cordoba" order="1">c_cordoba</GameId>
       <GameId game="CK2HIP" parent="k_andalusia" order="7">d_cordoba</GameId>
+      <GameId game="ImperatorRome">1377</GameId> <!-- Corduba -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qurtuba</Name>
+      <Name language="Arabic_Bedouin">Qurtuba</Name>
+      <Name language="Arabic_Egypt">Qurtuba</Name>
+      <Name language="Arabic_Levant">Qurtuba</Name>
+      <Name language="Arabic_Maghreb">Qurtuba</Name>
+      <Name language="Arabic_Yemen">Qurtuba</Name>
+      <Name language="Aragonese">Cordoba</Name>
+      <Name language="Basque">Kordoba</Name>
+      <Name language="Catalan_Medieval">Còrdova</Name>
+      <Name language="French_Old">Cordoue</Name>
+      <Name language="Greek_Medieval">Kordyba</Name>
+      <Name language="Hejazi_Arabic">Qurtuba</Name>
       <Name language="Italian">Cordova</Name>
       <Name language="Latgalian">Kordova</Name>
+      <Name language="Latin_Medieval">Corduba</Name>
+      <Name language="Leonese">Córduba</Name>
       <Name language="Lithuanian">Kordoba</Name>
+      <Name language="Masmuda">Qurtuba</Name>
       <Name language="Occitan">Còrdoa</Name>
       <Name language="Polish">Kordoba</Name>
+      <Name language="Portuguese">Córdova</Name>
+      <Name language="Sanhaja">Qurtuba</Name>
+      <Name language="Sicilian_Arabic">Qurtuba</Name>
       <Name language="Sicilian">Còrdova</Name>
+      <Name language="Tuareg_Tagelmust">Qurtuba</Name>
+      <Name language="Tuareg">Qurtuba</Name>
+      <Name language="Zenati">Qurtuba</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>cabra</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_cordoba" order="3">b_cabra</GameId>
+      <GameId game="ImperatorRome">1390</GameId> <!-- Igabrum -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qabra</Name>
+      <Name language="Arabic_Bedouin">Qabra</Name>
+      <Name language="Arabic_Egypt">Qabra</Name>
+      <Name language="Arabic_Levant">Qabra</Name>
+      <Name language="Arabic_Maghreb">Qabra</Name>
+      <Name language="Arabic_Yemen">Qabra</Name>
+      <Name language="Basque">Kabra</Name>
+      <Name language="French_Old">Cabre</Name>
+      <Name language="Greek_Medieval">Igabrum</Name>
+      <Name language="Hejazi_Arabic">Qabra</Name>
       <Name language="Irish">An Chabrach</Name>
+      <Name language="Latin_Medieval">Igabrum</Name>
+      <Name language="Masmuda">Qabra</Name>
+      <Name language="Sanhaja">Qabra</Name>
+      <Name language="Sicilian_Arabic">Qabra</Name>
+      <Name language="Tuareg_Tagelmust">Qabra</Name>
+      <Name language="Tuareg">Qabra</Name>
+      <Name language="Zenati">Qabra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54315,7 +54493,22 @@
       <GameId game="CK2HIP" parent="c_cordoba" order="6">b_montilla</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Buláy</Name>
+      <Name language="Arabic_Bedouin">Buláy</Name>
+      <Name language="Arabic_Egypt">Buláy</Name>
+      <Name language="Arabic_Levant">Buláy</Name>
+      <Name language="Arabic_Maghreb">Buláy</Name>
+      <Name language="Arabic_Yemen">Buláy</Name>
+      <Name language="French_Old">Montille</Name>
+      <Name language="Hejazi_Arabic">Buláy</Name>
       <Name language="Latin">Munda</Name>
+      <Name language="Masmuda">Buláy</Name>
+      <Name language="Portuguese">Montilha</Name>
+      <Name language="Sanhaja">Buláy</Name>
+      <Name language="Sicilian_Arabic">Buláy</Name>
+      <Name language="Tuareg_Tagelmust">Buláy</Name>
+      <Name language="Tuareg">Buláy</Name>
+      <Name language="Zenati">Buláy</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54376,20 +54569,51 @@
       <GameId game="CK2HIP" parent="k_andalusia" order="9">d_murcia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mursiya</Name>
+      <Name language="Arabic_Bedouin">Mursiya</Name>
+      <Name language="Arabic_Egypt">Mursiya</Name>
+      <Name language="Arabic_Levant">Mursiya</Name>
+      <Name language="Arabic_Maghreb">Mursiya</Name>
+      <Name language="Arabic_Yemen">Mursiya</Name>
+      <Name language="Basque">Murtzia</Name>
+      <Name language="Catalan_Medieval">Múrcia</Name>
+      <Name language="French_Old">Murcie</Name>
+      <Name language="Hejazi_Arabic">Mursiya</Name>
       <Name language="Latgalian">Mursija</Name>
       <Name language="Polish">Murcja</Name>
+      <Name language="Portuguese">Múrcia</Name>
+      <Name language="Sicilian_Arabic">Mursiya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>cartagena</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_murcia" order="2">b_cartagena</GameId>
+      <GameId game="ImperatorRome">1036</GameId> <!-- Mastia -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qartájanna al-Khalfá</Name>
+      <Name language="Arabic_Bedouin">Qartájanna al-Khalfá</Name>
+      <Name language="Arabic_Egypt">Qartájanna al-Khalfá</Name>
+      <Name language="Arabic_Levant">Qartájanna al-Khalfá</Name>
+      <Name language="Arabic_Maghreb">Qartájanna al-Khalfá</Name>
+      <Name language="Arabic_Yemen">Qartájanna al-Khalfá</Name>
+      <Name language="Aragonese">Cartachena</Name>
+      <Name language="Basque">Kartagena</Name>
+      <Name language="French_Old">Carthagène</Name>
       <Name language="Galician">Cartaxena</Name>
+      <Name language="Greek_Ancient">Karkhedon</Name>
+      <Name language="Greek_Medieval">Nea Karchedon</Name>
+      <Name language="Hejazi_Arabic">Qartájanna al-Khalfá</Name>
+      <Name language="Iberian">Mastia</Name>
       <Name language="Latgalian">Kartahena</Name>
+      <Name language="Latin_Medieval">Carthago Nova</Name>
+      <Name language="Latin_Old">Nova Carthago</Name>
       <Name language="Lithuanian">Kartachena</Name>
+      <Name language="Phoenician">Qart Hadasht</Name>
       <Name language="Polish">Kartagena</Name>
+      <Name language="Punic">Qart Hadasht</Name>
+      <Name language="Sicilian_Arabic">Qartájanna al-Khalfá</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -54415,7 +54639,6 @@
     <Id>almansa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_almansa" order="2">b_almansa</GameId>
-      <GameId game="CK2HIP" parent="d_murcia" order="2">c_almansa</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">al-Mansaf</Name>
@@ -54806,10 +55029,23 @@
       <GameId game="CK2HIP" parent="c_lemos" order="2">b_ourense</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Urinsiyya</Name>
+      <Name language="Arabic_Bedouin">Urinsiyya</Name>
+      <Name language="Arabic_Egypt">Urinsiyya</Name>
+      <Name language="Arabic_Levant">Urinsiyya</Name>
+      <Name language="Arabic_Maghreb">Urinsiyya</Name>
+      <Name language="Arabic_Yemen">Urinsiyya</Name>
+      <Name language="Aragonese">Orense</Name>
+      <Name language="Castilian">Orense</Name>
+      <Name language="Catalan_Medieval">Orense</Name>
       <Name language="Finnish">Orense</Name>
+      <Name language="French_Old">Orense</Name>
       <Name language="Greek_Medieval">Aquae Urente</Name>
-      <Name language="Polish">Orense</Name>
+      <Name language="Hejazi_Arabic">Urinsiyya</Name>
       <Name language="Latin">Aquae Urente</Name>
+      <Name language="Leonese">Orense</Name>
+      <Name language="Polish">Orense</Name>
+      <Name language="Sicilian_Arabic">Urinsiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55365,43 +55601,47 @@
       <GameId game="CK2HIP" parent="d_tunis" order="1">c_tunis</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Túnis</Name>
+      <Name language="Arabic_Bedouin">Túnis</Name>
+      <Name language="Arabic_Egypt">Túnis</Name>
+      <Name language="Arabic_Levant">Túnis</Name>
+      <Name language="Arabic_Maghreb">Túnis</Name>
+      <Name language="Arabic_Yemen">Túnis</Name>
       <Name language="Aragonese">Túniz</Name>
       <Name language="Breton_Middle">Tuniz</Name>
       <Name language="Castilian">Túnez</Name>
+      <Name language="Hejazi_Arabic">Túnis</Name>
       <Name language="Hungarian">Tunisz</Name>
       <Name language="Irish">Túinis</Name>
       <Name language="Italian">Tunisi</Name>
       <Name language="Latgalian">Tunisa</Name>
       <Name language="Lithuanian">Tunisas</Name>
+      <Name language="Masmuda">Tunes</Name>
       <Name language="Portuguese">Tunes</Name>
+      <Name language="Romanian">Tunis</Name>
+      <Name language="Sanhaja">Tunes</Name>
+      <Name language="Sicilian_Arabic">Túnis</Name>
       <Name language="Sicilian">Tùnisi</Name>
+      <Name language="Tuareg_Tagelmust">Tunes</Name>
+      <Name language="Tuareg">Tunes</Name>
       <Name language="Turkish">Tunus</Name>
       <Name language="Venetian">Túnixi</Name>
       <Name language="Welsh">Tiwnis</Name>
+      <Name language="Zenati">Tunes</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>hammamet</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tunis" order="5">b_hammamet</GameId>
+      <GameId game="ImperatorRome">3244</GameId> <!-- Pupput -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Pupput</Name>
+      <Name language="Latin_Medieval">Pupput</Name>
+      <Name language="Latin_Old">Pulpite</Name>
       <Name language="Lithuanian">Hamametas</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>medjerda</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_tunis" order="2">c_medjerda</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Czech">Súsy</Name>
-      <Name language="Catalan">Sussa</Name>
-      <Name language="French_Old">Suse</Name>
-      <Name language="Hungarian">Szúsza</Name>
-      <Name language="Lithuanian">Susas</Name>
-      <Name language="Polish">Suza</Name>
-      <Name language="Slovak">Súsy</Name>
+      <Name language="Punic">Thinissut</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55410,23 +55650,38 @@
       <GameId game="CK2HIP" parent="c_medjerda" order="3">b_monastir</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Rouspína</Name>
       <Name language="Hungarian">Monasztir</Name>
+      <Name language="Latin_Medieval">Ruspina</Name>
       <Name language="Lithuanian">Monastyras</Name>
+      <Name language="Masmuda">Munastir</Name>
       <Name language="Polish">Monastyr</Name>
+      <Name language="Sanhaja">Munastir</Name>
+      <Name language="Tuareg_Tagelmust">Munastir</Name>
+      <Name language="Tuareg">Munastir</Name>
+      <Name language="Zenati">Munastir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sousse</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_medjerda" order="4">b_sousse</GameId>
+      <GameId game="CK2HIP" parent="d_tunis" order="2">c_medjerda</GameId>
+      <GameId game="ImperatorRome">3276</GameId> <!-- Hadrametum -->
     </GameIds>
     <Names>
-      <Name language="Czech">Súsy</Name>
       <Name language="Catalan">Sussa</Name>
+      <Name language="Czech">Súsy</Name>
       <Name language="French_Old">Suse</Name>
+      <Name language="Greek_Ancient">Adrymeton</Name>
+      <Name language="Greek_Medieval">Adroúmetos</Name>
       <Name language="Hungarian">Szúsza</Name>
+      <Name language="Latin_Medieval">Hadrumetum</Name>
+      <Name language="Latin_Old">Hadrametum</Name>
       <Name language="Lithuanian">Susas</Name>
+      <Name language="Phoenician">Adramat</Name>
       <Name language="Polish">Suza</Name>
+      <Name language="Punic">Adramat</Name>
       <Name language="Slovak">Súsy</Name>
     </Names>
   </LocationEntity>
@@ -55435,14 +55690,26 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_bizerte" order="1">b_bizerte</GameId>
       <GameId game="CK2HIP" parent="d_tunis" order="3">c_bizerte</GameId>
+      <GameId game="ImperatorRome">3258</GameId> <!-- Hippo Diarrhytus -->
     </GameIds>
     <Names>
       <Name language="Castilian">Bizerta</Name>
       <Name language="Catalan">Bizerta</Name>
       <Name language="Finnish">Biserta</Name>
       <Name language="German">Bizerta</Name>
+      <Name language="Greek_Ancient">Hippon Diarrytos</Name>
+      <Name language="Greek_Medieval">Hippòn Diárrhytos</Name>
       <Name language="Italian">Biserta</Name>
+      <Name language="Latin_Medieval">Hippo Diarrhytus</Name>
+      <Name language="Latin_Old">Hippo Zarytus</Name>
+      <Name language="Masmuda">Benzart</Name>
+      <Name language="Phoenician">Ubon</Name>
       <Name language="Polish">Bizerta</Name>
+      <Name language="Punic">Ubon</Name>
+      <Name language="Sanhaja">Benzart</Name>
+      <Name language="Tuareg_Tagelmust">Benzart</Name>
+      <Name language="Tuareg">Benzart</Name>
+      <Name language="Zenati">Benzart</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55457,10 +55724,17 @@
       <Name language="Castilian">Kairuán</Name>
       <Name language="Catalan">Kairuan</Name>
       <Name language="Croatian">Kairuan</Name>
+      <Name language="Greek_Medieval">Kamounia</Name>
+      <Name language="Latin_Medieval">Kamounia</Name>
       <Name language="Lithuanian">Kairuanas</Name>
+      <Name language="Masmuda">Takerwant</Name>
       <Name language="Polish">Kairuan</Name>
       <Name language="Portuguese">Cairuão</Name>
+      <Name language="Sanhaja">Takerwant</Name>
+      <Name language="Tuareg_Tagelmust">Takerwant</Name>
+      <Name language="Tuareg">Takerwant</Name>
       <Name language="Turkish">Kayravan</Name>
+      <Name language="Zenati">Takerwant</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55468,12 +55742,28 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_sfax" order="1">b_sfax</GameId>
       <GameId game="CK2HIP" parent="d_tunis" order="5">c_sfax</GameId>
+      <GameId game="ImperatorRome">3287</GameId> <!-- Taparura -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Safákus</Name>
+      <Name language="Arabic_Bedouin">Safákus</Name>
+      <Name language="Arabic_Egypt">Safákus</Name>b_chebba
+      <Name language="Arabic_Levant">Safákus</Name>
+      <Name language="Arabic_Maghreb">Safákus</Name>
+      <Name language="Arabic_Yemen">Safákus</Name>
+      <Name language="Greek_Medieval">Taparura</Name>
+      <Name language="Hejazi_Arabic">Safákus</Name>
       <Name language="Hungarian">Szfaksz</Name>
+      <Name language="Latin_Medieval">Taparura</Name>
       <Name language="Lithuanian">Sfaksas</Name>
+      <Name language="Masmuda">Sifaks</Name>
       <Name language="Polish">Safakis</Name>
+      <Name language="Sanhaja">Sifaks</Name>
+      <Name language="Sicilian_Arabic">Safákus</Name>
+      <Name language="Tuareg_Tagelmust">Sifaks</Name>
+      <Name language="Tuareg">Sifaks</Name>
       <Name language="Turkish">Safakes</Name>
+      <Name language="Zenati">Sifaks</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55481,10 +55771,17 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_gabes" order="2">b_gabes</GameId>
       <GameId game="CK2HIP" parent="d_qamuda" order="1">c_gabes</GameId>
+      <GameId game="ImperatorRome">3291</GameId> <!-- Tacape -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Takapi</Name>
+      <Name language="Greek_Medieval">Tacape</Name>
+      <Name language="Latin_Medieval">Tacapae</Name>
+      <Name language="Latin_Old">Tacapae</Name>
       <Name language="Lithuanian">Gabesas</Name>
+      <Name language="Phoenician">Takapes</Name>
       <Name language="Polish">Kabis</Name>
+      <Name language="Punic">Takapes</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55493,6 +55790,8 @@
       <GameId game="CK2HIP" parent="c_gabes" order="5">b_tataouine</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Tabalati</Name>
+      <Name language="Latin_Medieval">Tabalati</Name>
       <Name language="Lithuanian">Tatavinas</Name>
       <Name language="Polish">Tatawin</Name>
       <Name language="Turkish">Tatavin</Name>
@@ -55502,9 +55801,12 @@
     <Id>medenine</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_gabes" order="6">b_medenine</GameId>
+      <GameId game="ImperatorRome">3296</GameId> <!-- Zitha -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Zitha</Name>
       <Name language="Italian">Medenina</Name>
+      <Name language="Latin_Medieval">Zitha</Name>
       <Name language="Lithuanian">Medeninas</Name>
       <Name language="Turkish">Medenin</Name>
     </Names>
@@ -55513,11 +55815,18 @@
     <Id>ajim</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_djerba" order="4">b_ajim</GameId>
+      <GameId game="ImperatorRome">3218</GameId> <!-- Tipasa -->
     </GameIds>
     <Names>
       <Name language="French_Old">Tipaza</Name>
+      <Name language="Greek_Medieval">Tipasa</Name>
       <Name language="Hungarian">Tipáza</Name>
+      <Name language="Latin_Medieval">Tipasa</Name>
+      <Name language="Latin_Old">Tipasa</Name>
+      <Name language="Massylian">Tipaza</Name>
+      <Name language="Phoenician">Tipaza</Name>
       <Name language="Polish">Tipaza</Name>
+      <Name language="Punic">Tipaza</Name>
       <Name language="Romanian">Tipaza</Name>
     </Names>
   </LocationEntity>
@@ -55525,8 +55834,11 @@
     <Id>turra</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_nafzawa" order="2">b_turra</GameId>
+      <GameId game="ImperatorRome">3290</GameId> <!-- Turris Tamalleni -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Turris Tamelleni</Name>
+      <Name language="Latin_Medieval">Turris Tamelleni</Name>
       <Name language="Scottish_Gaelic">Torraibh</Name>
     </Names>
   </LocationEntity>
@@ -55536,8 +55848,18 @@
       <GameId game="CK2HIP" parent="c_qashtiliya" order="3">b_tazwir</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Túzar</Name>
+      <Name language="Arabic_Bedouin">Túzar</Name>
+      <Name language="Arabic_Egypt">Túzar</Name>
+      <Name language="Arabic_Levant">Túzar</Name>
+      <Name language="Arabic_Maghreb">Túzar</Name>
+      <Name language="Arabic_Yemen">Túzar</Name>
+      <Name language="Greek_Medieval">Thusuros</Name>
+      <Name language="Hejazi_Arabic">Túzar</Name>
+      <Name language="Latin_Medieval">Thusuros</Name>
       <Name language="Lithuanian">Tauzaras</Name>
       <Name language="Polish">Tauzar</Name>
+      <Name language="Sicilian_Arabic">Túzar</Name>
       <Name language="Turkish">Tuzer</Name>
     </Names>
   </LocationEntity>
@@ -55547,33 +55869,62 @@
       <GameId game="CK2HIP" parent="c_tripolitana" order="1">b_libtripoli</GameId>
       <GameId game="CK2HIP" parent="d_tripolitania" order="4">c_tripolitana</GameId>
       <GameId game="CK2HIP" parent="k_africa" order="3">d_tripolitania</GameId>
+      <GameId game="ImperatorRome">3303</GameId> <!-- Oea -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tarábulus</Name>
+      <Name language="Arabic_Bedouin">Tarábulus</Name>
+      <Name language="Arabic_Egypt">Tarábulus</Name>
+      <Name language="Arabic_Levant">Tarábulus</Name>
+      <Name language="Arabic_Maghreb">Tarábulus</Name>
+      <Name language="Arabic_Yemen">Tarábulus</Name>
       <Name language="Castilian">Oya</Name>
       <Name language="Czech">Tripolis</Name>
       <Name language="Dutch_Middle">Tripolis</Name>
       <Name language="Frisian_Old">Tripoly</Name>
       <Name language="German">Tripolis</Name>
+      <Name language="Greek_Ancient">Oía</Name>
+      <Name language="Greek_Medieval">Oía</Name>
+      <Name language="Hejazi_Arabic">Tarábulus</Name>
       <Name language="Irish">Tripilí</Name>
       <Name language="Latgalian">Tripole</Name>
+      <Name language="Latin_Medieval">Oea</Name>
+      <Name language="Latin_Old">Oea</Name>
       <Name language="Latin">Tripolis</Name>
       <Name language="Lithuanian">Tripolis</Name>
       <Name language="Lombard">Tripul</Name>
+      <Name language="Masmuda">Tripuli</Name>
       <Name language="Occitan">Trípol</Name>
+      <Name language="Phoenician">Oyat</Name>
       <Name language="Polish">Trypolis</Name>
+      <Name language="Punic">Oyat</Name>
+      <Name language="Sanhaja">Tripuli</Name>
+      <Name language="Sicilian_Arabic">Tarábulus</Name>
       <Name language="Sicilian">Trìpuli</Name>
       <Name language="Slovak">Tripolis</Name>
       <Name language="Somali">Triboli</Name>
+      <Name language="Tuareg_Tagelmust">Tripuli</Name>
+      <Name language="Tuareg">Tripuli</Name>
       <Name language="Turkish">Trablus</Name>
+      <Name language="Zenati">Tripuli</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>misratah</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_leptis_magna" order="1">b_misratah</GameId>
+      <GameId game="CK2HIP" parent="d_tripolitania" order="2">c_leptis_magna</GameId>
+      <GameId game="ImperatorRome">3325</GameId> <!-- Thubactis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thubactis</Name>
+      <Name language="Latin_Medieval">Thubactis</Name>
+      <Name language="Masmuda">Misrata</Name>
+      <Name language="Sanhaja">Misrata</Name>
+      <Name language="Tuareg_Tagelmust">Misrata</Name>
+      <Name language="Tuareg">Misrata</Name>
       <Name language="Turkish">Misrata</Name>
+      <Name language="Zenati">Misrata</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55581,23 +55932,44 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_syrte" order="1">b_syrte</GameId>
       <GameId game="CK2HIP" parent="d_tripolitania" order="3">c_syrte</GameId>
+      <GameId game="ImperatorRome">3334</GameId> <!-- Iscina -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Surt</Name>
+      <Name language="Arabic_Bedouin">Surt</Name>
+      <Name language="Arabic_Egypt">Surt</Name>
+      <Name language="Arabic_Levant">Surt</Name>
+      <Name language="Arabic_Maghreb">Surt</Name>
+      <Name language="Arabic_Yemen">Surt</Name>
       <Name language="Czech">Syrta</Name>
+      <Name language="Greek_Ancient">Charax</Name>
+      <Name language="Greek_Medieval">Iscina</Name>
+      <Name language="Hejazi_Arabic">Surt</Name>
       <Name language="Hungarian">Szurt</Name>
       <Name language="Latgalian">Sirta</Name>
+      <Name language="Latin_Medieval">Iscina</Name>
+      <Name language="Latin_Old">Iscina</Name>
       <Name language="Lithuanian">Surtas</Name>
+      <Name language="Masmuda">Surt</Name>
       <Name language="Polish">Syrta</Name>
+      <Name language="Sanhaja">Surt</Name>
+      <Name language="Sicilian_Arabic">Surt</Name>
       <Name language="Slovak">Syrta</Name>
+      <Name language="Tuareg_Tagelmust">Surt</Name>
+      <Name language="Tuareg">Surt</Name>
+      <Name language="Zenati">Surt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>jarjis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_jafara" order="3">b_jarjis</GameId>
+      <GameId game="ImperatorRome">3295</GameId> <!-- Gergis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Gergis</Name>
       <Name language="Hungarian">Dzsardzsísz</Name>
+      <Name language="Latin_Medieval">Gergis</Name>
       <Name language="Polish">Dzardzis</Name>
     </Names>
   </LocationEntity>
@@ -55608,29 +55980,24 @@
     </GameIds>
     <Names>
       <Name language="French_Old">Beni Ulid</Name>
+      <Name language="Greek_Medieval">Assaria</Name>
       <Name language="Hungarian">Bani Valíd</Name>
+      <Name language="Latin_Medieval">Assaria</Name>
       <Name language="Lithuanian">Bani Validas</Name>
       <Name language="Sicilian">Beni Ulid</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>beni_yanni</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_kabylia" order="1">c_beni_yanni</GameId>
-    </GameIds>
-    <Names>
-      <Name language="Catalan">Gíger</Name>
-      <Name language="Lithuanian">Džidželis</Name>
-      <Name language="Polish">Dzidzili</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>jijel</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_beni_yanni" order="1">b_jijel</GameId>
+      <GameId game="CK2HIP" parent="d_kabylia" order="1">c_beni_yanni</GameId>
+      <GameId game="ImperatorRome">3150</GameId> <!-- Igilgili -->
     </GameIds>
     <Names>
       <Name language="Catalan">Gíger</Name>
+      <Name language="Greek_Medieval">Igilgili</Name>
+      <Name language="Latin_Medieval">Igilgili</Name>
       <Name language="Lithuanian">Džidželis</Name>
       <Name language="Polish">Dzidzili</Name>
     </Names>
@@ -55640,11 +56007,18 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_constantine" order="1">b_constantine</GameId>
       <GameId game="CK2HIP" parent="d_kabylia" order="2">c_constantine</GameId>
+      <GameId game="ImperatorRome">3163</GameId> <!-- Cirta -->
     </GameIds>
     <Names>
       <Name language="Castilian">Constantina</Name>
+      <Name language="Greek_Ancient">Kirta</Name>
       <Name language="Italian">Constantina</Name>
+      <Name language="Latin_Medieval">Cirta</Name>
+      <Name language="Latin_Old">Cirta</Name>
+      <Name language="Massylian">Kirta</Name>
+      <Name language="Phoenician">Qirtan</Name>
       <Name language="Portuguese">Constantina</Name>
+      <Name language="Punic">Qirtan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55661,11 +56035,16 @@
     <Id>guelma</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_constantine" order="5">b_guelma</GameId>
+      <GameId game="ImperatorRome">3223</GameId> <!-- Calama -->
     </GameIds>
     <Names>
-      <Name language="Lithuanian">Gelma</Name>
-      <Name language="Polish">Kalima</Name>
+      <Name language="Greek_Ancient">Kalama</Name>
+      <Name language="Latin_Old">Calama</Name>
       <Name language="Latin">Calama</Name>
+      <Name language="Lithuanian">Gelma</Name>
+      <Name language="Phoenician">Malaka</Name>
+      <Name language="Polish">Kalima</Name>
+      <Name language="Punic">Malaka</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55673,13 +56052,20 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_bejaija" order="1">b_bejaija</GameId>
       <GameId game="CK2HIP" parent="d_kabylia" order="3">c_bejaija</GameId>
+      <GameId game="ImperatorRome">3126</GameId> <!-- Saldae -->
     </GameIds>
     <Names>
       <Name language="Castilian">Bugía</Name>
       <Name language="Catalan">Bugia</Name>
       <Name language="German">Bidschãya</Name>
+      <Name language="Greek_Medieval">Saldai</Name>
       <Name language="Italian">Bijaya</Name>
+      <Name language="Latin_Medieval">Saldae</Name>
+      <Name language="Latin_Old">Saldae</Name>
+      <Name language="Massylian">Zalda</Name>
+      <Name language="Phoenician">Zalda</Name>
       <Name language="Portuguese">Bugia</Name>
+      <Name language="Punic">Zalda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55687,11 +56073,17 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_annaba" order="1">b_annabah</GameId>
       <GameId game="CK2HIP" parent="d_kabylia" order="4">c_annaba</GameId>
+      <GameId game="ImperatorRome">3225</GameId> <!-- Hippo Regius -->
     </GameIds>
     <Names>
       <Name language="French_Old">Bone</Name>
+      <Name language="Greek_Ancient">Hippon Basilikos</Name>
       <Name language="Hungarian">Annába</Name>
+      <Name language="Latin_Medieval">Hippo Regius</Name>
+      <Name language="Latin_Old">Hippo Regius</Name>
       <Name language="Lithuanian">Anaba</Name>
+      <Name language="Phoenician">Ubon Massylia</Name>
+      <Name language="Punic">Ubon Massylia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55714,6 +56106,8 @@
       <Name language="Dutch_Middle">Taif</Name>
       <Name language="French_Old">Taëf</Name>
       <Name language="German">Taif</Name>
+      <Name language="Greek_Medieval">Setifis</Name>
+      <Name language="Latin_Medieval">Setifis</Name>
       <Name language="Lithuanian">Setifas</Name>
       <Name language="Polish">Satif</Name>
       <Name language="Portuguese">Taif</Name>
@@ -55727,6 +56121,8 @@
     </GameIds>
     <Names>
       <Name language="Polish">Biskira</Name>
+      <Name language="Greek_Medieval">Vescera</Name>
+      <Name language="Latin_Medieval">Vescera</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -55745,8 +56141,15 @@
       <GameId game="CK2HIP" order="11846">k_tiaret</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Tingartia</Name>
+      <Name language="Latin_Medieval">Tingartia</Name>
       <Name language="Lithuanian">Tiaretas</Name>
+      <Name language="Masmuda">Tagdemt</Name>
       <Name language="Polish">Tijarat</Name>
+      <Name language="Sanhaja">Tagdemt</Name>
+      <Name language="Tuareg_Tagelmust">Tagdemt</Name>
+      <Name language="Tuareg">Tagdemt</Name>
+      <Name language="Zenati">Tagdemt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56428,7 +56831,21 @@
       <GameId game="CK2HIP" parent="k_armenia" order="6">d_taron</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Muš</Name>
+      <Name language="Arabic_Bedouin">Muš</Name>
+      <Name language="Arabic_Egypt">Muš</Name>
+      <Name language="Arabic_Levant">Muš</Name>
+      <Name language="Arabic_Maghreb">Muš</Name>
+      <Name language="Arabic_Yemen">Muš</Name>
+      <Name language="Armenian_Middle">Daron</Name>
+      <Name language="Greek_Medieval">Taron</Name>
+      <Name language="Hejazi_Arabic">Muš</Name>
+      <Name language="Kurdish">Mûs</Name>
       <Name language="Latin">Taraunitis</Name>
+      <Name language="Oghuz">Mus</Name>
+      <Name language="Sicilian_Arabic">Muš</Name>
+      <Name language="Turkish_Old">Mus</Name>
+      <Name language="Turkmen_Medieval">Mus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56459,7 +56876,13 @@
       <GameId game="CK2HIP" parent="d_mesopotamia" order="2">c_sper</GameId>
     </GameIds>
     <Names>
+      <Name language="Georgian">Speri</Name>
+      <Name language="Greek_Medieval">Hyspirátis</Name>
+      <Name language="Kurdish">Espîr</Name>
       <Name language="Latin">Syspiritis</Name>
+      <Name language="Oghuz">Ispir</Name>
+      <Name language="Turkish_Old">Ispir</Name>
+      <Name language="Turkmen_Medieval">Ispir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56468,7 +56891,20 @@
       <GameId game="CK2HIP" parent="c_karin" order="2">b_keltzene</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Arzinjan</Name>
+      <Name language="Arabic_Bedouin">Arzinjan</Name>
+      <Name language="Arabic_Egypt">Arzinjan</Name>
+      <Name language="Arabic_Levant">Arzinjan</Name>
+      <Name language="Arabic_Maghreb">Arzinjan</Name>
+      <Name language="Arabic_Yemen">Arzinjan</Name>
+      <Name language="Greek_Medieval">Keltzene</Name>
+      <Name language="Hejazi_Arabic">Arzinjan</Name>
+      <Name language="Kurdish">Ezirgan</Name>
       <Name language="Latin">Keltzene</Name>
+      <Name language="Oghuz">Erzincan</Name>
+      <Name language="Sicilian_Arabic">Arzinjan</Name>
+      <Name language="Turkish_Old">Erzincan</Name>
+      <Name language="Turkmen_Medieval">Erzincan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56478,7 +56914,20 @@
       <GameId game="CK2HIP" parent="d_dzopk" order="2">c_charpete</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hisn Ziyad</Name>
+      <Name language="Arabic_Bedouin">Hisn Ziyad</Name>
+      <Name language="Arabic_Egypt">Hisn Ziyad</Name>
+      <Name language="Arabic_Levant">Hisn Ziyad</Name>
+      <Name language="Arabic_Maghreb">Hisn Ziyad</Name>
+      <Name language="Arabic_Yemen">Hisn Ziyad</Name>
+      <Name language="Greek_Medieval">Charpete</Name>
+      <Name language="Hejazi_Arabic">Hisn Ziyad</Name>
+      <Name language="Kurdish">Xarpet</Name>
       <Name language="Latin">Charpete</Name>
+      <Name language="Oghuz">Harput</Name>
+      <Name language="Sicilian_Arabic">Hisn Ziyad</Name>
+      <Name language="Turkish_Old">Harput</Name>
+      <Name language="Turkmen_Medieval">Harput</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56487,7 +56936,12 @@
       <GameId game="CK2HIP" parent="c_charpete" order="1">b_chosomachon</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Chosomachon</Name>
+      <Name language="Kurdish">Melkisî</Name>
       <Name language="Latin">Chosomachon</Name>
+      <Name language="Oghuz">Çemisgezek</Name>
+      <Name language="Turkish_Old">Çemisgezek</Name>
+      <Name language="Turkmen_Medieval">Çemisgezek</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56496,7 +56950,12 @@
       <GameId game="CK2HIP" parent="c_charpete" order="2">b_mertikerton</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Mertikerton</Name>
+      <Name language="Kurdish">Mazgerd</Name>
       <Name language="Latin">Mertikerton</Name>
+      <Name language="Oghuz">Mazgirt</Name>
+      <Name language="Turkish_Old">Mazgirt</Name>
+      <Name language="Turkmen_Medieval">Mazgirt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56505,7 +56964,12 @@
       <GameId game="CK2HIP" parent="c_charpete" order="3">b_chozanon</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Chozanon</Name>
+      <Name language="Kurdish">Xozad</Name>
       <Name language="Latin">Chozanon</Name>
+      <Name language="Oghuz">Xozad</Name>
+      <Name language="Turkish_Old">Xozad</Name>
+      <Name language="Turkmen_Medieval">Xozad</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -56767,7 +57231,35 @@
       <GameId game="CK2HIP" parent="c_reval" order="5">b_tallin</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qlwn</Name>
+      <Name language="Arabic_Bedouin">Qlwn</Name>
+      <Name language="Arabic_Egypt">Qlwn</Name>
+      <Name language="Arabic_Levant">Qlwn</Name>
+      <Name language="Arabic_Maghreb">Qlwn</Name>
+      <Name language="Arabic_Yemen">Qlwn</Name>
+      <Name language="Danish_Middle">Revælæ</Name>
+      <Name language="English_Old_Norse">Revælæ</Name>
+      <Name language="Estonian">Lyndanisse</Name>
+      <Name language="Finnish">Kesoniemi</Name>
+      <Name language="Gothic">Räffle</Name>
+      <Name language="Hejazi_Arabic">Qlwn</Name>
+      <Name language="Karelian">Kesoniemi</Name>
+      <Name language="Khanty">Lyndanisse</Name>
+      <Name language="Komi">Kesoniemi</Name>
+      <Name language="Latgalian">Lyndanisse</Name>
+      <Name language="Lithuanian_Medieval">Lyndanisse</Name>
+      <Name language="Livonian">Lyndanisse</Name>
+      <Name language="Mari">Kesoniemi</Name>
+      <Name language="Moksha">Kesoniemi</Name>
+      <Name language="Norwegian_Old">Revælæ</Name>
+      <Name language="Prussian_Old">Lyndanisse</Name>
       <Name language="Romanian">Talin</Name>
+      <Name language="Russian_Medieval">Ledenets</Name>
+      <Name language="Sami">Kesoniemi</Name>
+      <Name language="Samoyed">Kesoniemi</Name>
+      <Name language="Sicilian_Arabic">Qlwn</Name>
+      <Name language="Swedish_Old">Räffle</Name>
+      <Name language="Vepsian_Medieval">Lyndanisse</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57032,17 +57524,49 @@
       <GameId game="CK2HIP" parent="c_lower_dniepr" order="3">b_chyhyryn</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Cigirin</Name>
+      <Name language="Bashkir">Cigirin</Name>
+      <Name language="Bulgar">Cigirin</Name>
+      <Name language="Circassian">Cigirin</Name>
+      <Name language="Cuman">Cigirin</Name>
+      <Name language="Czech_Medieval">Czehryn</Name>
+      <Name language="Karluk">Cigirin</Name>
+      <Name language="Khazar_Kabar">Cigirin</Name>
+      <Name language="Khazar">Cigirin</Name>
+      <Name language="Kyrgyz">Cigirin</Name>
+      <Name language="Mongol_Proto">Cigirin</Name>
+      <Name language="Oghuz">Cigirin</Name>
+      <Name language="Pecheneg">Cigirin</Name>
+      <Name language="Polish_Old">Czehryn</Name>
       <Name language="Romanian">Ciîhîrîn</Name> <!-- Not sure about this one - may be just a transliteration -->
+      <Name language="Slovak_Medieval">Czehryn</Name>
+      <Name language="Sorbian">Czehryn</Name>
+      <Name language="Turkish_Old">Cigirin</Name>
+      <Name language="Turkmen_Medieval">Cigirin</Name>
+      <Name language="Uyghur">Cigirin</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>sneporod</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_zaporizhia" order="2">c_chortitza</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Romanian">Hortîțea</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>chortitza</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_chortitza" order="2">b_khortytsia</GameId>
-      <GameId game="CK2HIP" parent="d_zaporizhia" order="2">c_chortitza</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Chortyca</Name>
+      <Name language="German_Middle_High">Gortiz</Name>
+      <Name language="Polish_Old">Chortyca</Name>
       <Name language="Romanian">Hortîțea</Name>
+      <Name language="Slovak_Medieval">Chortyca</Name>
+      <Name language="Sorbian">Chortyca</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57127,9 +57651,41 @@
     <Id>berezan</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_olvia" order="7">b_berezan</GameId>
+      <GameId game="ImperatorRome">7871</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7872</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7873</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7874</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7875</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7876</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7877</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7878</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7879</GameId> <!-- Borysthenes -->
+      <GameId game="ImperatorRome">7880</GameId> <!-- Borysthenes -->
     </GameIds>
     <Names>
+      <Name language="Alan">Borysthenes</Name>
+      <Name language="Arberian">Borysthenes</Name>
+      <Name language="Armenian_Middle">Borysthenes</Name>
+      <Name language="Avar_Old">Pirezin</Name>
+      <Name language="Bashkir">Pirezin</Name>
+      <Name language="Bulgar">Pirezin</Name>
+      <Name language="Circassian">Pirezin</Name>
+      <Name language="Cuman">Pirezin</Name>
+      <Name language="Georgian">Borysthenes</Name>
+      <Name language="Gothic_Crimean">Borysthenes</Name>
+      <Name language="Greek_Medieval">Borysthenes</Name>
+      <Name language="Karluk">Pirezin</Name>
+      <Name language="Khazar_Kabar">Pirezin</Name>
+      <Name language="Khazar">Pirezin</Name>
+      <Name language="Kyrgyz">Pirezin</Name>
       <Name language="Latin">Borysthenes</Name>
+      <Name language="Lithuanian_Medieval">Boristenas</Name>
+      <Name language="Mongol_Proto">Pirezin</Name>
+      <Name language="Oghuz">Pirezin</Name>
+      <Name language="Pecheneg">Pirezin</Name>
+      <Name language="Turkish_Old">Pirezin</Name>
+      <Name language="Turkmen_Medieval">Pirezin</Name>
+      <Name language="Uyghur">Pirezin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57138,18 +57694,37 @@
       <GameId game="CK2HIP" parent="c_olvia" order="2">b_ochakiv</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Qara-Kerman</Name>
+      <Name language="Bashkir">Qara-Kerman</Name>
       <Name language="Bosnian">Ocakov</Name>
+      <Name language="Bulgar">Qara-Kerman</Name>
       <Name language="Bulgarian">Ocakov</Name>
-      <Name language="Slovene">Ocakov</Name>
+      <Name language="Circassian">Qara-Kerman</Name>
       <Name language="Croatian">Ocakov</Name>
+      <Name language="Cuman">Qara-Kerman</Name>
+      <Name language="Karluk">Qara-Kerman</Name>
+      <Name language="Khazar_Kabar">Qara-Kerman</Name>
+      <Name language="Khazar">Qara-Kerman</Name>
+      <Name language="Kyrgyz">Qara-Kerman</Name>
+      <Name language="Mongol_Proto">Qara-Kerman</Name>
+      <Name language="Oghuz">Kara-Kirman</Name>
+      <Name language="Pecheneg">Kara-Kirman</Name>
       <Name language="Romanian">Vozia</Name>
       <Name language="Serbian">Ocakov</Name>
+      <Name language="Slovene">Ocakov</Name>
+      <Name language="Turkish_Old">Kara-Kirman</Name>
+      <Name language="Turkmen_Medieval">Kara-Kirman</Name>
+      <Name language="Uyghur">Qara-Kerman</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>odessa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_olvia" order="3">b_odessa</GameId>
+      <GameId game="ImperatorRome">4525</GameId> <!-- Tyras -->
+      <GameId game="ImperatorRome">7881</GameId> <!-- Tyras -->
+      <GameId game="ImperatorRome">7882</GameId> <!-- Tyras -->
+      <GameId game="ImperatorRome">7883</GameId> <!-- Tyras -->
     </GameIds>
     <Names>
       <Name language="Alan">Tyras</Name>
@@ -57184,6 +57759,7 @@
       <Name language="Greek_Medieval">Tyras</Name>
       <Name language="Italian_Central">Ginestra</Name>
       <Name language="Italian_Medieval">Ginestra</Name>
+      <Name language="Karluk">Hacibey</Name>
       <Name language="Khazar_Kabar">Hocabey</Name>
       <Name language="Khazar">Hocabey</Name>
       <Name language="Khitan">Hacibey</Name>
@@ -57265,20 +57841,70 @@
       <GameId game="CK2HIP" parent="e_null" order="6">k_khazaria</GameId>
     </GameIds>
     <Names>
+      <Name language="Alan">Chazaria</Name>
+      <Name language="Arabic_Andalusia">Khazarstan</Name>
+      <Name language="Arabic_Bedouin">Khazarstan</Name>
+      <Name language="Arabic_Egypt">Khazarstan</Name>
+      <Name language="Arabic_Levant">Khazarstan</Name>
+      <Name language="Arabic_Maghreb">Khazarstan</Name>
+      <Name language="Arabic_Yemen">Khazarstan</Name>
+      <Name language="Arberian">Chazaria</Name>
+      <Name language="Armenian_Middle">Xazir-k'</Name>
+      <Name language="Balochi">Xazarstán</Name>
+      <Name language="Bashkir">Kozárstan</Name>
+      <Name language="Bosnian_Medieval">Kozaria</Name>
+      <Name language="Bulgarian_Old">Kozaria</Name>
+      <Name language="Circassian">Qazahrstan</Name>
+      <Name language="Croatian_Medieval">Kozaria</Name>
+      <Name language="Czech_Medieval">Chazarsko</Name>
       <Name language="Dalmatian_Medieval">Cassaria</Name>
+      <Name language="Daylami">Xazarstán</Name>
+      <Name language="Georgian">Xazar'i</Name>
+      <Name language="Gothic_Crimean">Chazaria</Name>
+      <Name language="Greek_Medieval">Chazaria</Name>
+      <Name language="Hejazi_Arabic">Khazarstan</Name>
+      <Name language="Hungarian_Old_Early">Kazaria</Name>
+      <Name language="Hungarian_Old">Kazária</Name>
       <Name language="Italian_Central">Cassaria</Name>
       <Name language="Italian_Medieval">Cassaria</Name>
+      <Name language="Karluk">Qasarstan</Name>
+      <Name language="Kurdish">Xazarstán</Name>
+      <Name language="Kyrgyz">Xäzärstan</Name>
       <Name language="Langobardic">Cassaria</Name>
       <Name language="Latin">Cassaria</Name>
       <Name language="Ligurian">Cassaria</Name>
+      <Name language="Masmuda">Khazarstan</Name>
+      <Name language="Mongol_Proto">Xäzärstan</Name>
       <Name language="Neapolitan">Cassaria</Name>
+      <Name language="Oghuz">Hazarstan</Name>
+      <Name language="Pashto">Xazarstán</Name>
+      <Name language="Pecheneg">Hazarstan</Name>
+      <Name language="Persian_Middle">Xazarstán</Name>
+      <Name language="Persian">Xazarstán</Name>
+      <Name language="Polish_Old">Kozariaia</Name>
       <Name language="Romanian_Old">Cassaria</Name>
       <Name language="Romanian">Hazaria</Name>
+      <Name language="Russian_Medieval">Kozariya</Name>
+      <Name language="Sanhaja">Khazarstan</Name>
       <Name language="Sardinian">Cassaria</Name>
+      <Name language="Serbian_Medieval">Kozaria</Name>
+      <Name language="Sicilian_Arabic">Khazarstan</Name>
       <Name language="Sicilian">Cassaria</Name>
+      <Name language="Slovak_Medieval">Chazarsko</Name>
+      <Name language="Slovene_Medieval">Kozaria</Name>
+      <Name language="Sogdian">Xazarstán</Name>
+      <Name language="Sorbian">Kozaria</Name>
+      <Name language="Szekely_Old">Kazária</Name>
+      <Name language="Tajiki">Xazarstán</Name>
+      <Name language="Tuareg_Tagelmust">Khazarstan</Name>
+      <Name language="Tuareg">Khazarstan</Name>
+      <Name language="Turkish_Old">Hazarstan</Name>
+      <Name language="Turkmen_Medieval">Hazarstan</Name>
       <Name language="Tuscan_Medieval">Cassaria</Name>
       <Name language="Umbrian_Medieval">Cassaria</Name>
+      <Name language="Uyghur">Qasarstan</Name>
       <Name language="Venetian_Medieval">Cassaria</Name>
+      <Name language="Zenati">Khazarstan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -57384,6 +58010,7 @@
       <Name language="Ligurian">Atel</Name>
       <Name language="Lithuanian_Medieval">Atel</Name>
       <Name language="Mari">Jul</Name>
+      <Name language="Masmuda">Atil</Name>
       <Name language="Moksha">Jul</Name>
       <Name language="Mongol_Proto">Ejil</Name>
       <Name language="Neapolitan">Atel</Name>
@@ -57407,11 +58034,13 @@
       <Name language="Sicilian">Atel</Name>
       <Name language="Slovak_Medieval">Volha</Name>
       <Name language="Slovene_Medieval">Vl'ga</Name>
+      <Name language="Sogdian">Atil</Name>
       <Name language="Sorbian">Vl'ga</Name>
       <Name language="Swedish_Old">Atel</Name>
       <Name language="Szekely_Old">Etel</Name>
       <Name language="Tajiki">Atil</Name>
       <Name language="Thuringian_Medieval">Atel</Name>
+      <Name language="Tuareg_Tagelmust">Atil</Name>
       <Name language="Tuareg">Atil</Name>
       <Name language="Turkish_Old">Idil</Name>
       <Name language="Turkmen_Medieval">Idil</Name>
@@ -66604,7 +67233,7 @@
     <Id>manuf</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_manupura" order="1">b_manuf</GameId>
-      <GameId game="ImperatorRome">526</GameId>
+      <GameId game="ImperatorRome">526</GameId> <!-- Onouphis Ano -->
     </GameIds>
     <Names>
       <Name language="Egyptian_Coptic">Onufe</Name>
@@ -67713,16 +68342,47 @@
     <Id>sruk</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_edessa" order="2">b_sruk</GameId>
+      <GameId game="ImperatorRome">817</GameId> <!-- Batnae -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sarug</Name>
+      <Name language="Arabic_Bedouin">Sarug</Name>
+      <Name language="Arabic_Egypt">Sarug</Name>
+      <Name language="Arabic_Levant">Sarug</Name>
+      <Name language="Arabic_Maghreb">Sarug</Name>
+      <Name language="Arabic_Yemen">Sarug</Name>
+      <Name language="French_Old">Sorogia</Name>
+      <Name language="Greek_Medieval">Batnai</Name>
+      <Name language="Hejazi_Arabic">Sarug</Name>
+      <Name language="Kurdish">Sirûc</Name>
+      <Name language="Latin_Medieval">Batnae</Name>
+      <Name language="Norman">Sorogia</Name>
+      <Name language="Oghuz">Suruç</Name>
+      <Name language="Sicilian_Arabic">Sarug</Name>
+      <Name language="Turkish_Old">Suruç</Name>
+      <Name language="Turkmen_Medieval">Suruç</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>bile</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_edessa" order="3">b_bile</GameId>
+      <GameId game="ImperatorRome">891</GameId> <!-- Birtha -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Birah</Name>
+      <Name language="Arabic_Bedouin">al-Birah</Name>
+      <Name language="Arabic_Egypt">al-Birah</Name>
+      <Name language="Arabic_Levant">al-Birah</Name>
+      <Name language="Arabic_Maghreb">al-Birah</Name>
+      <Name language="Arabic_Yemen">al-Birah</Name>
+      <Name language="Greek_Medieval">Birtha</Name>
+      <Name language="Hejazi_Arabic">al-Birah</Name>
+      <Name language="Kurdish">Bêrecûg</Name>
+      <Name language="Oghuz">Birecik</Name>
+      <Name language="Sicilian_Arabic">al-Birah</Name>
+      <Name language="Turkish_Old">Birecik</Name>
+      <Name language="Turkmen_Medieval">Birecik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67731,6 +68391,22 @@
       <GameId game="CK2HIP" parent="c_edessa" order="4">b_hromgla</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at al-Rum</Name>
+      <Name language="Arabic_Bedouin">Qal'at al-Rum</Name>
+      <Name language="Arabic_Egypt">Qal'at al-Rum</Name>
+      <Name language="Arabic_Levant">Qal'at al-Rum</Name>
+      <Name language="Arabic_Maghreb">Qal'at al-Rum</Name>
+      <Name language="Arabic_Yemen">Qal'at al-Rum</Name>
+      <Name language="Armenian_Middle">Hromkla</Name>
+      <Name language="French_Old">Ranculat</Name>
+      <Name language="Greek_Medieval">Romaion Koula</Name>
+      <Name language="Hejazi_Arabic">Qal'at al-Rum</Name>
+      <Name language="Kurdish">Kela Zêrîn</Name>
+      <Name language="Norman">Ranculat</Name>
+      <Name language="Oghuz">Rumkale</Name>
+      <Name language="Sicilian_Arabic">Qal'at al-Rum</Name>
+      <Name language="Turkish_Old">Rumkale</Name>
+      <Name language="Turkmen_Medieval">Rumkale</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67739,22 +68415,39 @@
       <GameId game="CK2HIP" parent="c_edessa" order="5">b_samsat</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sumaysat</Name>
+      <Name language="Arabic_Bedouin">Sumaysat</Name>
+      <Name language="Arabic_Egypt">Sumaysat</Name>
+      <Name language="Arabic_Levant">Sumaysat</Name>
+      <Name language="Arabic_Maghreb">Sumaysat</Name>
+      <Name language="Arabic_Yemen">Sumaysat</Name>
+      <Name language="Armenian_Middle">Šamšat</Name>
+      <Name language="Greek_Medieval">Samosata</Name>
+      <Name language="Hejazi_Arabic">Sumaysat</Name>
+      <Name language="Oghuz">Šimšat</Name>
+      <Name language="Sicilian_Arabic">Sumaysat</Name>
+      <Name language="Turkish_Old">Šimšat</Name>
+      <Name language="Turkmen_Medieval">Šimšat</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>tell_bashir</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_tell_bashir" order="1">b_turbessel</GameId>
       <GameId game="CK2HIP" parent="d_edessa" order="2">c_tell_bashir</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>turbessel</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_tell_bashir" order="1">b_turbessel</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Arabic_Andalusia">Tell Bashir</Name>
+      <Name language="Arabic_Bedouin">Tell Bashir</Name>
+      <Name language="Arabic_Egypt">Tell Bashir</Name>
+      <Name language="Arabic_Levant">Tell Bashir</Name>
+      <Name language="Arabic_Maghreb">Tell Bashir</Name>
+      <Name language="Arabic_Yemen">Tell Bashir</Name>
+      <Name language="Hejazi_Arabic">Tell Bashir</Name>
+      <Name language="Oghuz">Tilbesar</Name>
+      <Name language="Sicilian_Arabic">Tell Bashir</Name>
+      <Name language="Turkish_Old">Tilbesar</Name>
+      <Name language="Turkmen_Medieval">Tilbesar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67763,14 +68456,35 @@
       <GameId game="CK2HIP" parent="c_tell_bashir" order="2">b_trihalet</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tell Halid</Name>
+      <Name language="Arabic_Bedouin">Tell Halid</Name>
+      <Name language="Arabic_Egypt">Tell Halid</Name>
+      <Name language="Arabic_Levant">Tell Halid</Name>
+      <Name language="Arabic_Maghreb">Tell Halid</Name>
+      <Name language="Arabic_Yemen">Tell Halid</Name>
+      <Name language="Hejazi_Arabic">Tell Halid</Name>
+      <Name language="Sicilian_Arabic">Tell Halid</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>kyrrhos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tell_bashir" order="3">b_kyrrhos</GameId>
+      <GameId game="ImperatorRome">794</GameId> <!-- Cyrrhus -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qurus</Name>
+      <Name language="Arabic_Bedouin">Qurus</Name>
+      <Name language="Arabic_Egypt">Qurus</Name>
+      <Name language="Arabic_Levant">Qurus</Name>
+      <Name language="Arabic_Maghreb">Qurus</Name>
+      <Name language="Arabic_Yemen">Qurus</Name>
+      <Name language="French_Old">Corice</Name>
+      <Name language="Greek_Ancient">Kyrrhos</Name>
+      <Name language="Hejazi_Arabic">Qurus</Name>
+      <Name language="Latin_Old">Cyrrhus</Name>
+      <Name language="Norman">Corice</Name>
+      <Name language="Sicilian_Arabic">Qurus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67779,6 +68493,7 @@
       <GameId game="CK2HIP" parent="c_tell_bashir" order="4">b_nizip</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Nisibina</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67787,6 +68502,14 @@
       <GameId game="CK2HIP" parent="c_aintab" order="4">b_ravendan</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">ar-Rawandan</Name>
+      <Name language="Arabic_Bedouin">ar-Rawandan</Name>
+      <Name language="Arabic_Egypt">ar-Rawandan</Name>
+      <Name language="Arabic_Levant">ar-Rawandan</Name>
+      <Name language="Arabic_Maghreb">ar-Rawandan</Name>
+      <Name language="Arabic_Yemen">ar-Rawandan</Name>
+      <Name language="Hejazi_Arabic">ar-Rawandan</Name>
+      <Name language="Sicilian_Arabic">ar-Rawandan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67795,6 +68518,10 @@
       <GameId game="CK2HIP" parent="c_aintab" order="5">b_duluk</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Doliche</Name>
+      <Name language="Oghuz">Dülük</Name>
+      <Name language="Turkish_Old">Dülük</Name>
+      <Name language="Turkmen_Medieval">Dülük</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67804,6 +68531,15 @@
       <GameId game="CK2HIP" parent="d_edessa" order="4">c_kaisun</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Kaisum</Name>
+      <Name language="Arabic_Bedouin">Kaisum</Name>
+      <Name language="Arabic_Egypt">Kaisum</Name>
+      <Name language="Arabic_Levant">Kaisum</Name>
+      <Name language="Arabic_Maghreb">Kaisum</Name>
+      <Name language="Arabic_Yemen">Kaisum</Name>
+      <Name language="Greek_Medieval">Kaison</Name>
+      <Name language="Hejazi_Arabic">Kaisum</Name>
+      <Name language="Sicilian_Arabic">Kaisum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67812,6 +68548,20 @@
       <GameId game="CK2HIP" parent="c_kaisun" order="2">b_behetselin</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hisn Mansur</Name>
+      <Name language="Arabic_Bedouin">Hisn Mansur</Name>
+      <Name language="Arabic_Egypt">Hisn Mansur</Name>
+      <Name language="Arabic_Levant">Hisn Mansur</Name>
+      <Name language="Arabic_Maghreb">Hisn Mansur</Name>
+      <Name language="Arabic_Yemen">Hisn Mansur</Name>
+      <Name language="Armenian_Middle">Perre</Name>
+      <Name language="Greek_Medieval">Perre</Name>
+      <Name language="Hejazi_Arabic">Hisn Mansur</Name>
+      <Name language="Kurdish">Semsûr</Name>
+      <Name language="Oghuz">Hisn-i Mansur</Name>
+      <Name language="Sicilian_Arabic">Hisn Mansur</Name>
+      <Name language="Turkish_Old">Hisn-i Mansur</Name>
+      <Name language="Turkmen_Medieval">Hisn-i Mansur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -67906,14 +68656,6 @@
       <Name language="Greek_Medieval">Trapezon</Name>
       <Name language="Hejazi_Arabic">ad-Darbasak</Name>
       <Name language="Sicilian_Arabic">ad-Darbasak</Name>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>harenc</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_antiocheia" order="4">b_harenc</GameId>
-    </GameIds>
-    <Names>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68140,6 +68882,20 @@
       <GameId game="CK2HIP" parent="d_tripoli" order="1">c_tortosa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Antartus</Name>
+      <Name language="Arabic_Bedouin">Antartus</Name>
+      <Name language="Arabic_Egypt">Antartus</Name>
+      <Name language="Arabic_Levant">Antartus</Name>
+      <Name language="Arabic_Maghreb">Antartus</Name>
+      <Name language="Arabic_Yemen">Antartus</Name>
+      <Name language="Greek_Medieval">Antarados</Name>
+      <Name language="Hejazi_Arabic">Antartus</Name>
+      <Name language="Masmuda">Antartus</Name>
+      <Name language="Sanhaja">Antartus</Name>
+      <Name language="Sicilian_Arabic">Antartus</Name>
+      <Name language="Tuareg_Tagelmust">Antartus</Name>
+      <Name language="Tuareg">Antartus</Name>
+      <Name language="Zenati">Antartus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68216,6 +68972,19 @@
       <GameId game="CK2HIP" parent="c_monferrand" order="1">b_chastelrouge</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at Yahmur</Name>
+      <Name language="Arabic_Bedouin">Qal'at Yahmur</Name>
+      <Name language="Arabic_Egypt">Qal'at Yahmur</Name>
+      <Name language="Arabic_Levant">Qal'at Yahmur</Name>
+      <Name language="Arabic_Maghreb">Qal'at Yahmur</Name>
+      <Name language="Arabic_Yemen">Qal'at Yahmur</Name>
+      <Name language="Hejazi_Arabic">Qal'at Yahmur</Name>
+      <Name language="Masmuda">Qal'at Yahmur</Name>
+      <Name language="Sanhaja">Qal'at Yahmur</Name>
+      <Name language="Sicilian_Arabic">Qal'at Yahmur</Name>
+      <Name language="Tuareg_Tagelmust">Qal'at Yahmur</Name>
+      <Name language="Tuareg">Qal'at Yahmur</Name>
+      <Name language="Zenati">Qal'at Yahmur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68224,6 +68993,19 @@
       <GameId game="CK2HIP" parent="c_monferrand" order="3">b_chastelblanc</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Burj Safita</Name>
+      <Name language="Arabic_Bedouin">Burj Safita</Name>
+      <Name language="Arabic_Egypt">Burj Safita</Name>
+      <Name language="Arabic_Levant">Burj Safita</Name>
+      <Name language="Arabic_Maghreb">Burj Safita</Name>
+      <Name language="Arabic_Yemen">Burj Safita</Name>
+      <Name language="Hejazi_Arabic">Burj Safita</Name>
+      <Name language="Masmuda">Burj Safita</Name>
+      <Name language="Sanhaja">Burj Safita</Name>
+      <Name language="Sicilian_Arabic">Burj Safita</Name>
+      <Name language="Tuareg_Tagelmust">Burj Safita</Name>
+      <Name language="Tuareg">Burj Safita</Name>
+      <Name language="Zenati">Burj Safita</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68232,6 +69014,19 @@
       <GameId game="CK2HIP" parent="c_monferrand" order="4">b_krakdeschevaliers</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hisn al-Akrád</Name>
+      <Name language="Arabic_Bedouin">Hisn al-Akrád</Name>
+      <Name language="Arabic_Egypt">Hisn al-Akrád</Name>
+      <Name language="Arabic_Levant">Hisn al-Akrád</Name>
+      <Name language="Arabic_Maghreb">Hisn al-Akrád</Name>
+      <Name language="Arabic_Yemen">Hisn al-Akrád</Name>
+      <Name language="Hejazi_Arabic">Hisn al-Akrád</Name>
+      <Name language="Masmuda">Hisn al-Akrád</Name>
+      <Name language="Sanhaja">Hisn al-Akrád</Name>
+      <Name language="Sicilian_Arabic">Hisn al-Akrád</Name>
+      <Name language="Tuareg_Tagelmust">Hisn al-Akrád</Name>
+      <Name language="Tuareg">Hisn al-Akrád</Name>
+      <Name language="Zenati">Hisn al-Akrád</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -68309,14 +69104,6 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>gibeletcastle</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_gibelet" order="1">b_gibeletcastle</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>aljazira</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="e_arabia" order="8">k_aljazira</GameId>
@@ -68330,6 +69117,7 @@
       <GameId game="CK2HIP" parent="c_amida" order="1">b_kiaburc</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Kastron Amida</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72088,6 +72876,21 @@
       <GameId game="CK2HIP" parent="c_galloway" order="2">b_kirkcudbright</GameId>
     </GameIds>
     <Names>
+      <Name language="English">Kirkcubright</Name>
+      <Name language="English_Old_Norse">Kirkjucudbright</Name>
+      <Name language="Breton_Middle">Cille Chuithbeirt</Name>
+      <Name language="Cornish_Middle">Cille Chuithbeirt</Name>
+      <Name language="Cumbric">Cille Chuithbeirt</Name>
+      <Name language="Danish_Middle">Kirkjucudbright</Name>
+      <Name language="Gothic">Kirkjucudbright</Name>
+      <Name language="Icelandic_Old">Kirkjucudbright</Name>
+      <Name language="Irish_Middle">Cille Chuithbeirt</Name>
+      <Name language="Norse">Kirkjucudbright</Name>
+      <Name language="Irish_Middle_Norse">Cille Chuithbeirt</Name>
+      <Name language="Norwegian_Old">Kirkjucudbright</Name>
+      <Name language="Scottish_Gaelic">Cille Chuithbeirt</Name>
+      <Name language="Swedish_Old">Kirkjucudbright</Name>
+      <Name language="Welsh_Middle">Cille Chuithbeirt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72096,6 +72899,22 @@
       <GameId game="CK2HIP" parent="c_galloway" order="3">b_whithorn</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Taigh Mhàrtainn</Name>
+      <Name language="Cornish_Middle">Taigh Mhàrtainn</Name>
+      <Name language="Cumbric">Taigh Mhàrtainn</Name>
+      <Name language="Danish_Middle">Hvítþorn</Name>
+      <Name language="English_Old_Norse">Hvítþorn</Name>
+      <Name language="English_Old">Hwítþorn</Name>
+      <Name language="English">Whithorn</Name>
+      <Name language="Gothic">Hvítþorn</Name>
+      <Name language="Icelandic_Old">Hvítþorn</Name>
+      <Name language="Irish_Middle_Norse">Taigh Mhàrtainn</Name>
+      <Name language="Irish_Middle">Taigh Mhàrtainn</Name>
+      <Name language="Norse">Hvítþorn</Name>
+      <Name language="Norwegian_Old">Hvítþorn</Name>
+      <Name language="Scottish_Gaelic">Taigh Mhàrtainn</Name>
+      <Name language="Swedish_Old">Hvítþorn</Name>
+      <Name language="Welsh_Middle">Taigh Mhàrtainn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72104,6 +72923,14 @@
       <GameId game="CK2HIP" parent="c_galloway" order="4">b_dunragit</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Dùn Reicheit</Name>
+      <Name language="Cornish_Middle">Dùn Reicheit</Name>
+      <Name language="Cumbric">Dùn Reicheit</Name>
+      <Name language="English">Dunargit</Name>
+      <Name language="Irish_Middle_Norse">Dùn Reicheit</Name>
+      <Name language="Irish_Middle">Dùn Reicheit</Name>
+      <Name language="Scottish_Gaelic">Dùn Reicheit</Name>
+      <Name language="Welsh_Middle">Dùn Reicheit</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72112,6 +72939,14 @@
       <GameId game="CK2HIP" parent="c_galloway" order="5">b_glenluce</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Clachan Ghlinn Lus</Name>
+      <Name language="Cornish_Middle">Clachan Ghlinn Lus</Name>
+      <Name language="Cumbric">Clachan Ghlinn Lus</Name>
+      <Name language="English">Glenluce</Name>
+      <Name language="Irish_Middle_Norse">Clachan Ghlinn Lus</Name>
+      <Name language="Irish_Middle">Clachan Ghlinn Lus</Name>
+      <Name language="Scottish_Gaelic">Clachan Ghlinn Lus</Name>
+      <Name language="Welsh_Middle">Clachan Ghlinn Lus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72229,6 +73064,22 @@
       <GameId game="CK2HIP" parent="c_lothian" order="3">b_abercorn</GameId>
     </GameIds>
     <Names>
+      <Name language="Breton_Middle">Obar Chùirnidh</Name>
+      <Name language="Cornish_Middle">Obar Chùirnidh</Name>
+      <Name language="Cumbric">Obar Chùirnidh</Name>
+      <Name language="Danish_Middle">Æburcurnig</Name>
+      <Name language="English_Old_Norse">Æburcurnig</Name>
+      <Name language="English_Old">Æburcurnig</Name>
+      <Name language="English">Abercorn</Name>
+      <Name language="Gothic">Æburcurnig</Name>
+      <Name language="Icelandic_Old">Æburcurnig</Name>
+      <Name language="Irish_Middle_Norse">Obar Chùirnidh</Name>
+      <Name language="Irish_Middle">Obar Chùirnidh</Name>
+      <Name language="Norse">Æburcurnig</Name>
+      <Name language="Norwegian_Old">Æburcurnig</Name>
+      <Name language="Scottish_Gaelic">Obar Chùirnidh</Name>
+      <Name language="Swedish_Old">Æburcurnig</Name>
+      <Name language="Welsh_Middle">Obar Chùirnidh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72237,6 +73088,15 @@
       <GameId game="CK2HIP" parent="c_lothian" order="4">b_whitekirk</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Hvítrkirkju</Name>
+      <Name language="English_Old_Norse">Hvítrkirkju</Name>
+      <Name language="English_Old">Hwit Cirice</Name>
+      <Name language="English">Whitekirk</Name>
+      <Name language="Gothic">Hvítrkirkju</Name>
+      <Name language="Icelandic_Old">Hvítrkirkju</Name>
+      <Name language="Norse">Hvítrkirkju</Name>
+      <Name language="Norwegian_Old">Hvítrkirkju</Name>
+      <Name language="Swedish_Old">Hvítrkirkju</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -72245,6 +73105,8 @@
       <GameId game="CK2HIP" parent="c_lothian" order="5">b_thilerstane</GameId>
     </GameIds>
     <Names>
+      <Name language="English_Old">Thilerstan</Name>
+      <Name language="English">Thilerstane</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79315,6 +80177,19 @@
       <GameId game="CK2HIP" parent="c_granada" order="2">b_motril</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mutrayil</Name>
+      <Name language="Arabic_Bedouin">Mutrayil</Name>
+      <Name language="Arabic_Egypt">Mutrayil</Name>
+      <Name language="Arabic_Levant">Mutrayil</Name>
+      <Name language="Arabic_Maghreb">Mutrayil</Name>
+      <Name language="Arabic_Yemen">Mutrayil</Name>
+      <Name language="Hejazi_Arabic">Mutrayil</Name>
+      <Name language="Masmuda">Mutrayil</Name>
+      <Name language="Sanhaja">Mutrayil</Name>
+      <Name language="Sicilian_Arabic">Mutrayil</Name>
+      <Name language="Tuareg_Tagelmust">Mutrayil</Name>
+      <Name language="Tuareg">Mutrayil</Name>
+      <Name language="Zenati">Mutrayil</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79323,6 +80198,19 @@
       <GameId game="CK2HIP" parent="c_granada" order="3">b_baza</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Basta</Name>
+      <Name language="Arabic_Bedouin">Basta</Name>
+      <Name language="Arabic_Egypt">Basta</Name>
+      <Name language="Arabic_Levant">Basta</Name>
+      <Name language="Arabic_Maghreb">Basta</Name>
+      <Name language="Arabic_Yemen">Basta</Name>
+      <Name language="Hejazi_Arabic">Basta</Name>
+      <Name language="Masmuda">Bastsha</Name>
+      <Name language="Sanhaja">Bastsha</Name>
+      <Name language="Sicilian_Arabic">Basta</Name>
+      <Name language="Tuareg_Tagelmust">Bastsha</Name>
+      <Name language="Tuareg">Bastsha</Name>
+      <Name language="Zenati">Bastsha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79331,6 +80219,21 @@
       <GameId game="CK2HIP" parent="c_granada" order="4">b_guadix</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Wádí Ash</Name>
+      <Name language="Arabic_Bedouin">Wádí Ash</Name>
+      <Name language="Arabic_Egypt">Wádí Ash</Name>
+      <Name language="Arabic_Levant">Wádí Ash</Name>
+      <Name language="Arabic_Maghreb">Wádí Ash</Name>
+      <Name language="Arabic_Yemen">Wádí Ash</Name>
+      <Name language="Greek_Medieval">Akki</Name>
+      <Name language="Hejazi_Arabic">Wádí Ash</Name>
+      <Name language="Latin_Medieval">Acci</Name>
+      <Name language="Masmuda">Wádí Ash</Name>
+      <Name language="Sanhaja">Wádí Ash</Name>
+      <Name language="Sicilian_Arabic">Wádí Ash</Name>
+      <Name language="Tuareg_Tagelmust">Wádí Ash</Name>
+      <Name language="Tuareg">Wádí Ash</Name>
+      <Name language="Zenati">Wádí Ash</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79339,6 +80242,19 @@
       <GameId game="CK2HIP" parent="c_granada" order="5">b_alhama_granada</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Hamma</Name>
+      <Name language="Arabic_Bedouin">al-Hamma</Name>
+      <Name language="Arabic_Egypt">al-Hamma</Name>
+      <Name language="Arabic_Levant">al-Hamma</Name>
+      <Name language="Arabic_Maghreb">al-Hamma</Name>
+      <Name language="Arabic_Yemen">al-Hamma</Name>
+      <Name language="Hejazi_Arabic">al-Hamma</Name>
+      <Name language="Masmuda">al-Hamma</Name>
+      <Name language="Sanhaja">al-Hamma</Name>
+      <Name language="Sicilian_Arabic">al-Hamma</Name>
+      <Name language="Tuareg_Tagelmust">al-Hamma</Name>
+      <Name language="Tuareg">al-Hamma</Name>
+      <Name language="Zenati">al-Hamma</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79346,8 +80262,30 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_granada" order="3">c_malaga</GameId>
       <GameId game="CK2HIP" parent="c_malaga" order="1">b_malaga</GameId>
+      <GameId game="ImperatorRome">1362</GameId> <!-- Malaca -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Málaqa</Name>
+      <Name language="Arabic_Bedouin">Málaqa</Name>
+      <Name language="Arabic_Egypt">Málaqa</Name>
+      <Name language="Arabic_Levant">Málaqa</Name>
+      <Name language="Arabic_Maghreb">Málaqa</Name>
+      <Name language="Arabic_Yemen">Málaqa</Name>
+      <Name language="Basque">Malaga</Name>
+      <Name language="Catalan_Medieval">Màlaga</Name>
+      <Name language="Greek_Ancient">Malake</Name>
+      <Name language="Greek_Medieval">Malaka</Name>
+      <Name language="Hejazi_Arabic">Málaqa</Name>
+      <Name language="Latin_Medieval">Malaca</Name>
+      <Name language="Latin_Old">Malaca</Name>
+      <Name language="Masmuda">Málaqa</Name>
+      <Name language="Phoenician">Malaka</Name>
+      <Name language="Punic">Malaka</Name>
+      <Name language="Sanhaja">Málaqa</Name>
+      <Name language="Sicilian_Arabic">Málaqa</Name>
+      <Name language="Tuareg_Tagelmust">Málaqa</Name>
+      <Name language="Tuareg">Málaqa</Name>
+      <Name language="Zenati">Málaqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79356,6 +80294,19 @@
       <GameId game="CK2HIP" parent="c_malaga" order="2">b_archidona</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Urjudhúna</Name>
+      <Name language="Arabic_Bedouin">Urjudhúna</Name>
+      <Name language="Arabic_Egypt">Urjudhúna</Name>
+      <Name language="Arabic_Levant">Urjudhúna</Name>
+      <Name language="Arabic_Maghreb">Urjudhúna</Name>
+      <Name language="Arabic_Yemen">Urjudhúna</Name>
+      <Name language="Hejazi_Arabic">Urjudhúna</Name>
+      <Name language="Masmuda">Urjudhúna</Name>
+      <Name language="Sanhaja">Urjudhúna</Name>
+      <Name language="Sicilian_Arabic">Urjudhúna</Name>
+      <Name language="Tuareg_Tagelmust">Urjudhúna</Name>
+      <Name language="Tuareg">Urjudhúna</Name>
+      <Name language="Zenati">Urjudhúna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79364,6 +80315,19 @@
       <GameId game="CK2HIP" parent="c_malaga" order="3">b_bobastro</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bubashtru</Name>
+      <Name language="Arabic_Bedouin">Bubashtru</Name>
+      <Name language="Arabic_Egypt">Bubashtru</Name>
+      <Name language="Arabic_Levant">Bubashtru</Name>
+      <Name language="Arabic_Maghreb">Bubashtru</Name>
+      <Name language="Arabic_Yemen">Bubashtru</Name>
+      <Name language="Hejazi_Arabic">Bubashtru</Name>
+      <Name language="Masmuda">Bubashtru</Name>
+      <Name language="Sanhaja">Bubashtru</Name>
+      <Name language="Sicilian_Arabic">Bubashtru</Name>
+      <Name language="Tuareg_Tagelmust">Bubashtru</Name>
+      <Name language="Tuareg">Bubashtru</Name>
+      <Name language="Zenati">Bubashtru</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79389,14 +80353,48 @@
       <GameId game="CK2HIP" parent="c_malaga" order="5">b_velezmalaga</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bálish-Málaqa</Name>
+      <Name language="Arabic_Bedouin">Bálish-Málaqa</Name>
+      <Name language="Arabic_Egypt">Bálish-Málaqa</Name>
+      <Name language="Arabic_Levant">Bálish-Málaqa</Name>
+      <Name language="Arabic_Maghreb">Bálish-Málaqa</Name>
+      <Name language="Arabic_Yemen">Bálish-Málaqa</Name>
+      <Name language="Basque">Belez-Malaga</Name>
+      <Name language="Catalan_Medieval">Vélez-Màlaga</Name>
+      <Name language="Hejazi_Arabic">Bálish-Málaqa</Name>
+      <Name language="Masmuda">Bálish-Málaqa</Name>
+      <Name language="Sanhaja">Bálish-Málaqa</Name>
+      <Name language="Sicilian_Arabic">Bálish-Málaqa</Name>
+      <Name language="Tuareg_Tagelmust">Bálish-Málaqa</Name>
+      <Name language="Tuareg">Bálish-Málaqa</Name>
+      <Name language="Zenati">Bálish-Málaqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>antequera</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_malaga" order="6">b_antequera</GameId>
+      <GameId game="ImperatorRome">1388</GameId> <!-- Anticaria -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Madína Antakira</Name>
+      <Name language="Arabic_Bedouin">Madína Antakira</Name>
+      <Name language="Arabic_Egypt">Madína Antakira</Name>
+      <Name language="Arabic_Levant">Madína Antakira</Name>
+      <Name language="Arabic_Maghreb">Madína Antakira</Name>
+      <Name language="Arabic_Yemen">Madína Antakira</Name>
+      <Name language="Basque">Antekera</Name>
+      <Name language="Galician">Antequeira</Name>
+      <Name language="Greek_Medieval">Antikaria</Name>
+      <Name language="Hejazi_Arabic">Madína Antakira</Name>
+      <Name language="Latin_Medieval">Anticaria</Name>
+      <Name language="Masmuda">Madína Antakira</Name>
+      <Name language="Portuguese">Antequeira</Name>
+      <Name language="Sanhaja">Madína Antakira</Name>
+      <Name language="Sicilian_Arabic">Madína Antakira</Name>
+      <Name language="Tuareg_Tagelmust">Madína Antakira</Name>
+      <Name language="Tuareg">Madína Antakira</Name>
+      <Name language="Zenati">Madína Antakira</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79405,6 +80403,21 @@
       <GameId game="CK2HIP" parent="c_malaga" order="7">b_benalmadena</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ibn al-Ma'din</Name>
+      <Name language="Arabic_Bedouin">Ibn al-Ma'din</Name>
+      <Name language="Arabic_Egypt">Ibn al-Ma'din</Name>
+      <Name language="Arabic_Levant">Ibn al-Ma'din</Name>
+      <Name language="Arabic_Maghreb">Ibn al-Ma'din</Name>
+      <Name language="Arabic_Yemen">Ibn al-Ma'din</Name>
+      <Name language="Basque">Benalmadena</Name>
+      <Name language="Catalan_Medieval">Benalmàdena</Name>
+      <Name language="Hejazi_Arabic">Ibn al-Ma'din</Name>
+      <Name language="Masmuda">Ibn al-Ma'din</Name>
+      <Name language="Sanhaja">Ibn al-Ma'din</Name>
+      <Name language="Sicilian_Arabic">Ibn al-Ma'din</Name>
+      <Name language="Tuareg_Tagelmust">Ibn al-Ma'din</Name>
+      <Name language="Tuareg">Ibn al-Ma'din</Name>
+      <Name language="Zenati">Ibn al-Ma'din</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79413,6 +80426,20 @@
       <GameId game="CK2HIP" parent="c_cordoba" order="2">b_alcolea</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qulay'a</Name>
+      <Name language="Arabic_Bedouin">al-Qulay'a</Name>
+      <Name language="Arabic_Egypt">al-Qulay'a</Name>
+      <Name language="Arabic_Levant">al-Qulay'a</Name>
+      <Name language="Arabic_Maghreb">al-Qulay'a</Name>
+      <Name language="Arabic_Yemen">al-Qulay'a</Name>
+      <Name language="Basque">Alkolea</Name>
+      <Name language="Hejazi_Arabic">al-Qulay'a</Name>
+      <Name language="Masmuda">al-Qulay'a</Name>
+      <Name language="Sanhaja">al-Qulay'a</Name>
+      <Name language="Sicilian_Arabic">al-Qulay'a</Name>
+      <Name language="Tuareg_Tagelmust">al-Qulay'a</Name>
+      <Name language="Tuareg">al-Qulay'a</Name>
+      <Name language="Zenati">al-Qulay'a</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79421,6 +80448,21 @@
       <GameId game="CK2HIP" parent="c_cordoba" order="4">b_lucena</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Yussána</Name>
+      <Name language="Arabic_Bedouin">al-Yussána</Name>
+      <Name language="Arabic_Egypt">al-Yussána</Name>
+      <Name language="Arabic_Levant">al-Yussána</Name>
+      <Name language="Arabic_Maghreb">al-Yussána</Name>
+      <Name language="Arabic_Yemen">al-Yussána</Name>
+      <Name language="Basque">Lutzena</Name>
+      <Name language="French_Old">Lucene</Name>
+      <Name language="Hejazi_Arabic">al-Yussána</Name>
+      <Name language="Masmuda">al-Yussána</Name>
+      <Name language="Sanhaja">al-Yussána</Name>
+      <Name language="Sicilian_Arabic">al-Yussána</Name>
+      <Name language="Tuareg_Tagelmust">al-Yussána</Name>
+      <Name language="Tuareg">al-Yussána</Name>
+      <Name language="Zenati">al-Yussána</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79429,6 +80471,20 @@
       <GameId game="CK2HIP" parent="c_cordoba" order="5">b_baena</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bayyána</Name>
+      <Name language="Arabic_Bedouin">Bayyána</Name>
+      <Name language="Arabic_Egypt">Bayyána</Name>
+      <Name language="Arabic_Levant">Bayyána</Name>
+      <Name language="Arabic_Maghreb">Bayyána</Name>
+      <Name language="Arabic_Yemen">Bayyána</Name>
+      <Name language="French_Old">Baene</Name>
+      <Name language="Hejazi_Arabic">Bayyána</Name>
+      <Name language="Masmuda">Bayyána</Name>
+      <Name language="Sanhaja">Bayyána</Name>
+      <Name language="Sicilian_Arabic">Bayyána</Name>
+      <Name language="Tuareg_Tagelmust">Bayyána</Name>
+      <Name language="Tuareg">Bayyána</Name>
+      <Name language="Zenati">Bayyána</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79437,6 +80493,14 @@
       <GameId game="CK2HIP" parent="c_cordoba" order="7">b_madinat_al_zahra</GameId>
     </GameIds>
     <Names>
+      <Name language="Aragonese">Cordoba la Viella</Name>
+      <Name language="Basque">Kordoba Zaharra</Name>
+      <Name language="Castilian">Córdoba la Vieja</Name>
+      <Name language="Catalan_Medieval">Còrdova la Vella</Name>
+      <Name language="French_Old">Cordoue la Vieille</Name>
+      <Name language="Galician">Córdova a Vella</Name>
+      <Name language="Leonese">Córduba la Vieya</Name>
+      <Name language="Portuguese">Córdova a Velha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79679,6 +80743,20 @@
       <GameId game="CK2HIP" parent="c_calatrava" order="3">b_tomelloso</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tummili</Name>
+      <Name language="Arabic_Bedouin">Tummili</Name>
+      <Name language="Arabic_Egypt">Tummili</Name>
+      <Name language="Arabic_Levant">Tummili</Name>
+      <Name language="Arabic_Maghreb">Tummili</Name>
+      <Name language="Arabic_Yemen">Tummili</Name>
+      <Name language="Basque">Ezkaioa</Name>
+      <Name language="Catalan_Medieval">Tomellós</Name>
+      <Name language="French_Old">Thymose</Name>
+      <Name language="Galician">Tomiñoso</Name>
+      <Name language="Hejazi_Arabic">Tummili</Name>
+      <Name language="Leonese">Tomellosu</Name>
+      <Name language="Portuguese">Tomilhoso</Name>
+      <Name language="Sicilian_Arabic">Tummili</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79687,6 +80765,22 @@
       <GameId game="CK2HIP" parent="c_calatrava" order="4">b_puertollano</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Burtu al-Muz</Name>
+      <Name language="Arabic_Bedouin">Burtu al-Muz</Name>
+      <Name language="Arabic_Egypt">Burtu al-Muz</Name>
+      <Name language="Arabic_Levant">Burtu al-Muz</Name>
+      <Name language="Arabic_Maghreb">Burtu al-Muz</Name>
+      <Name language="Arabic_Yemen">Burtu al-Muz</Name>
+      <Name language="Aragonese">Puertoplano</Name>
+      <Name language="Basque">Ordokiportu</Name>
+      <Name language="Castilian">Puerto de Muelas</Name>
+      <Name language="Catalan_Medieval">Portplá</Name>
+      <Name language="French_Old">Portplaine</Name>
+      <Name language="Galician">Portoxano</Name>
+      <Name language="Hejazi_Arabic">Burtu al-Muz</Name>
+      <Name language="Leonese">Puertuchanu</Name>
+      <Name language="Portuguese">Portochano</Name>
+      <Name language="Sicilian_Arabic">Burtu al-Muz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79695,6 +80789,17 @@
       <GameId game="CK2HIP" parent="c_calatrava" order="5">b_almagro</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Magrib</Name>
+      <Name language="Arabic_Bedouin">al-Magrib</Name>
+      <Name language="Arabic_Egypt">al-Magrib</Name>
+      <Name language="Arabic_Levant">al-Magrib</Name>
+      <Name language="Arabic_Maghreb">al-Magrib</Name>
+      <Name language="Arabic_Yemen">al-Magrib</Name>
+      <Name language="Catalan_Medieval">Almagre</Name>
+      <Name language="French_Old">Almagre</Name>
+      <Name language="Hejazi_Arabic">al-Magrib</Name>
+      <Name language="Leonese">Almagru</Name>
+      <Name language="Sicilian_Arabic">al-Magrib</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79703,6 +80808,21 @@
       <GameId game="CK2HIP" parent="c_calatrava" order="6">b_alcazardesanjuan</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qasr Baní 'Atiyya</Name>
+      <Name language="Arabic_Bedouin">Qasr Baní 'Atiyya</Name>
+      <Name language="Arabic_Egypt">Qasr Baní 'Atiyya</Name>
+      <Name language="Arabic_Levant">Qasr Baní 'Atiyya</Name>
+      <Name language="Arabic_Maghreb">Qasr Baní 'Atiyya</Name>
+      <Name language="Arabic_Yemen">Qasr Baní 'Atiyya</Name>
+      <Name language="Aragonese">Alcázar de Sant Chuan</Name>
+      <Name language="Basque">Gaztelua Sant Jon</Name>
+      <Name language="Catalan_Medieval">Alcàsser de Sant Joan</Name>
+      <Name language="French_Old">Château de Saint Jean</Name>
+      <Name language="Galician">Alcácer de San Xoán</Name>
+      <Name language="Hejazi_Arabic">Qasr Baní 'Atiyya</Name>
+      <Name language="Leonese">Alcázar de San Xuan</Name>
+      <Name language="Portuguese">Alcácer de São João</Name>
+      <Name language="Sicilian_Arabic">Qasr Baní 'Atiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79711,6 +80831,18 @@
       <GameId game="CK2HIP" parent="c_murcia" order="3">b_lorca</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Lúrqa</Name>
+      <Name language="Arabic_Bedouin">Lúrqa</Name>
+      <Name language="Arabic_Egypt">Lúrqa</Name>
+      <Name language="Arabic_Levant">Lúrqa</Name>
+      <Name language="Arabic_Maghreb">Lúrqa</Name>
+      <Name language="Arabic_Yemen">Lúrqa</Name>
+      <Name language="Basque">Lorka</Name>
+      <Name language="Catalan_Medieval">Llorca</Name>
+      <Name language="French_Old">Lorque</Name>
+      <Name language="Hejazi_Arabic">Lúrqa</Name>
+      <Name language="Leonese">Llorca</Name>
+      <Name language="Sicilian_Arabic">Lúrqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79719,6 +80851,18 @@
       <GameId game="CK2HIP" parent="c_murcia" order="4">b_orihuela</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Uryúla</Name>
+      <Name language="Arabic_Bedouin">Uryúla</Name>
+      <Name language="Arabic_Egypt">Uryúla</Name>
+      <Name language="Arabic_Levant">Uryúla</Name>
+      <Name language="Arabic_Maghreb">Uryúla</Name>
+      <Name language="Arabic_Yemen">Uryúla</Name>
+      <Name language="Aragonese">Oriuela</Name>
+      <Name language="Catalan_Medieval">Oriola</Name>
+      <Name language="French_Old">Oriole</Name>
+      <Name language="Hejazi_Arabic">Uryúla</Name>
+      <Name language="Latin_Medieval">Orecelis</Name>
+      <Name language="Sicilian_Arabic">Uryúla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79768,6 +80912,7 @@
     <Id>villena</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_almansa" order="7">b_villena</GameId>
+      <GameId game="CK2HIP" parent="d_murcia" order="2">c_almansa</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Bilyana</Name>
@@ -79852,6 +80997,18 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="1">b_alcudia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Kudia</Name>
+      <Name language="Arabic_Bedouin">al-Kudia</Name>
+      <Name language="Arabic_Egypt">al-Kudia</Name>
+      <Name language="Arabic_Levant">al-Kudia</Name>
+      <Name language="Arabic_Maghreb">al-Kudia</Name>
+      <Name language="Arabic_Yemen">al-Kudia</Name>
+      <Name language="Basque">Alkudia</Name>
+      <Name language="Catalan_Medieval">Alcúdia</Name>
+      <Name language="Greek_Medieval">Pollentia</Name>
+      <Name language="Hejazi_Arabic">al-Kudia</Name>
+      <Name language="Latin_Medieval">Pollentia</Name>
+      <Name language="Sicilian_Arabic">al-Kudia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79860,6 +81017,14 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="2">b_palma</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Madínat Mayúrqa</Name>
+      <Name language="Arabic_Bedouin">Madínat Mayúrqa</Name>
+      <Name language="Arabic_Egypt">Madínat Mayúrqa</Name>
+      <Name language="Arabic_Levant">Madínat Mayúrqa</Name>
+      <Name language="Arabic_Maghreb">Madínat Mayúrqa</Name>
+      <Name language="Arabic_Yemen">Madínat Mayúrqa</Name>
+      <Name language="Hejazi_Arabic">Madínat Mayúrqa</Name>
+      <Name language="Sicilian_Arabic">Madínat Mayúrqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79868,6 +81033,17 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="3">b_eivissa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Yábisa</Name>
+      <Name language="Arabic_Bedouin">Yábisa</Name>
+      <Name language="Arabic_Egypt">Yábisa</Name>
+      <Name language="Arabic_Levant">Yábisa</Name>
+      <Name language="Arabic_Maghreb">Yábisa</Name>
+      <Name language="Arabic_Yemen">Yábisa</Name>
+      <Name language="Catalan_Medieval">Eivissa</Name>
+      <Name language="French_Old">Ibice</Name>
+      <Name language="Hejazi_Arabic">Yábisa</Name>
+      <Name language="Portuguese">Ibiça</Name>
+      <Name language="Sicilian_Arabic">Yábisa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79876,6 +81052,15 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="4">b_algaida</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Gaydah</Name>
+      <Name language="Arabic_Bedouin">al-Gaydah</Name>
+      <Name language="Arabic_Egypt">al-Gaydah</Name>
+      <Name language="Arabic_Levant">al-Gaydah</Name>
+      <Name language="Arabic_Maghreb">al-Gaydah</Name>
+      <Name language="Arabic_Yemen">al-Gaydah</Name>
+      <Name language="French_Old">Algaïde</Name>
+      <Name language="Hejazi_Arabic">al-Gaydah</Name>
+      <Name language="Sicilian_Arabic">al-Gaydah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79884,6 +81069,14 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="6">b_felanitx</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Filanish</Name>
+      <Name language="Arabic_Bedouin">Filanish</Name>
+      <Name language="Arabic_Egypt">Filanish</Name>
+      <Name language="Arabic_Levant">Filanish</Name>
+      <Name language="Arabic_Maghreb">Filanish</Name>
+      <Name language="Arabic_Yemen">Filanish</Name>
+      <Name language="Hejazi_Arabic">Filanish</Name>
+      <Name language="Sicilian_Arabic">Filanish</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79892,6 +81085,15 @@
       <GameId game="CK2HIP" parent="c_mallorca" order="7">b_manacor</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Manaqur</Name>
+      <Name language="Arabic_Bedouin">Manaqur</Name>
+      <Name language="Arabic_Egypt">Manaqur</Name>
+      <Name language="Arabic_Levant">Manaqur</Name>
+      <Name language="Arabic_Maghreb">Manaqur</Name>
+      <Name language="Arabic_Yemen">Manaqur</Name>
+      <Name language="Basque">Manakor</Name>
+      <Name language="Hejazi_Arabic">Manaqur</Name>
+      <Name language="Sicilian_Arabic">Manaqur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -79900,6 +81102,17 @@
       <GameId game="CK2HIP" parent="d_mallorca" order="2">c_menorca</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Minúrqa</Name>
+      <Name language="Arabic_Bedouin">Minúrqa</Name>
+      <Name language="Arabic_Egypt">Minúrqa</Name>
+      <Name language="Arabic_Levant">Minúrqa</Name>
+      <Name language="Arabic_Maghreb">Minúrqa</Name>
+      <Name language="Arabic_Yemen">Minúrqa</Name>
+      <Name language="Basque">Menorka</Name>
+      <Name language="French_Old">Minorque</Name>
+      <Name language="Hejazi_Arabic">Minúrqa</Name>
+      <Name language="Portuguese">Minorca</Name>
+      <Name language="Sicilian_Arabic">Minúrqa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80131,22 +81344,41 @@
       <GameId game="CK2HIP" parent="c_lugo" order="6">b_ocebreiro</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sibrir</Name>
+      <Name language="Arabic_Bedouin">Sibrir</Name>
+      <Name language="Arabic_Egypt">Sibrir</Name>
+      <Name language="Arabic_Levant">Sibrir</Name>
+      <Name language="Arabic_Maghreb">Sibrir</Name>
+      <Name language="Arabic_Yemen">Sibrir</Name>
+      <Name language="Aragonese">O Cebrero</Name>
+      <Name language="Basque">Zebreroa</Name>
+      <Name language="Castilian">El Cebrero</Name>
+      <Name language="Catalan_Medieval">El Cebrer</Name>
+      <Name language="French_Old">Le Cebrer</Name>
+      <Name language="Hejazi_Arabic">Sibrir</Name>
+      <Name language="Leonese">El Cebreru</Name>
+      <Name language="Sicilian_Arabic">Sibrir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>lemos</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="c_lemos" order="1">b_monforte_de_lemos</GameId>
       <GameId game="CK2HIP" parent="d_galicia" order="4">c_lemos</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>monforte_de_lemos</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="c_lemos" order="1">b_monforte_de_lemos</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Arabic_Andalusia">Lyimus</Name>
+      <Name language="Arabic_Bedouin">Lyimus</Name>
+      <Name language="Arabic_Egypt">Lyimus</Name>
+      <Name language="Arabic_Levant">Lyimus</Name>
+      <Name language="Arabic_Maghreb">Lyimus</Name>
+      <Name language="Arabic_Yemen">Lyimus</Name>
+      <Name language="Aragonese">Lemos</Name>
+      <Name language="Basque">Lemos</Name>
+      <Name language="Catalan_Medieval">Lemos</Name>
+      <Name language="French_Old">Lemos</Name>
+      <Name language="Hejazi_Arabic">Lyimus</Name>
+      <Name language="Sicilian_Arabic">Lyimus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80155,6 +81387,15 @@
       <GameId game="CK2HIP" parent="c_lemos" order="3">b_ribadavia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ribbadabiyya</Name>
+      <Name language="Arabic_Bedouin">Ribbadabiyya</Name>
+      <Name language="Arabic_Egypt">Ribbadabiyya</Name>
+      <Name language="Arabic_Levant">Ribbadabiyya</Name>
+      <Name language="Arabic_Maghreb">Ribbadabiyya</Name>
+      <Name language="Arabic_Yemen">Ribbadabiyya</Name>
+      <Name language="Basque">Ribadabia</Name>
+      <Name language="Hejazi_Arabic">Ribbadabiyya</Name>
+      <Name language="Sicilian_Arabic">Ribbadabiyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80163,6 +81404,15 @@
       <GameId game="CK2HIP" parent="c_lemos" order="4">b_allariz</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Arid</Name>
+      <Name language="Arabic_Bedouin">al-Arid</Name>
+      <Name language="Arabic_Egypt">al-Arid</Name>
+      <Name language="Arabic_Levant">al-Arid</Name>
+      <Name language="Arabic_Maghreb">al-Arid</Name>
+      <Name language="Arabic_Yemen">al-Arid</Name>
+      <Name language="Hejazi_Arabic">al-Arid</Name>
+      <Name language="Portuguese">Alhariz</Name>
+      <Name language="Sicilian_Arabic">al-Arid</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80235,6 +81485,16 @@
       <GameId game="CK2HIP" parent="c_castelo_branco" order="3">b_belmonte</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Balmunt</Name>
+      <Name language="Arabic_Bedouin">Balmunt</Name>
+      <Name language="Arabic_Egypt">Balmunt</Name>
+      <Name language="Arabic_Levant">Balmunt</Name>
+      <Name language="Arabic_Maghreb">Balmunt</Name>
+      <Name language="Arabic_Yemen">Balmunt</Name>
+      <Name language="Basque">Ederramendi</Name>
+      <Name language="French_Old">Belmont</Name>
+      <Name language="Hejazi_Arabic">Balmunt</Name>
+      <Name language="Sicilian_Arabic">Balmunt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80243,6 +81503,20 @@
       <GameId game="CK2HIP" parent="c_castelo_branco" order="4">b_oleiros</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Ulir</Name>
+      <Name language="Arabic_Bedouin">Ulir</Name>
+      <Name language="Arabic_Egypt">Ulir</Name>
+      <Name language="Arabic_Levant">Ulir</Name>
+      <Name language="Arabic_Maghreb">Ulir</Name>
+      <Name language="Arabic_Yemen">Ulir</Name>
+      <Name language="Aragonese">Olers</Name>
+      <Name language="Basque">Oleros</Name>
+      <Name language="Castilian">Oleros</Name>
+      <Name language="Catalan_Medieval">Olers</Name>
+      <Name language="French_Old">Oliers</Name>
+      <Name language="Hejazi_Arabic">Ulir</Name>
+      <Name language="Leonese">Oleros</Name>
+      <Name language="Sicilian_Arabic">Ulir</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80251,6 +81525,21 @@
       <GameId game="CK2HIP" parent="c_castelo_branco" order="5">b_idanha_a_nova</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Antaniya</Name>
+      <Name language="Arabic_Bedouin">al-Antaniya</Name>
+      <Name language="Arabic_Egypt">al-Antaniya</Name>
+      <Name language="Arabic_Levant">al-Antaniya</Name>
+      <Name language="Arabic_Maghreb">al-Antaniya</Name>
+      <Name language="Arabic_Yemen">al-Antaniya</Name>
+      <Name language="Aragonese">Idanya a Nova</Name>
+      <Name language="Basque">Idaña Berria</Name>
+      <Name language="Castilian">Idaña la Nueva</Name>
+      <Name language="Catalan_Medieval">Idanya la Nova</Name>
+      <Name language="French_Old">Nouvelle Idagne</Name>
+      <Name language="Galician">Idaña a Nova</Name>
+      <Name language="Hejazi_Arabic">al-Antaniya</Name>
+      <Name language="Leonese">Idaña la Nueva</Name>
+      <Name language="Sicilian_Arabic">al-Antaniya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80259,6 +81548,18 @@
       <GameId game="CK2HIP" parent="c_castelo_branco" order="6">b_penamacor</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sajra al-Maqqur</Name>
+      <Name language="Arabic_Bedouin">Sajra al-Maqqur</Name>
+      <Name language="Arabic_Egypt">Sajra al-Maqqur</Name>
+      <Name language="Arabic_Levant">Sajra al-Maqqur</Name>
+      <Name language="Arabic_Maghreb">Sajra al-Maqqur</Name>
+      <Name language="Arabic_Yemen">Sajra al-Maqqur</Name>
+      <Name language="Aragonese">Penyamacor</Name>
+      <Name language="Basque">Peñamakor</Name>
+      <Name language="Catalan_Medieval">Penyamacor</Name>
+      <Name language="French_Old">Rochemacor</Name>
+      <Name language="Hejazi_Arabic">Sajra al-Maqqur</Name>
+      <Name language="Sicilian_Arabic">Sajra al-Maqqur</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80267,6 +81568,21 @@
       <GameId game="CK2HIP" parent="c_castelo_branco" order="7">b_proenca_a_nova</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Burinsa</Name>
+      <Name language="Arabic_Bedouin">Burinsa</Name>
+      <Name language="Arabic_Egypt">Burinsa</Name>
+      <Name language="Arabic_Levant">Burinsa</Name>
+      <Name language="Arabic_Maghreb">Burinsa</Name>
+      <Name language="Arabic_Yemen">Burinsa</Name>
+      <Name language="Aragonese">Proença a Nova</Name>
+      <Name language="Basque">Proentza Berria</Name>
+      <Name language="Castilian">Proenza la Nueva</Name>
+      <Name language="Catalan_Medieval">Proença la Nova</Name>
+      <Name language="French_Old">Nouvelle Proence</Name>
+      <Name language="Galician">Proenza a Nova</Name>
+      <Name language="Hejazi_Arabic">Burinsa</Name>
+      <Name language="Leonese">Proenza la Nueva</Name>
+      <Name language="Sicilian_Arabic">Burinsa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80681,6 +81997,17 @@
       <GameId game="CK2HIP" parent="c_viseu" order="1">b_aveiro</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Awar</Name>
+      <Name language="Arabic_Bedouin">al-Awar</Name>
+      <Name language="Arabic_Egypt">al-Awar</Name>
+      <Name language="Arabic_Levant">al-Awar</Name>
+      <Name language="Arabic_Maghreb">al-Awar</Name>
+      <Name language="Arabic_Yemen">al-Awar</Name>
+      <Name language="Basque">Abeiro</Name>
+      <Name language="French_Old">Aveire</Name>
+      <Name language="Hejazi_Arabic">al-Awar</Name>
+      <Name language="Leonese">Aveiru</Name>
+      <Name language="Sicilian_Arabic">al-Awar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80965,6 +82292,14 @@
       <GameId game="CK2HIP" parent="c_castellon" order="3">b_segorbe</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Shaqurb</Name>
+      <Name language="Arabic_Bedouin">Shaqurb</Name>
+      <Name language="Arabic_Egypt">Shaqurb</Name>
+      <Name language="Arabic_Levant">Shaqurb</Name>
+      <Name language="Arabic_Maghreb">Shaqurb</Name>
+      <Name language="Arabic_Yemen">Shaqurb</Name>
+      <Name language="Hejazi_Arabic">Shaqurb</Name>
+      <Name language="Sicilian_Arabic">Shaqurb</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80973,6 +82308,14 @@
       <GameId game="CK2HIP" parent="c_castellon" order="4">b_nules</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Nulish</Name>
+      <Name language="Arabic_Bedouin">Nulish</Name>
+      <Name language="Arabic_Egypt">Nulish</Name>
+      <Name language="Arabic_Levant">Nulish</Name>
+      <Name language="Arabic_Maghreb">Nulish</Name>
+      <Name language="Arabic_Yemen">Nulish</Name>
+      <Name language="Hejazi_Arabic">Nulish</Name>
+      <Name language="Sicilian_Arabic">Nulish</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80981,6 +82324,17 @@
       <GameId game="CK2HIP" parent="c_castellon" order="5">b_vinaros</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Beni al-Arus</Name>
+      <Name language="Arabic_Bedouin">Beni al-Arus</Name>
+      <Name language="Arabic_Egypt">Beni al-Arus</Name>
+      <Name language="Arabic_Levant">Beni al-Arus</Name>
+      <Name language="Arabic_Maghreb">Beni al-Arus</Name>
+      <Name language="Arabic_Yemen">Beni al-Arus</Name>
+      <Name language="Basque">Binaroz</Name>
+      <Name language="Catalan_Medieval">Vinaròs</Name>
+      <Name language="Hejazi_Arabic">Beni al-Arus</Name>
+      <Name language="Portuguese">Vinaroce</Name>
+      <Name language="Sicilian_Arabic">Beni al-Arus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80989,6 +82343,16 @@
       <GameId game="CK2HIP" parent="c_castellon" order="6">b_morella</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Muril'la</Name>
+      <Name language="Arabic_Bedouin">Muril'la</Name>
+      <Name language="Arabic_Egypt">Muril'la</Name>
+      <Name language="Arabic_Levant">Muril'la</Name>
+      <Name language="Arabic_Maghreb">Muril'la</Name>
+      <Name language="Arabic_Yemen">Muril'la</Name>
+      <Name language="French_Old">Moreille</Name>
+      <Name language="Hejazi_Arabic">Muril'la</Name>
+      <Name language="Portuguese">Morelha</Name>
+      <Name language="Sicilian_Arabic">Muril'la</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -80997,6 +82361,18 @@
       <GameId game="CK2HIP" parent="c_castellon" order="7">b_vilarreal</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qariya al-Malik</Name>
+      <Name language="Arabic_Bedouin">al-Qariya al-Malik</Name>
+      <Name language="Arabic_Egypt">al-Qariya al-Malik</Name>
+      <Name language="Arabic_Levant">al-Qariya al-Malik</Name>
+      <Name language="Arabic_Maghreb">al-Qariya al-Malik</Name>
+      <Name language="Arabic_Yemen">al-Qariya al-Malik</Name>
+      <Name language="Aragonese">Vila-reyal</Name>
+      <Name language="Basque">Erregeko-Herri</Name>
+      <Name language="Catalan_Medieval">Vila-real</Name>
+      <Name language="French_Old">Ville-royale</Name>
+      <Name language="Hejazi_Arabic">al-Qariya al-Malik</Name>
+      <Name language="Sicilian_Arabic">al-Qariya al-Malik</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81243,6 +82619,18 @@
       <GameId game="CK2HIP" parent="c_leon" order="4">b_luna</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Lunnah</Name>
+      <Name language="Arabic_Bedouin">Lunnah</Name>
+      <Name language="Arabic_Egypt">Lunnah</Name>
+      <Name language="Arabic_Levant">Lunnah</Name>
+      <Name language="Arabic_Maghreb">Lunnah</Name>
+      <Name language="Arabic_Yemen">Lunnah</Name>
+      <Name language="French_Old">Lune</Name>
+      <Name language="Galician">Lúa</Name>
+      <Name language="Hejazi_Arabic">Lunnah</Name>
+      <Name language="Leonese">Tsuna</Name>
+      <Name language="Portuguese">Lua</Name>
+      <Name language="Sicilian_Arabic">Lunnah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81251,6 +82639,19 @@
       <GameId game="CK2HIP" parent="c_leon" order="5">b_coyanza</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Quyansha</Name>
+      <Name language="Arabic_Bedouin">Quyansha</Name>
+      <Name language="Arabic_Egypt">Quyansha</Name>
+      <Name language="Arabic_Levant">Quyansha</Name>
+      <Name language="Arabic_Maghreb">Quyansha</Name>
+      <Name language="Arabic_Yemen">Quyansha</Name>
+      <Name language="Basque">Koiantza</Name>
+      <Name language="Catalan_Medieval">Coyança</Name>
+      <Name language="French_Old">Coyance</Name>
+      <Name language="Hejazi_Arabic">Quyansha</Name>
+      <Name language="Leonese">Coyança</Name>
+      <Name language="Portuguese">Coyança</Name>
+      <Name language="Sicilian_Arabic">Quyansha</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81259,6 +82660,20 @@
       <GameId game="CK2HIP" parent="c_leon" order="6">b_puentedeorbigo</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Qantarat al-Urbyqq</Name>
+      <Name language="Arabic_Bedouin">al-Qantarat al-Urbyqq</Name>
+      <Name language="Arabic_Egypt">al-Qantarat al-Urbyqq</Name>
+      <Name language="Arabic_Levant">al-Qantarat al-Urbyqq</Name>
+      <Name language="Arabic_Maghreb">al-Qantarat al-Urbyqq</Name>
+      <Name language="Arabic_Yemen">al-Qantarat al-Urbyqq</Name>
+      <Name language="Basque">Orbigozubia</Name>
+      <Name language="Catalan_Medieval">Pont d'Òrbig</Name>
+      <Name language="French_Old">Pont d'Orbigue</Name>
+      <Name language="Galician">Ponte do Órbigo</Name>
+      <Name language="Hejazi_Arabic">al-Qantarat al-Urbyqq</Name>
+      <Name language="Leonese">Puente d'Órbigu</Name>
+      <Name language="Portuguese">Ponte do Órbigo</Name>
+      <Name language="Sicilian_Arabic">al-Qantarat al-Urbyqq</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81267,6 +82682,16 @@
       <GameId game="CK2HIP" parent="c_leon" order="7">b_cistierna</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sishtirniyya</Name>
+      <Name language="Arabic_Bedouin">Sishtirniyya</Name>
+      <Name language="Arabic_Egypt">Sishtirniyya</Name>
+      <Name language="Arabic_Levant">Sishtirniyya</Name>
+      <Name language="Arabic_Maghreb">Sishtirniyya</Name>
+      <Name language="Arabic_Yemen">Sishtirniyya</Name>
+      <Name language="Basque">Zisterna</Name>
+      <Name language="French_Old">Cisterne</Name>
+      <Name language="Hejazi_Arabic">Sishtirniyya</Name>
+      <Name language="Sicilian_Arabic">Sishtirniyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81296,6 +82721,17 @@
       <GameId game="CK2HIP" parent="c_zamora" order="2">b_tabara</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Tabbara</Name>
+      <Name language="Arabic_Bedouin">Tabbara</Name>
+      <Name language="Arabic_Egypt">Tabbara</Name>
+      <Name language="Arabic_Levant">Tabbara</Name>
+      <Name language="Arabic_Maghreb">Tabbara</Name>
+      <Name language="Arabic_Yemen">Tabbara</Name>
+      <Name language="Basque">Tabara</Name>
+      <Name language="Catalan_Medieval">Tàbara</Name>
+      <Name language="French_Old">Tabare</Name>
+      <Name language="Hejazi_Arabic">Tabbara</Name>
+      <Name language="Sicilian_Arabic">Tabbara</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -81304,6 +82740,19 @@
       <GameId game="CK2HIP" parent="c_zamora" order="2">b_sanabria</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Sennabrah</Name>
+      <Name language="Arabic_Bedouin">Sennabrah</Name>
+      <Name language="Arabic_Egypt">Sennabrah</Name>
+      <Name language="Arabic_Levant">Sennabrah</Name>
+      <Name language="Arabic_Maghreb">Sennabrah</Name>
+      <Name language="Arabic_Yemen">Sennabrah</Name>
+      <Name language="Catalan_Medieval">Sanàbria</Name>
+      <Name language="French_Old">Sanabrie</Name>
+      <Name language="Galician">Seabra</Name>
+      <Name language="Hejazi_Arabic">Sennabrah</Name>
+      <Name language="Leonese">Senabria</Name>
+      <Name language="Portuguese">Seabra</Name>
+      <Name language="Sicilian_Arabic">Sennabrah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82157,8 +83606,22 @@
     <Id>membressa</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tunis" order="3">b_membressa</GameId>
+      <GameId game="ImperatorRome">3251</GameId> <!-- Membressa -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Majaz al-Bab</Name>
+      <Name language="Arabic_Bedouin">Majaz al-Bab</Name>
+      <Name language="Arabic_Egypt">Majaz al-Bab</Name>
+      <Name language="Arabic_Levant">Majaz al-Bab</Name>
+      <Name language="Arabic_Maghreb">Majaz al-Bab</Name>
+      <Name language="Arabic_Yemen">Majaz al-Bab</Name>
+      <Name language="Hejazi_Arabic">Majaz al-Bab</Name>
+      <Name language="Masmuda">Mjezz Lbab</Name>
+      <Name language="Sanhaja">Mjezz Lbab</Name>
+      <Name language="Sicilian_Arabic">Majaz al-Bab</Name>
+      <Name language="Tuareg_Tagelmust">Mjezz Lbab</Name>
+      <Name language="Tuareg">Mjezz Lbab</Name>
+      <Name language="Zenati">Mjezz Lbab</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82167,22 +83630,59 @@
       <GameId game="CK2HIP" parent="c_tunis" order="4">b_kelibia</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Iqlíbiya</Name>
+      <Name language="Arabic_Bedouin">Iqlíbiya</Name>
+      <Name language="Arabic_Egypt">Iqlíbiya</Name>
+      <Name language="Arabic_Levant">Iqlíbiya</Name>
+      <Name language="Arabic_Maghreb">Iqlíbiya</Name>
+      <Name language="Arabic_Yemen">Iqlíbiya</Name>
+      <Name language="Greek_Medieval">Clypia</Name>
+      <Name language="Hejazi_Arabic">Iqlíbiya</Name>
+      <Name language="Latin_Medieval">Clypia</Name>
+      <Name language="Sicilian_Arabic">Iqlíbiya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>cartaghe</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tunis" order="7">b_cartaghe</GameId>
+      <GameId game="ImperatorRome">3256</GameId> <!-- Carthago -->
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qartájanna</Name>
+      <Name language="Arabic_Bedouin">Qartájanna</Name>
+      <Name language="Arabic_Egypt">Qartájanna</Name>
+      <Name language="Arabic_Levant">Qartájanna</Name>
+      <Name language="Arabic_Maghreb">Qartájanna</Name>
+      <Name language="Arabic_Yemen">Qartájanna</Name>
+      <Name language="Greek_Ancient">Karkhedon</Name>
+      <Name language="Greek_Medieval">Karchedon</Name>
+      <Name language="Hejazi_Arabic">Qartájanna</Name>
+      <Name language="Latin_Medieval">Carthago</Name>
+      <Name language="Latin_Old">Carthago</Name>
+      <Name language="Masmuda">Kartajen</Name>
+      <Name language="Phoenician">Qart Hadasht</Name>
+      <Name language="Punic">Carthage</Name>
+      <Name language="Sanhaja">Kartajen</Name>
+      <Name language="Sicilian_Arabic">Qartájanna</Name>
+      <Name language="Tuareg_Tagelmust">Kartajen</Name>
+      <Name language="Tuareg">Kartajen</Name>
+      <Name language="Zenati">Kartajen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>mahdia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_medjerda" order="1">b_mahdia</GameId>
+      <GameId game="ImperatorRome">3278</GameId> <!-- Thapsus -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Thapsos</Name>
+      <Name language="Greek_Medieval">Thapsos</Name>
+      <Name language="Latin_Medieval">Thapsus</Name>
+      <Name language="Latin_Old">Thapsus</Name>
+      <Name language="Phoenician">Tapsa</Name>
+      <Name language="Punic">Tapsa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82191,6 +83691,8 @@
       <GameId game="CK2HIP" parent="c_medjerda" order="2">b_salakta</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Sullecthum</Name>
+      <Name language="Latin_Medieval">Sullecthum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82199,6 +83701,16 @@
       <GameId game="CK2HIP" parent="c_bizerte" order="2">b_tunbeja</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Bájat al-Qamh</Name>
+      <Name language="Arabic_Bedouin">Bájat al-Qamh</Name>
+      <Name language="Arabic_Egypt">Bájat al-Qamh</Name>
+      <Name language="Arabic_Levant">Bájat al-Qamh</Name>
+      <Name language="Arabic_Maghreb">Bájat al-Qamh</Name>
+      <Name language="Arabic_Yemen">Bájat al-Qamh</Name>
+      <Name language="Greek_Medieval">Ouaga</Name>
+      <Name language="Hejazi_Arabic">Bájat al-Qamh</Name>
+      <Name language="Latin_Medieval">Vaga</Name>
+      <Name language="Sicilian_Arabic">Bájat al-Qamh</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82207,6 +83719,13 @@
       <GameId game="CK2HIP" parent="c_bizerte" order="3">b_tabarqa</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thabraka</Name>
+      <Name language="Latin_Medieval">Thabraca</Name>
+      <Name language="Masmuda">Tabarka</Name>
+      <Name language="Sanhaja">Tabarka</Name>
+      <Name language="Tuareg_Tagelmust">Tabarka</Name>
+      <Name language="Tuareg">Tabarka</Name>
+      <Name language="Zenati">Tabarka</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82215,22 +83734,30 @@
       <GameId game="CK2HIP" parent="c_kairwan" order="1">b_rakkada</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Iubaltiana</Name>
+      <Name language="Latin_Medieval">Iubaltiana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sabiba</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_kairwan" order="4">b_sabiba</GameId>
+      <GameId game="ImperatorRome">3210</GameId> <!-- Sufes -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Sufes</Name>
+      <Name language="Latin_Medieval">Sufes</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sabra</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_kairwan" order="5">b_sabra</GameId>
+      <GameId game="ImperatorRome">3212</GameId> <!-- Aquae Regiae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Aquae Regiae</Name>
+      <Name language="Latin_Medieval">Aquae Regiae</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82239,6 +83766,8 @@
       <GameId game="CK2HIP" parent="c_sfax" order="2">b_chebba</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Caput Vada</Name>
+      <Name language="Latin_Medieval">Caput Vada</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82247,6 +83776,19 @@
       <GameId game="CK2HIP" parent="c_sfax" order="3">b_kerkennah</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qarqana</Name>
+      <Name language="Arabic_Bedouin">Qarqana</Name>
+      <Name language="Arabic_Egypt">Qarqana</Name>
+      <Name language="Arabic_Levant">Qarqana</Name>
+      <Name language="Arabic_Maghreb">Qarqana</Name>
+      <Name language="Arabic_Yemen">Qarqana</Name>
+      <Name language="Hejazi_Arabic">Qarqana</Name>
+      <Name language="Masmuda">Qarqana</Name>
+      <Name language="Sanhaja">Qarqana</Name>
+      <Name language="Sicilian_Arabic">Qarqana</Name>
+      <Name language="Tuareg_Tagelmust">Qarqana</Name>
+      <Name language="Tuareg">Qarqana</Name>
+      <Name language="Zenati">Qarqana</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82261,16 +83803,22 @@
     <Id>haddej</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_gabes" order="1">b_haddej</GameId>
+      <GameId game="ImperatorRome">3292</GameId> <!-- Bezereos -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Bezereos</Name>
+      <Name language="Latin_Medieval">Bezereos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>alhamma</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_gabes" order="3">b_alhamma</GameId>
+      <GameId game="ImperatorRome">3285</GameId> <!-- Thaenae -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thaenae</Name>
+      <Name language="Latin_Medieval">Thaenae</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82280,6 +83828,8 @@
       <GameId game="CK2HIP" parent="c_djerba" order="1">b_djerba</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Girba</Name>
+      <Name language="Latin_Medieval">Girba</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82288,6 +83838,8 @@
       <GameId game="CK2HIP" parent="c_nafzawa" order="3">b_alqalah</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Ad Templum</Name>
+      <Name language="Latin_Medieval">Ad Templum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82312,6 +83864,8 @@
       <GameId game="CK2HIP" parent="c_qashtiliya" order="1">b_qafsa</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Capsa</Name>
+      <Name language="Latin_Medieval">Capsa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82320,6 +83874,8 @@
       <GameId game="CK2HIP" parent="c_qashtiliya" order="3">b_alhamma_qashtiliya</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Aquae</Name>
+      <Name language="Latin_Medieval">Aquae</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82328,22 +83884,30 @@
       <GameId game="CK2HIP" parent="c_qashtiliya" order="4">b_nafta</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Nepte</Name>
+      <Name language="Latin_Medieval">Nepte</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>takyus</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_qashtiliya" order="5">b_takyus</GameId>
+      <GameId game="ImperatorRome">3190</GameId> <!-- Thiges -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thiges</Name>
+      <Name language="Latin_Medieval">Thiges</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>qamuda</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_qashtiliya" order="6">b_qamuda</GameId>
+      <GameId game="ImperatorRome">3194</GameId> <!-- Thelepte -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thelepte</Name>
+      <Name language="Latin_Medieval">Thelepte</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82373,24 +83937,31 @@
     <Id>sabrata</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tripolitana" order="5">b_sabrata</GameId>
+      <GameId game="ImperatorRome">3301</GameId> <!-- Sabratha -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Avrotonon</Name>
+      <Name language="Greek_Medieval">Sabratha</Name>
+      <Name language="Latin_Medieval">Sabratha</Name>
+      <Name language="Latin_Old">Sabratha</Name>
+      <Name language="Phoenician">Tsabratan</Name>
+      <Name language="Punic">Tsabratan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>zawiya</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_tripolitana" order="4">b_zawiya</GameId>
+      <GameId game="ImperatorRome">2018</GameId> <!-- Pontes -->
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>leptis_magna</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_tripolitania" order="2">c_leptis_magna</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Greek_Medieval">Pontos</Name>
+      <Name language="Latin_Medieval">Pontes</Name>
+      <Name language="Masmuda">Zzaweyya</Name>
+      <Name language="Sanhaja">Zzaweyya</Name>
+      <Name language="Tuareg_Tagelmust">Zzaweyya</Name>
+      <Name language="Tuareg">Zzaweyya</Name>
+      <Name language="Zenati">Zzaweyya</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82422,6 +83993,8 @@
       <GameId game="CK2HIP" parent="c_jafara" order="1">b_manu</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Ammonem</Name>
+      <Name language="Latin_Medieval">Ammonem</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82430,6 +84003,8 @@
       <GameId game="CK2HIP" parent="c_jafara" order="2">b_zuwara</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Villa Aniciorum</Name>
+      <Name language="Latin_Medieval">Villa Aniciorum</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82437,8 +84012,11 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_tripolitania" order="5">c_nafusa</GameId>
       <GameId game="CK2HIP" parent="c_nafusa" order="1">b_nafusa</GameId>
+      <GameId game="ImperatorRome">5989</GameId> <!-- Thenteos -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thenteos</Name>
+      <Name language="Latin_Medieval">Thenteos</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82447,6 +84025,8 @@
       <GameId game="CK2HIP" parent="c_nafusa" order="2">b_nalut</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Tabuinati</Name>
+      <Name language="Latin_Medieval">Tabuinati</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82455,6 +84035,8 @@
       <GameId game="CK2HIP" parent="c_nafusa" order="3">b_jafran</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Thenadassa</Name>
+      <Name language="Latin_Medieval">Thenadassa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82462,8 +84044,11 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_tripolitania" order="6">c_waddan</GameId>
       <GameId game="CK2HIP" parent="c_waddan" order="1">b_waddan</GameId>
+      <GameId game="ImperatorRome">5991</GameId> <!-- Gholaia -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Gholaia</Name>
+      <Name language="Latin_Medieval">Gholaia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82480,38 +84065,59 @@
       <GameId game="CK2HIP" parent="c_constantine" order="4">b_elkhroub</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Tiddis</Name>
+      <Name language="Latin_Medieval">Tiddis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>tadallis</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_bejaija" order="2">b_tadallis</GameId>
+      <GameId game="ImperatorRome">3121</GameId> <!-- Rusuccuru -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Kisse</Name>
+      <Name language="Greek_Medieval">Rusuccuru</Name>
+      <Name language="Latin_Medieval">Rusuccuru</Name>
+      <Name language="Latin_Old">Cissi</Name>
+      <Name language="Phoenician">Qishi</Name>
+      <Name language="Punic">Qishi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>buna</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_annaba" order="2">b_buna</GameId>
+      <GameId game="ImperatorRome">3227</GameId> <!-- Rusicade -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Rousikada</Name>
+      <Name language="Latin_Medieval">Rusicade</Name>
+      <Name language="Latin_Old">Rusicade</Name>
+      <Name language="Phoenician">Rushikad</Name>
+      <Name language="Punic">Rushikad</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>mila</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_annaba" order="3">b_mila</GameId>
+      <GameId game="ImperatorRome">3161</GameId> <!-- Chullu -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Koullou</Name>
+      <Name language="Latin_Medieval">Chullu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>qalatbhammad</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_setif" order="2">b_qalatbhammad</GameId>
+      <GameId game="ImperatorRome">3149</GameId> <!-- Cuicul -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Cuicul</Name>
+      <Name language="Latin_Medieval">Cuicul</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82523,19 +84129,14 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>ouled_nail</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_zab" order="1">c_ouled_nail</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>bousaada</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_ouled_nail" order="1">b_bousaada</GameId>
+      <GameId game="CK2HIP" parent="d_zab" order="1">c_ouled_nail</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Dimmidi</Name>
+      <Name language="Latin_Medieval">Dimmidi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82899,8 +84500,16 @@
     <Id>walila</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_fes" order="4">b_walila</GameId>
+      <GameId game="ImperatorRome">3067</GameId> <!-- Volubilis -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Ouloubilis</Name>
+      <Name language="Latin_Medieval">Volubilis</Name>
+      <Name language="Masmuda">Tizra</Name>
+      <Name language="Sanhaja">Tizra</Name>
+      <Name language="Tuareg_Tagelmust">Tizra</Name>
+      <Name language="Tuareg">Tizra</Name>
+      <Name language="Zenati">Tizra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82908,8 +84517,11 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_infa" order="1">b_chella</GameId>
       <GameId game="CK2HIP" parent="d_fes" order="2">c_infa</GameId>
+      <GameId game="ImperatorRome">6475</GameId> <!-- Anfa -->
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Sala Colonia</Name>
+      <Name language="Latin_Medieval">Sala Colonia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82918,6 +84530,8 @@
       <GameId game="CK2HIP" parent="c_infa" order="2">b_infa</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Anfa</Name>
+      <Name language="Latin_Medieval">Anfa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82926,6 +84540,7 @@
       <GameId game="CK2HIP" parent="c_el_rif" order="3">b_guercif</GameId>
     </GameIds>
     <Names>
+      <Name language="Zenati">Agarsif</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82951,6 +84566,11 @@
       <GameId game="CK2HIP" parent="c_idjil" order="1">b_idjil</GameId>
     </GameIds>
     <Names>
+      <Name language="Masmuda">Izal</Name>
+      <Name language="Sanhaja">Izal</Name>
+      <Name language="Tuareg_Tagelmust">Izal</Name>
+      <Name language="Tuareg">Izal</Name>
+      <Name language="Zenati">Izal</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82961,6 +84581,12 @@
       <GameId game="CK2HIP" parent="k_ghana" order="4">d_oualata</GameId>
     </GameIds>
     <Names>
+      <Name language="Masmuda">Iwalatan</Name>
+      <Name language="Sanhaja">Iwalatan</Name>
+      <Name language="Soninke">Biru</Name>
+      <Name language="Tuareg_Tagelmust">Iwalatan</Name>
+      <Name language="Tuareg">Iwalatan</Name>
+      <Name language="Zenati">Iwalatan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82978,6 +84604,8 @@
       <GameId game="CK2HIP" parent="c_esfahan" order="1">b_esfahan</GameId>
     </GameIds>
     <Names>
+      <Name language="Syriac_Classical">Espahan</Name>
+      <Name language="Persian_Middle">Spahan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82987,6 +84615,7 @@
       <GameId game="CK2HIP" parent="c_qom" order="1">b_qom</GameId>
     </GameIds>
     <Names>
+      <Name language="Persian_Middle">Goman</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -82994,8 +84623,16 @@
     <GameIds>
       <GameId game="CK2HIP" parent="d_jebal" order="4">c_hamadan</GameId>
       <GameId game="CK2HIP" parent="c_hamadan" order="1">b_hamadan</GameId>
+      <GameId game="ImperatorRome">1595</GameId> <!-- Ecbatana -->
     </GameIds>
     <Names>
+      <Name language="Greek_Ancient">Ekbatana</Name>
+      <Name language="Greek_Medieval">Ekbatana</Name>
+      <Name language="Latin_Medieval">Ecbatana</Name>
+      <Name language="Latin_Old">Ecbatana</Name>
+      <Name language="Persian_Middle">Ahmadan</Name>
+      <Name language="Persian_Old">Hagmatana</Name>
+      <Name language="Syriac_Classical">Beth Madaye</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -83865,6 +85502,18 @@
       <GameId game="CK2HIP" parent="d_albania" order="2">c_utik</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Utiq</Name>
+      <Name language="Arabic_Bedouin">Utiq</Name>
+      <Name language="Arabic_Egypt">Utiq</Name>
+      <Name language="Arabic_Levant">Utiq</Name>
+      <Name language="Arabic_Maghreb">Utiq</Name>
+      <Name language="Arabic_Yemen">Utiq</Name>
+      <Name language="Greek_Medieval">Otene</Name>
+      <Name language="Hejazi_Arabic">Utiq</Name>
+      <Name language="Oghuz">Gence</Name>
+      <Name language="Sicilian_Arabic">Utiq</Name>
+      <Name language="Turkish_Old">Gence</Name>
+      <Name language="Turkmen_Medieval">Gence</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84035,17 +85684,18 @@
   <LocationEntity>
     <Id>gujarat</Id>
     <GameIds>
+      <GameId game="CK2HIP" parent="k_gujarat" order="1">d_gurjara_mandala</GameId>
       <GameId game="CK2HIP" parent="e_rajastan" order="4">k_gujarat</GameId>
     </GameIds>
     <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
-    <Id>gurjara_mandala</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="k_gujarat" order="1">d_gurjara_mandala</GameId>
-    </GameIds>
-    <Names>
+      <Name language="Arabic_Andalusia">al-Jurz</Name>
+      <Name language="Arabic_Bedouin">al-Jurz</Name>
+      <Name language="Arabic_Egypt">al-Jurz</Name>
+      <Name language="Arabic_Levant">al-Jurz</Name>
+      <Name language="Arabic_Maghreb">al-Jurz</Name>
+      <Name language="Arabic_Yemen">al-Jurz</Name>
+      <Name language="Hejazi_Arabic">al-Jurz</Name>
+      <Name language="Sicilian_Arabic">al-Jurz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84062,6 +85712,14 @@
       <GameId game="CK2HIP" parent="e_rajastan" order="6">k_malwa</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">al-Máribah</Name>
+      <Name language="Arabic_Bedouin">al-Máribah</Name>
+      <Name language="Arabic_Egypt">al-Máribah</Name>
+      <Name language="Arabic_Levant">al-Máribah</Name>
+      <Name language="Arabic_Maghreb">al-Máribah</Name>
+      <Name language="Arabic_Yemen">al-Máribah</Name>
+      <Name language="Hejazi_Arabic">al-Máribah</Name>
+      <Name language="Sicilian_Arabic">al-Máribah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84071,6 +85729,14 @@
       <GameId game="CK2HIP" parent="c_ujjayini" order="1">b_ujjayini</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Uzayn</Name>
+      <Name language="Arabic_Bedouin">Uzayn</Name>
+      <Name language="Arabic_Egypt">Uzayn</Name>
+      <Name language="Arabic_Levant">Uzayn</Name>
+      <Name language="Arabic_Maghreb">Uzayn</Name>
+      <Name language="Arabic_Yemen">Uzayn</Name>
+      <Name language="Hejazi_Arabic">Uzayn</Name>
+      <Name language="Sicilian_Arabic">Uzayn</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84584,6 +86250,20 @@
       <GameId game="CK2HIP" parent="c_vanand" order="1">b_kars</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qars</Name>
+      <Name language="Arabic_Bedouin">Qars</Name>
+      <Name language="Arabic_Egypt">Qars</Name>
+      <Name language="Arabic_Levant">Qars</Name>
+      <Name language="Arabic_Maghreb">Qars</Name>
+      <Name language="Arabic_Yemen">Qars</Name>
+      <Name language="Georgian">Karsi</Name>
+      <Name language="Greek_Medieval">Karse</Name>
+      <Name language="Hejazi_Arabic">Qars</Name>
+      <Name language="Kurdish">Qers</Name>
+      <Name language="Oghuz">Qárs</Name>
+      <Name language="Sicilian_Arabic">Qars</Name>
+      <Name language="Turkish_Old">Qárs</Name>
+      <Name language="Turkmen_Medieval">Qárs</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84592,6 +86272,10 @@
       <GameId game="CK2HIP" parent="c_vanand" order="2">b_kaghzvan</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Kalzuan</Name>
+      <Name language="Oghuz">Kagizman</Name>
+      <Name language="Turkish_Old">Kagizman</Name>
+      <Name language="Turkmen_Medieval">Kagizman</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84600,6 +86284,7 @@
       <GameId game="CK2HIP" parent="c_vanand" order="3">b_surpstephanos</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Monì tìs Agios Stephános</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84608,6 +86293,7 @@
       <GameId game="CK2HIP" parent="c_vanand" order="3">b_surparakelots</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Agíon Apostólon Ekklisía</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84625,6 +86311,7 @@
       <GameId game="CK2HIP" parent="c_lori" order="1">b_loriberd</GameId>
     </GameIds>
     <Names>
+      <Name language="Georgian">Lore</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84633,6 +86320,7 @@
       <GameId game="CK2HIP" parent="c_lori" order="3">b_dmanisi</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Dmanis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84641,6 +86329,7 @@
       <GameId game="CK2HIP" parent="c_lori" order="4">b_bolnisi</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Bolnis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84724,6 +86413,9 @@
       <GameId game="CK2HIP" parent="c_taron" order="2">b_sason</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Sasun</Name>
+      <Name language="Greek_Medieval">Sassoun</Name>
+      <Name language="Kurdish">Qabilcewz</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84732,6 +86424,19 @@
       <GameId game="CK2HIP" parent="c_taron" order="2">b_mush</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Mus</Name>
+      <Name language="Arabic_Bedouin">Mus</Name>
+      <Name language="Arabic_Egypt">Mus</Name>
+      <Name language="Arabic_Levant">Mus</Name>
+      <Name language="Arabic_Maghreb">Mus</Name>
+      <Name language="Arabic_Yemen">Mus</Name>
+      <Name language="Greek_Medieval">Mous</Name>
+      <Name language="Hejazi_Arabic">Mus</Name>
+      <Name language="Kurdish">Mûs</Name>
+      <Name language="Oghuz">Mus</Name>
+      <Name language="Sicilian_Arabic">Mus</Name>
+      <Name language="Turkish_Old">Mus</Name>
+      <Name language="Turkmen_Medieval">Mus</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84740,6 +86445,7 @@
       <GameId game="CK2HIP" parent="c_taron" order="3">b_surpmarineh</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Ekklisía tis Agías Nautilías</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84748,6 +86454,10 @@
       <GameId game="CK2HIP" parent="c_taron" order="1">b_arakelots</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Monì Agíon Apostólon</Name>
+      <Name language="Oghuz">Arak Manastiri</Name>
+      <Name language="Turkish_Old">Arak Manastiri</Name>
+      <Name language="Turkmen_Medieval">Arak Manastiri</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84757,6 +86467,19 @@
       <GameId game="CK2HIP" parent="c_manzikert" order="1">b_manzikert</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Minazjird</Name>
+      <Name language="Arabic_Bedouin">Minazjird</Name>
+      <Name language="Arabic_Egypt">Minazjird</Name>
+      <Name language="Arabic_Levant">Minazjird</Name>
+      <Name language="Arabic_Maghreb">Minazjird</Name>
+      <Name language="Arabic_Yemen">Minazjird</Name>
+      <Name language="Greek_Medieval">Matzierte</Name>
+      <Name language="Hejazi_Arabic">Minazjird</Name>
+      <Name language="Kurdish">Malazgir</Name>
+      <Name language="Oghuz">Malazgird</Name>
+      <Name language="Sicilian_Arabic">Minazjird</Name>
+      <Name language="Turkish_Old">Malazgird</Name>
+      <Name language="Turkmen_Medieval">Malazgird</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84765,6 +86488,11 @@
       <GameId game="CK2HIP" parent="c_manzikert" order="2">b_glak</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Glakavank</Name>
+      <Name language="Greek_Medieval">Monì Glak</Name>
+      <Name language="Oghuz">Çanli Kilise</Name>
+      <Name language="Turkish_Old">Çanli Kilise</Name>
+      <Name language="Turkmen_Medieval">Çanli Kilise</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84773,6 +86501,7 @@
       <GameId game="CK2HIP" parent="c_manzikert" order="4">b_olnoutin</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Olnoutin</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84781,6 +86510,10 @@
       <GameId game="CK2HIP" parent="c_manzikert" order="5">b_khnus</GameId>
     </GameIds>
     <Names>
+      <Name language="Kurdish">Xinûs</Name>
+      <Name language="Oghuz">Hinis</Name>
+      <Name language="Turkish_Old">Hinis</Name>
+      <Name language="Turkmen_Medieval">Hinis</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84789,6 +86522,19 @@
       <GameId game="CK2HIP" parent="c_theodosiopolis" order="1">b_theodosiopolis</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qaliqala</Name>
+      <Name language="Arabic_Bedouin">Qaliqala</Name>
+      <Name language="Arabic_Egypt">Qaliqala</Name>
+      <Name language="Arabic_Levant">Qaliqala</Name>
+      <Name language="Arabic_Maghreb">Qaliqala</Name>
+      <Name language="Arabic_Yemen">Qaliqala</Name>
+      <Name language="Greek_Medieval">Theodosioupolis</Name>
+      <Name language="Hejazi_Arabic">Qaliqala</Name>
+      <Name language="Kurdish">Erzîrom</Name>
+      <Name language="Oghuz">Erzen er-Rûm</Name>
+      <Name language="Sicilian_Arabic">Qaliqala</Name>
+      <Name language="Turkish_Old">Erzen er-Rúm</Name>
+      <Name language="Turkmen_Medieval">Erzen er-Rúm</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84797,6 +86543,11 @@
       <GameId game="CK2HIP" parent="c_theodosiopolis" order="3">b_derzene</GameId>
     </GameIds>
     <Names>
+      <Name language="Greek_Medieval">Derzene</Name>
+      <Name language="Kurdish">Tercan</Name>
+      <Name language="Oghuz">Mama Hatun</Name>
+      <Name language="Turkish_Old">Mama Hatun</Name>
+      <Name language="Turkmen_Medieval">Mama Hatun</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84805,6 +86556,12 @@
       <GameId game="CK2HIP" parent="c_theodosiopolis" order="5">b_basean</GameId>
     </GameIds>
     <Names>
+      <Name language="Georgian">Basiani</Name>
+      <Name language="Greek_Medieval">Phasiane</Name>
+      <Name language="Kurdish">Hesenqela</Name>
+      <Name language="Oghuz">Hasankale</Name>
+      <Name language="Turkish_Old">Hasankale</Name>
+      <Name language="Turkmen_Medieval">Hasankale</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84813,6 +86570,9 @@
       <GameId game="CK2HIP" parent="c_theodosiopolis" order="3">b_jermuk_erzurum</GameId>
     </GameIds>
     <Names>
+      <Name language="Oghuz">Cermük</Name>
+      <Name language="Turkish_Old">Cermük</Name>
+      <Name language="Turkmen_Medieval">Cermük</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84821,6 +86581,18 @@
       <GameId game="CK2HIP" parent="c_sper" order="1">b_baydbert</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Báburt</Name>
+      <Name language="Arabic_Bedouin">Báburt</Name>
+      <Name language="Arabic_Egypt">Báburt</Name>
+      <Name language="Arabic_Levant">Báburt</Name>
+      <Name language="Arabic_Maghreb">Báburt</Name>
+      <Name language="Arabic_Yemen">Báburt</Name>
+      <Name language="Greek_Medieval">Baiberdôn</Name>
+      <Name language="Hejazi_Arabic">Báburt</Name>
+      <Name language="Oghuz">Bayburt</Name>
+      <Name language="Sicilian_Arabic">Báburt</Name>
+      <Name language="Turkish_Old">Bayburt</Name>
+      <Name language="Turkmen_Medieval">Bayburt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84845,6 +86617,19 @@
       <GameId game="CK2HIP" parent="c_karin" order="1">b_kamakha</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Hisn Kamakh</Name>
+      <Name language="Arabic_Bedouin">Hisn Kamakh</Name>
+      <Name language="Arabic_Egypt">Hisn Kamakh</Name>
+      <Name language="Arabic_Levant">Hisn Kamakh</Name>
+      <Name language="Arabic_Maghreb">Hisn Kamakh</Name>
+      <Name language="Arabic_Yemen">Hisn Kamakh</Name>
+      <Name language="Greek_Medieval">Kamacha</Name>
+      <Name language="Hejazi_Arabic">Hisn Kamakh</Name>
+      <Name language="Kurdish">Kemax</Name>
+      <Name language="Oghuz">Kemah</Name>
+      <Name language="Sicilian_Arabic">Hisn Kamakh</Name>
+      <Name language="Turkish_Old">Kemah</Name>
+      <Name language="Turkmen_Medieval">Kemah</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84853,6 +86638,10 @@
       <GameId game="CK2HIP" parent="c_karin" order="2">b_barzanissa</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Vartenik</Name>
+      <Name language="Oghuz">Baspinar</Name>
+      <Name language="Turkish_Old">Baspinar</Name>
+      <Name language="Turkmen_Medieval">Baspinar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84861,6 +86650,8 @@
       <GameId game="CK2HIP" parent="c_charpete" order="5">b_pertek</GameId>
     </GameIds>
     <Names>
+      <Name language="Armenian_Middle">Berdak</Name>
+      <Name language="Greek_Medieval">Berdak</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -84871,6 +86662,37 @@
       <GameId game="CK2HIP" parent="k_pomerania" order="1">d_mecklemburg</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Qal'at Nakon</Name>
+      <Name language="Arabic_Bedouin">Qal'at Nakon</Name>
+      <Name language="Arabic_Egypt">Qal'at Nakon</Name>
+      <Name language="Arabic_Levant">Qal'at Nakon</Name>
+      <Name language="Arabic_Maghreb">Qal'at Nakon</Name>
+      <Name language="Arabic_Yemen">Qal'at Nakon</Name>
+      <Name language="Bosnian_Medieval">Veligrad</Name>
+      <Name language="Bulgarian_Old">Veligrad</Name>
+      <Name language="Croatian_Medieval">Veligrad</Name>
+      <Name language="Czech_Medieval">Veligrad</Name>
+      <Name language="Danish_Middle">Mikelenburgh</Name>
+      <Name language="English_Old_Norse">Mikelenborg</Name>
+      <Name language="Gothic">Mikelenborg</Name>
+      <Name language="Hejazi_Arabic">Qal'at Nakon</Name>
+      <Name language="Icelandic_Old">Mikelenborg</Name>
+      <Name language="Irish_Middle_Norse">Mikelenborg</Name>
+      <Name language="Masmuda">Qal'at Nakon</Name>
+      <Name language="Norse">Mikelenborg</Name>
+      <Name language="Norwegian_Old">Mikelenborg</Name>
+      <Name language="Polish_Old">Meklemburgia</Name>
+      <Name language="Russian_Medieval">Veligrad</Name>
+      <Name language="Sanhaja">Qal'at Nakon</Name>
+      <Name language="Serbian_Medieval">Veligrad</Name>
+      <Name language="Sicilian_Arabic">Qal'at Nakon</Name>
+      <Name language="Slovak_Medieval">Veligrad</Name>
+      <Name language="Slovene_Medieval">Veligrad</Name>
+      <Name language="Sorbian">Veligrad</Name>
+      <Name language="Swedish_Old">Mikelenborg</Name>
+      <Name language="Tuareg_Tagelmust">Qal'at Nakon</Name>
+      <Name language="Tuareg">Qal'at Nakon</Name>
+      <Name language="Zenati">Qal'at Nakon</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -86051,6 +87873,7 @@
       <Name language="Hejazi_Arabic">Weltaba</Name>
       <Name language="Icelandic_Old">Jómsborg</Name>
       <Name language="Irish_Middle_Norse">Jómsborg</Name>
+      <Name language="Masmuda">Weltaba</Name>
       <Name language="Norse">Jómsborg</Name>
       <Name language="Norwegian_Old">Jómsborg</Name>
       <Name language="Polish_Old">Wolyn</Name>
@@ -86062,6 +87885,7 @@
       <Name language="Slovene_Medieval">Wolyn</Name>
       <Name language="Sorbian">Wòlin</Name>
       <Name language="Swedish_Old">Jómsborg</Name>
+      <Name language="Tuareg_Tagelmust">Weltaba</Name>
       <Name language="Tuareg">Weltaba</Name>
       <Name language="Zenati">Weltaba</Name>
     </Names>
@@ -88051,11 +89875,39 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>reval</Id>
+    <Id>harria</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="d_esthonia" order="1">c_reval</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Harrien</Name>
+      <Name language="Bavarian_Medieval">Harrien</Name>
+      <Name language="Danish_Middle">Hæriæ</Name>
+      <Name language="Dutch_Middle">Harrien</Name>
+      <Name language="English_Old_Norse">Harria</Name>
+      <Name language="Estonian">Harju</Name>
+      <Name language="Finnish">Harju</Name>
+      <Name language="Frankish_Low">Harrien</Name>
+      <Name language="Frankish">Harrien</Name>
+      <Name language="German_Middle_High">Harrien</Name>
+      <Name language="German_Middle_Low">Harrien</Name>
+      <Name language="German_Old_Low">Harrien</Name>
+      <Name language="Gothic">Harria</Name>
+      <Name language="Karelian">Harju</Name>
+      <Name language="Khanty">Harju</Name>
+      <Name language="Komi">Harju</Name>
+      <Name language="Latgalian">Harju</Name>
+      <Name language="Lithuanian_Medieval">Harju</Name>
+      <Name language="Livonian">Harju</Name>
+      <Name language="Mari">Harju</Name>
+      <Name language="Moksha">Harju</Name>
+      <Name language="Norwegian_Old">Harria</Name>
+      <Name language="Prussian_Old">Harju</Name>
+      <Name language="Sami">Harju</Name>
+      <Name language="Samoyed">Harju</Name>
+      <Name language="Swedish_Old">Harria</Name>
+      <Name language="Thuringian_Medieval">Harrien</Name>
+      <Name language="Vepsian_Medieval">Harju</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88064,6 +89916,20 @@
       <GameId game="CK2HIP" parent="c_reval" order="2">b_varbola</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Varbola</Name>
+      <Name language="Finnish">Varbola</Name>
+      <Name language="Karelian">Varbola</Name>
+      <Name language="Khanty">Varbola</Name>
+      <Name language="Komi">Varbola</Name>
+      <Name language="Latgalian">Varbola</Name>
+      <Name language="Lithuanian_Medieval">Varbola</Name>
+      <Name language="Livonian">Varbola</Name>
+      <Name language="Mari">Varbola</Name>
+      <Name language="Moksha">Varbola</Name>
+      <Name language="Prussian_Old">Varbola</Name>
+      <Name language="Sami">Varbola</Name>
+      <Name language="Samoyed">Varbola</Name>
+      <Name language="Vepsian_Medieval">Varbola</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88072,6 +89938,25 @@
       <GameId game="CK2HIP" parent="c_reval" order="3">b_rapla</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Rapal</Name>
+      <Name language="English_Old_Norse">Rapal</Name>
+      <Name language="Estonian">Rapla</Name>
+      <Name language="Finnish">Rapla</Name>
+      <Name language="Gothic">Rapal</Name>
+      <Name language="Karelian">Rapla</Name>
+      <Name language="Khanty">Rapla</Name>
+      <Name language="Komi">Rapla</Name>
+      <Name language="Latgalian">Rapla</Name>
+      <Name language="Lithuanian_Medieval">Rapla</Name>
+      <Name language="Livonian">Rapla</Name>
+      <Name language="Mari">Rapla</Name>
+      <Name language="Moksha">Rapla</Name>
+      <Name language="Norwegian_Old">Rapal</Name>
+      <Name language="Prussian_Old">Rapla</Name>
+      <Name language="Sami">Rapla</Name>
+      <Name language="Samoyed">Rapla</Name>
+      <Name language="Swedish_Old">Rapal</Name>
+      <Name language="Vepsian_Medieval">Rapla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88080,6 +89965,21 @@
       <GameId game="CK2HIP" parent="c_reval" order="4">b_toompea</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Toompea</Name>
+      <Name language="Finnish">Toompea</Name>
+      <Name language="Karelian">Toompea</Name>
+      <Name language="Khanty">Toompea</Name>
+      <Name language="Komi">Toompea</Name>
+      <Name language="Latgalian">Toompea</Name>
+      <Name language="Latin">Castrum Danorum</Name>
+      <Name language="Lithuanian_Medieval">Toompea</Name>
+      <Name language="Livonian">Toompea</Name>
+      <Name language="Mari">Toompea</Name>
+      <Name language="Moksha">Toompea</Name>
+      <Name language="Prussian_Old">Toompea</Name>
+      <Name language="Sami">Toompea</Name>
+      <Name language="Samoyed">Toompea</Name>
+      <Name language="Vepsian_Medieval">Toompea</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88088,15 +89988,81 @@
       <GameId game="CK2HIP" parent="c_reval" order="6">b_keila</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Keiknl</Name>
+      <Name language="English_Old_Norse">Keiknl</Name>
+      <Name language="Estonian">Keila</Name>
+      <Name language="Finnish">Keila</Name>
+      <Name language="Gothic">Keiknl</Name>
+      <Name language="Karelian">Keila</Name>
+      <Name language="Khanty">Keila</Name>
+      <Name language="Komi">Keila</Name>
+      <Name language="Latgalian">Keila</Name>
+      <Name language="Lithuanian_Medieval">Keila</Name>
+      <Name language="Livonian">Keila</Name>
+      <Name language="Mari">Keila</Name>
+      <Name language="Moksha">Keila</Name>
+      <Name language="Norwegian_Old">Keiknl</Name>
+      <Name language="Prussian_Old">Keila</Name>
+      <Name language="Sami">Keila</Name>
+      <Name language="Samoyed">Keila</Name>
+      <Name language="Swedish_Old">Keiknl</Name>
+      <Name language="Vepsian_Medieval">Keila</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>vironia</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_esthonia" order="2">c_narva</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Danish_Middle">Virland</Name>
+      <Name language="English_Old_Norse">Virland</Name>
+      <Name language="Estonian">Virumaa</Name>
+      <Name language="Finnish">Virumaa</Name>
+      <Name language="German_Middle_High">Wierland</Name>
+      <Name language="Gothic">Virland</Name>
+      <Name language="Karelian">Virumaa</Name>
+      <Name language="Khanty">Virumaa</Name>
+      <Name language="Komi">Virumaa</Name>
+      <Name language="Latgalian">Viruzeme</Name>
+      <Name language="Lithuanian_Medieval">Virumaa</Name>
+      <Name language="Livonian">Virumaa</Name>
+      <Name language="Mari">Virumaa</Name>
+      <Name language="Moksha">Virumaa</Name>
+      <Name language="Norwegian_Old">Virland</Name>
+      <Name language="Prussian_Old">Virumaa</Name>
+      <Name language="Sami">Virumaa</Name>
+      <Name language="Samoyed">Virumaa</Name>
+      <Name language="Swedish_Old">Virland</Name>
+      <Name language="Vepsian_Medieval">Virumaa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>narva</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_esthonia" order="2">c_narva</GameId>
       <GameId game="CK2HIP" parent="c_narva" order="1">b_narva</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Narvia</Name>
+      <Name language="English_Old_Norse">Narvia</Name>
+      <Name language="Estonian">Rugodiv</Name>
+      <Name language="Finnish">Rugodiv</Name>
+      <Name language="Gothic">Narvia</Name>
+      <Name language="Karelian">Rugodiv</Name>
+      <Name language="Khanty">Rugodiv</Name>
+      <Name language="Komi">Rugodiv</Name>
+      <Name language="Latgalian">Rugodiv</Name>
+      <Name language="Lithuanian_Medieval">Rugodiv</Name>
+      <Name language="Livonian">Rugodiv</Name>
+      <Name language="Mari">Rugodiv</Name>
+      <Name language="Moksha">Rugodiv</Name>
+      <Name language="Norwegian_Old">Narvia</Name>
+      <Name language="Prussian_Old">Rugodiv</Name>
+      <Name language="Russian_Medieval">Narov</Name>
+      <Name language="Sami">Rugodiv</Name>
+      <Name language="Samoyed">Rugodiv</Name>
+      <Name language="Swedish_Old">Narvia</Name>
+      <Name language="Vepsian_Medieval">Rugodiv</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88105,6 +90071,20 @@
       <GameId game="CK2HIP" parent="c_narva" order="2">b_viru_nigulas</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Viru-Nigulas</Name>
+      <Name language="Finnish">Viru-Nigulas</Name>
+      <Name language="Karelian">Viru-Nigulas</Name>
+      <Name language="Khanty">Viru-Nigulas</Name>
+      <Name language="Komi">Viru-Nigulas</Name>
+      <Name language="Latgalian">Viru-Nigulas</Name>
+      <Name language="Lithuanian_Medieval">Viru-Nigulas</Name>
+      <Name language="Livonian">Viru-Nigulas</Name>
+      <Name language="Mari">Viru-Nigulas</Name>
+      <Name language="Moksha">Viru-Nigulas</Name>
+      <Name language="Prussian_Old">Viru-Nigulas</Name>
+      <Name language="Sami">Viru-Nigulas</Name>
+      <Name language="Samoyed">Viru-Nigulas</Name>
+      <Name language="Vepsian_Medieval">Viru-Nigulas</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88113,6 +90093,25 @@
       <GameId game="CK2HIP" parent="c_narva" order="3">b_varangu</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Wrangalæ</Name>
+      <Name language="English_Old_Norse">Wrangalæ</Name>
+      <Name language="Estonian">Varangu</Name>
+      <Name language="Finnish">Varangu</Name>
+      <Name language="Gothic">Wrangalæ</Name>
+      <Name language="Karelian">Varangu</Name>
+      <Name language="Khanty">Varangu</Name>
+      <Name language="Komi">Varangu</Name>
+      <Name language="Latgalian">Varangu</Name>
+      <Name language="Lithuanian_Medieval">Varangu</Name>
+      <Name language="Livonian">Varangu</Name>
+      <Name language="Mari">Varangu</Name>
+      <Name language="Moksha">Varangu</Name>
+      <Name language="Norwegian_Old">Wrangalæ</Name>
+      <Name language="Prussian_Old">Varangu</Name>
+      <Name language="Sami">Varangu</Name>
+      <Name language="Samoyed">Varangu</Name>
+      <Name language="Swedish_Old">Wrangalæ</Name>
+      <Name language="Vepsian_Medieval">Varangu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88121,6 +90120,25 @@
       <GameId game="CK2HIP" parent="c_narva" order="4">b_maidla</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Maydalæ</Name>
+      <Name language="English_Old_Norse">Maydalæ</Name>
+      <Name language="Estonian">Maidla</Name>
+      <Name language="Finnish">Maidla</Name>
+      <Name language="Gothic">Maydalæ</Name>
+      <Name language="Karelian">Maidla</Name>
+      <Name language="Khanty">Maidla</Name>
+      <Name language="Komi">Maidla</Name>
+      <Name language="Latgalian">Maidla</Name>
+      <Name language="Lithuanian_Medieval">Maidla</Name>
+      <Name language="Livonian">Maidla</Name>
+      <Name language="Mari">Maidla</Name>
+      <Name language="Moksha">Maidla</Name>
+      <Name language="Norwegian_Old">Maydalæ</Name>
+      <Name language="Prussian_Old">Maidla</Name>
+      <Name language="Sami">Maidla</Name>
+      <Name language="Samoyed">Maidla</Name>
+      <Name language="Swedish_Old">Maydalæ</Name>
+      <Name language="Vepsian_Medieval">Maidla</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88129,6 +90147,20 @@
       <GameId game="CK2HIP" parent="c_narva" order="5">b_rakvere</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Rakvere</Name>
+      <Name language="Finnish">Rakvere</Name>
+      <Name language="Karelian">Rakvere</Name>
+      <Name language="Khanty">Rakvere</Name>
+      <Name language="Komi">Rakvere</Name>
+      <Name language="Latgalian">Rakvere</Name>
+      <Name language="Lithuanian_Medieval">Rakvere</Name>
+      <Name language="Livonian">Rakvere</Name>
+      <Name language="Mari">Rakvere</Name>
+      <Name language="Moksha">Rakvere</Name>
+      <Name language="Prussian_Old">Rakvere</Name>
+      <Name language="Sami">Rakvere</Name>
+      <Name language="Samoyed">Rakvere</Name>
+      <Name language="Vepsian_Medieval">Rakvere</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88137,6 +90169,22 @@
       <GameId game="CK2HIP" parent="d_esthonia" order="3">c_jarva</GameId>
     </GameIds>
     <Names>
+      <Name language="Danish_Middle">Jerwia</Name>
+      <Name language="English_Old_Norse">Jerwia</Name>
+      <Name language="Estonian">Järva</Name>
+      <Name language="Finnish">Järva</Name>
+      <Name language="German_Middle_High">Jerwen</Name>
+      <Name language="Gothic">Jerwia</Name>
+      <Name language="Icelandic_Old">Jerwia</Name>
+      <Name language="Irish_Middle_Norse">Jerwia</Name>
+      <Name language="Komi">Järva</Name>
+      <Name language="Latgalian">Järva</Name>
+      <Name language="Lithuanian_Medieval">Järva</Name>
+      <Name language="Livonian">Järva</Name>
+      <Name language="Norwegian_Old">Jerwia</Name>
+      <Name language="Prussian_Old">Järva</Name>
+      <Name language="Sami">Järva</Name>
+      <Name language="Swedish_Old">Jerwia</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88145,6 +90193,20 @@
       <GameId game="CK2HIP" parent="c_jarva" order="1">b_pilistvere</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Pilistvere</Name>
+      <Name language="Finnish">Pilistvere</Name>
+      <Name language="Karelian">Pilistvere</Name>
+      <Name language="Khanty">Pilistvere</Name>
+      <Name language="Komi">Pilistvere</Name>
+      <Name language="Latgalian">Pilistvere</Name>
+      <Name language="Lithuanian_Medieval">Pilistvere</Name>
+      <Name language="Livonian">Pilistvere</Name>
+      <Name language="Mari">Pilistvere</Name>
+      <Name language="Moksha">Pilistvere</Name>
+      <Name language="Prussian_Old">Pilistvere</Name>
+      <Name language="Sami">Pilistvere</Name>
+      <Name language="Samoyed">Pilistvere</Name>
+      <Name language="Vepsian_Medieval">Pilistvere</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88153,6 +90215,21 @@
       <GameId game="CK2HIP" parent="c_jarva" order="2">b_keava</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Keava</Name>
+      <Name language="Finnish">Keava</Name>
+      <Name language="Karelian">Keava</Name>
+      <Name language="Khanty">Keava</Name>
+      <Name language="Komi">Keava</Name>
+      <Name language="Latgalian">Keava</Name>
+      <Name language="Lithuanian_Medieval">Keava</Name>
+      <Name language="Livonian">Keava</Name>
+      <Name language="Mari">Keava</Name>
+      <Name language="Moksha">Keava</Name>
+      <Name language="Prussian_Old">Keava</Name>
+      <Name language="Russian_Medieval">Kedipiv</Name>
+      <Name language="Sami">Keava</Name>
+      <Name language="Samoyed">Keava</Name>
+      <Name language="Vepsian_Medieval">Keava</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88161,6 +90238,20 @@
       <GameId game="CK2HIP" parent="c_jarva" order="3">b_paide</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Paide</Name>
+      <Name language="Finnish">Paide</Name>
+      <Name language="Karelian">Paide</Name>
+      <Name language="Khanty">Paide</Name>
+      <Name language="Komi">Paide</Name>
+      <Name language="Latgalian">Paide</Name>
+      <Name language="Lithuanian_Medieval">Paide</Name>
+      <Name language="Livonian">Paide</Name>
+      <Name language="Mari">Paide</Name>
+      <Name language="Moksha">Paide</Name>
+      <Name language="Prussian_Old">Paide</Name>
+      <Name language="Sami">Paide</Name>
+      <Name language="Samoyed">Paide</Name>
+      <Name language="Vepsian_Medieval">Paide</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88170,14 +90261,60 @@
       <GameId game="CK2HIP" parent="d_dorpat" order="1">c_dorpat</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Dorpat</Name>
+      <Name language="Alemannic_Medieval">Uggenois</Name>
+      <Name language="Bavarian_Medieval">Dorpat</Name>
+      <Name language="Bavarian_Medieval">Uggenois</Name>
+      <Name language="Dutch_Middle">Dorpat</Name>
+      <Name language="Dutch_Middle">Uggenois</Name>
+      <Name language="Estonian">Ugandi</Name>
+      <Name language="Finnish">Ugandi</Name>
+      <Name language="Frankish_Low">Dorpat</Name>
+      <Name language="Frankish_Low">Uggenois</Name>
+      <Name language="Frankish">Dorpat</Name>
+      <Name language="Frankish">Uggenois</Name>
+      <Name language="German_Middle_High">Dorpat</Name>
+      <Name language="German_Middle_High">Uggenois</Name>
+      <Name language="German_Middle_Low">Dorpat</Name>
+      <Name language="German_Middle_Low">Uggenois</Name>
+      <Name language="German_Old_Low">Dorpat</Name>
+      <Name language="German_Old_Low">Uggenois</Name>
+      <Name language="Karelian">Ugandi</Name>
+      <Name language="Khanty">Ugandi</Name>
+      <Name language="Komi">Ugandi</Name>
+      <Name language="Latgalian">Ugaunija</Name>
+      <Name language="Lithuanian_Medieval">Ugaunija</Name>
+      <Name language="Livonian">Ugandi</Name>
+      <Name language="Mari">Ugandi</Name>
+      <Name language="Moksha">Ugandi</Name>
+      <Name language="Prussian_Old">Ugaunija</Name>
+      <Name language="Sami">Ugandi</Name>
+      <Name language="Samoyed">Ugandi</Name>
+      <Name language="Thuringian_Medieval">Dorpat</Name>
+      <Name language="Thuringian_Medieval">Uggenois</Name>
+      <Name language="Vepsian_Medieval">Ugandi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>karknaabbey</Id>
+    <Id>karkna</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_dorpat" order="1">b_karknaabbey</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Kärkna</Name>
+      <Name language="Finnish">Kärkna</Name>
+      <Name language="Karelian">Kärkna</Name>
+      <Name language="Khanty">Kärkna</Name>
+      <Name language="Komi">Kärkna</Name>
+      <Name language="Latgalian">Kärkna</Name>
+      <Name language="Lithuanian_Medieval">Kärkna</Name>
+      <Name language="Livonian">Kärkna</Name>
+      <Name language="Mari">Kärkna</Name>
+      <Name language="Moksha">Kärkna</Name>
+      <Name language="Prussian_Old">Kärkna</Name>
+      <Name language="Sami">Kärkna</Name>
+      <Name language="Samoyed">Kärkna</Name>
+      <Name language="Vepsian_Medieval">Kärkna</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88186,6 +90323,20 @@
       <GameId game="CK2HIP" parent="c_dorpat" order="2">b_kavilda</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Kavilda</Name>
+      <Name language="Finnish">Kavilda</Name>
+      <Name language="Karelian">Kavilda</Name>
+      <Name language="Khanty">Kavilda</Name>
+      <Name language="Komi">Kavilda</Name>
+      <Name language="Latgalian">Kavilda</Name>
+      <Name language="Lithuanian_Medieval">Kavilda</Name>
+      <Name language="Livonian">Kavilda</Name>
+      <Name language="Mari">Kavilda</Name>
+      <Name language="Moksha">Kavilda</Name>
+      <Name language="Prussian_Old">Kavilda</Name>
+      <Name language="Sami">Kavilda</Name>
+      <Name language="Samoyed">Kavilda</Name>
+      <Name language="Vepsian_Medieval">Kavilda</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88194,6 +90345,20 @@
       <GameId game="CK2HIP" parent="c_dorpat" order="3">b_kirumpaa</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Kirumpää</Name>
+      <Name language="Finnish">Kirumpää</Name>
+      <Name language="Karelian">Kirumpää</Name>
+      <Name language="Khanty">Kirumpää</Name>
+      <Name language="Komi">Kirumpää</Name>
+      <Name language="Latgalian">Kirumpää</Name>
+      <Name language="Lithuanian_Medieval">Kirumpää</Name>
+      <Name language="Livonian">Kirumpää</Name>
+      <Name language="Mari">Kirumpää</Name>
+      <Name language="Moksha">Kirumpää</Name>
+      <Name language="Prussian_Old">Kirumpää</Name>
+      <Name language="Sami">Kirumpää</Name>
+      <Name language="Samoyed">Kirumpää</Name>
+      <Name language="Vepsian_Medieval">Kirumpää</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88202,6 +90367,20 @@
       <GameId game="CK2HIP" parent="c_dorpat" order="4">b_otepaa</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Otepää</Name>
+      <Name language="Finnish">Otepää</Name>
+      <Name language="Karelian">Otepää</Name>
+      <Name language="Khanty">Otepää</Name>
+      <Name language="Komi">Otepää</Name>
+      <Name language="Latgalian">Otepää</Name>
+      <Name language="Lithuanian_Medieval">Otepää</Name>
+      <Name language="Livonian">Otepää</Name>
+      <Name language="Mari">Otepää</Name>
+      <Name language="Moksha">Otepää</Name>
+      <Name language="Prussian_Old">Otepää</Name>
+      <Name language="Sami">Otepää</Name>
+      <Name language="Samoyed">Otepää</Name>
+      <Name language="Vepsian_Medieval">Otepää</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88210,6 +90389,21 @@
       <GameId game="CK2HIP" parent="c_dorpat" order="5">b_tartu</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Tarbatu</Name>
+      <Name language="Finnish">Tarbatu</Name>
+      <Name language="Karelian">Tarbatu</Name>
+      <Name language="Khanty">Tarbatu</Name>
+      <Name language="Komi">Tarbatu</Name>
+      <Name language="Latgalian">Tarbatu</Name>
+      <Name language="Lithuanian_Medieval">Tarbatu</Name>
+      <Name language="Livonian">Tarbatu</Name>
+      <Name language="Mari">Tarbatu</Name>
+      <Name language="Moksha">Tarbatu</Name>
+      <Name language="Prussian_Old">Tarbatu</Name>
+      <Name language="Russian_Medieval">Yuryev</Name>
+      <Name language="Sami">Tarbatu</Name>
+      <Name language="Samoyed">Tarbatu</Name>
+      <Name language="Vepsian_Medieval">Tarbatu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88218,6 +90412,20 @@
       <GameId game="CK2HIP" parent="c_vaiga" order="1">b_puurmani</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Puurmani</Name>
+      <Name language="Finnish">Puurmani</Name>
+      <Name language="Karelian">Puurmani</Name>
+      <Name language="Khanty">Puurmani</Name>
+      <Name language="Komi">Puurmani</Name>
+      <Name language="Latgalian">Puurmani</Name>
+      <Name language="Lithuanian_Medieval">Puurmani</Name>
+      <Name language="Livonian">Puurmani</Name>
+      <Name language="Mari">Puurmani</Name>
+      <Name language="Moksha">Puurmani</Name>
+      <Name language="Prussian_Old">Puurmani</Name>
+      <Name language="Sami">Puurmani</Name>
+      <Name language="Samoyed">Puurmani</Name>
+      <Name language="Vepsian_Medieval">Puurmani</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88226,6 +90434,20 @@
       <GameId game="CK2HIP" parent="c_vaiga" order="2">b_poltsamaa</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Põltsamaa</Name>
+      <Name language="Finnish">Põltsamaa</Name>
+      <Name language="Karelian">Põltsamaa</Name>
+      <Name language="Khanty">Põltsamaa</Name>
+      <Name language="Komi">Põltsamaa</Name>
+      <Name language="Latgalian">Põltsamaa</Name>
+      <Name language="Lithuanian_Medieval">Põltsamaa</Name>
+      <Name language="Livonian">Põltsamaa</Name>
+      <Name language="Mari">Põltsamaa</Name>
+      <Name language="Moksha">Põltsamaa</Name>
+      <Name language="Prussian_Old">Põltsamaa</Name>
+      <Name language="Sami">Põltsamaa</Name>
+      <Name language="Samoyed">Põltsamaa</Name>
+      <Name language="Vepsian_Medieval">Põltsamaa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88234,6 +90456,20 @@
       <GameId game="CK2HIP" parent="k_terra" order="8">d_osel_wiek</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Saare-Lääne</Name>
+      <Name language="Finnish">Saare-Lääne</Name>
+      <Name language="Karelian">Saare-Lääne</Name>
+      <Name language="Khanty">Saare-Lääne</Name>
+      <Name language="Komi">Saare-Lääne</Name>
+      <Name language="Latgalian">Saare-Lääne</Name>
+      <Name language="Lithuanian_Medieval">Saare-Lääne</Name>
+      <Name language="Livonian">Saare-Lääne</Name>
+      <Name language="Mari">Saare-Lääne</Name>
+      <Name language="Moksha">Saare-Lääne</Name>
+      <Name language="Prussian_Old">Saare-Lääne</Name>
+      <Name language="Sami">Saare-Lääne</Name>
+      <Name language="Samoyed">Saare-Lääne</Name>
+      <Name language="Vepsian_Medieval">Saare-Lääne</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88242,14 +90478,51 @@
       <GameId game="CK2HIP" parent="d_osel_wiek" order="1">c_laanemaa</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Wiek</Name>
+      <Name language="Bavarian_Medieval">Wiek</Name>
+      <Name language="Dutch_Middle">Wiek</Name>
+      <Name language="Estonian">Läänemaa</Name>
+      <Name language="Finnish">Läänemaa</Name>
+      <Name language="Frankish_Low">Wiek</Name>
+      <Name language="Frankish">Wiek</Name>
+      <Name language="German_Middle_High">Wiek</Name>
+      <Name language="German_Middle_Low">Wiek</Name>
+      <Name language="German_Old_Low">Wiek</Name>
+      <Name language="Karelian">Läänemaa</Name>
+      <Name language="Khanty">Läänemaa</Name>
+      <Name language="Komi">Läänemaa</Name>
+      <Name language="Latgalian">Läänemaa</Name>
+      <Name language="Lithuanian_Medieval">Läänemaa</Name>
+      <Name language="Livonian">Läänemaa</Name>
+      <Name language="Mari">Läänemaa</Name>
+      <Name language="Moksha">Läänemaa</Name>
+      <Name language="Prussian_Old">Läänemaa</Name>
+      <Name language="Sami">Läänemaa</Name>
+      <Name language="Samoyed">Läänemaa</Name>
+      <Name language="Thuringian_Medieval">Wiek</Name>
+      <Name language="Vepsian_Medieval">Läänemaa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>oldpernau</Id>
+    <Id>pernau</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_laanemaa" order="1">b_oldpernau</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Pernau</Name>
+      <Name language="Finnish">Pernau</Name>
+      <Name language="Karelian">Pernau</Name>
+      <Name language="Khanty">Pernau</Name>
+      <Name language="Komi">Pernau</Name>
+      <Name language="Latgalian">Pernau</Name>
+      <Name language="Lithuanian_Medieval">Pernau</Name>
+      <Name language="Livonian">Pernau</Name>
+      <Name language="Mari">Pernau</Name>
+      <Name language="Moksha">Pernau</Name>
+      <Name language="Prussian_Old">Pernau</Name>
+      <Name language="Sami">Pernau</Name>
+      <Name language="Samoyed">Pernau</Name>
+      <Name language="Vepsian_Medieval">Pernau</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88258,6 +90531,20 @@
       <GameId game="CK2HIP" parent="c_laanemaa" order="2">b_haapsalu</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Haapsalu</Name>
+      <Name language="Finnish">Haapsalu</Name>
+      <Name language="Karelian">Haapsalu</Name>
+      <Name language="Khanty">Haapsalu</Name>
+      <Name language="Komi">Haapsalu</Name>
+      <Name language="Latgalian">Haapsalu</Name>
+      <Name language="Lithuanian_Medieval">Haapsalu</Name>
+      <Name language="Livonian">Haapsalu</Name>
+      <Name language="Mari">Haapsalu</Name>
+      <Name language="Moksha">Haapsalu</Name>
+      <Name language="Prussian_Old">Haapsalu</Name>
+      <Name language="Sami">Haapsalu</Name>
+      <Name language="Samoyed">Haapsalu</Name>
+      <Name language="Vepsian_Medieval">Haapsalu</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88266,6 +90553,20 @@
       <GameId game="CK2HIP" parent="c_laanemaa" order="3">b_rotala</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Rmula</Name>
+      <Name language="Finnish">Rmula</Name>
+      <Name language="Karelian">Rmula</Name>
+      <Name language="Khanty">Rmula</Name>
+      <Name language="Komi">Rmula</Name>
+      <Name language="Latgalian">Rmula</Name>
+      <Name language="Lithuanian_Medieval">Rmula</Name>
+      <Name language="Livonian">Rmula</Name>
+      <Name language="Mari">Rmula</Name>
+      <Name language="Moksha">Rmula</Name>
+      <Name language="Prussian_Old">Rmula</Name>
+      <Name language="Sami">Rmula</Name>
+      <Name language="Samoyed">Rmula</Name>
+      <Name language="Vepsian_Medieval">Rmula</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88274,6 +90575,20 @@
       <GameId game="CK2HIP" parent="c_laanemaa" order="4">b_lihula</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Lihula</Name>
+      <Name language="Finnish">Lihula</Name>
+      <Name language="Karelian">Lihula</Name>
+      <Name language="Khanty">Lihula</Name>
+      <Name language="Komi">Lihula</Name>
+      <Name language="Latgalian">Lihula</Name>
+      <Name language="Lithuanian_Medieval">Lihula</Name>
+      <Name language="Livonian">Lihula</Name>
+      <Name language="Mari">Lihula</Name>
+      <Name language="Moksha">Lihula</Name>
+      <Name language="Prussian_Old">Lihula</Name>
+      <Name language="Sami">Lihula</Name>
+      <Name language="Samoyed">Lihula</Name>
+      <Name language="Vepsian_Medieval">Lihula</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88282,6 +90597,20 @@
       <GameId game="CK2HIP" parent="c_laanemaa" order="2">b_koluvere</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Koluvere</Name>
+      <Name language="Finnish">Koluvere</Name>
+      <Name language="Karelian">Koluvere</Name>
+      <Name language="Khanty">Koluvere</Name>
+      <Name language="Komi">Koluvere</Name>
+      <Name language="Latgalian">Koluvere</Name>
+      <Name language="Lithuanian_Medieval">Koluvere</Name>
+      <Name language="Livonian">Koluvere</Name>
+      <Name language="Mari">Koluvere</Name>
+      <Name language="Moksha">Koluvere</Name>
+      <Name language="Prussian_Old">Koluvere</Name>
+      <Name language="Sami">Koluvere</Name>
+      <Name language="Samoyed">Koluvere</Name>
+      <Name language="Vepsian_Medieval">Koluvere</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88290,6 +90619,35 @@
       <GameId game="CK2HIP" parent="d_osel_wiek" order="2">c_osel</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Ösel</Name>
+      <Name language="Bavarian_Medieval">Ösel</Name>
+      <Name language="Danish_Middle">Øsel</Name>
+      <Name language="Dutch_Middle">Ösel</Name>
+      <Name language="English_Old_Norse">Eysýsla</Name>
+      <Name language="Estonian">Saaremaa</Name>
+      <Name language="Finnish">Saarenmaa</Name>
+      <Name language="Frankish_Low">Ösel</Name>
+      <Name language="Frankish">Ösel</Name>
+      <Name language="German_Middle_High">Ösel</Name>
+      <Name language="German_Middle_Low">Ösel</Name>
+      <Name language="German_Old_Low">Ösel</Name>
+      <Name language="Gothic">Oysl</Name>
+      <Name language="Karelian">Saarenmaa</Name>
+      <Name language="Khanty">Saarenmaa</Name>
+      <Name language="Komi">Saarenmaa</Name>
+      <Name language="Latgalian">Sãmsala</Name>
+      <Name language="Lithuanian_Medieval">Sãmsala</Name>
+      <Name language="Livonian">Saaremaa</Name>
+      <Name language="Mari">Saarenmaa</Name>
+      <Name language="Moksha">Saarenmaa</Name>
+      <Name language="Norse">Eysýsla</Name>
+      <Name language="Norwegian_Old">Eysýsla</Name>
+      <Name language="Prussian_Old">Saaremaa</Name>
+      <Name language="Sami">Saarenmaa</Name>
+      <Name language="Samoyed">Saarenmaa</Name>
+      <Name language="Swedish_Old">Ösel</Name>
+      <Name language="Thuringian_Medieval">Ösel</Name>
+      <Name language="Vepsian_Medieval">Saarenmaa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88298,6 +90656,20 @@
       <GameId game="CK2HIP" parent="c_osel" order="1">b_poide</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Pöide</Name>
+      <Name language="Finnish">Pöide</Name>
+      <Name language="Karelian">Pöide</Name>
+      <Name language="Khanty">Pöide</Name>
+      <Name language="Komi">Pöide</Name>
+      <Name language="Latgalian">Pöide</Name>
+      <Name language="Lithuanian_Medieval">Pöide</Name>
+      <Name language="Livonian">Pöide</Name>
+      <Name language="Mari">Pöide</Name>
+      <Name language="Moksha">Pöide</Name>
+      <Name language="Prussian_Old">Pöide</Name>
+      <Name language="Sami">Pöide</Name>
+      <Name language="Samoyed">Pöide</Name>
+      <Name language="Vepsian_Medieval">Pöide</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88306,6 +90678,20 @@
       <GameId game="CK2HIP" parent="c_osel" order="2">b_maasi</GameId>
     </GameIds>
     <Names>
+      <Name language="Estonian">Maasi</Name>
+      <Name language="Finnish">Maasi</Name>
+      <Name language="Karelian">Maasi</Name>
+      <Name language="Khanty">Maasi</Name>
+      <Name language="Komi">Maasi</Name>
+      <Name language="Latgalian">Maasi</Name>
+      <Name language="Lithuanian_Medieval">Maasi</Name>
+      <Name language="Livonian">Maasi</Name>
+      <Name language="Mari">Maasi</Name>
+      <Name language="Moksha">Maasi</Name>
+      <Name language="Prussian_Old">Maasi</Name>
+      <Name language="Sami">Maasi</Name>
+      <Name language="Samoyed">Maasi</Name>
+      <Name language="Vepsian_Medieval">Maasi</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88426,6 +90812,40 @@
       <GameId game="CK2HIP" parent="c_sarkel" order="2">b_sarkel</GameId>
     </GameIds>
     <Names>
+      <Name language="Alan">Aspron Hospition</Name>
+      <Name language="Arberian">Aspron Hospition</Name>
+      <Name language="Armenian_Middle">Aspron Hospition</Name>
+      <Name language="Avar_Old">Sharkil</Name>
+      <Name language="Bashkir">Sharkil</Name>
+      <Name language="Bosnian_Medieval">Belaja Veža</Name>
+      <Name language="Bulgar">Sharkil</Name>
+      <Name language="Bulgarian_Old">Belaja Veža</Name>
+      <Name language="Circassian">Sarqhal</Name>
+      <Name language="Circassian">Sharkil</Name>
+      <Name language="Croatian_Medieval">Belaja Veža</Name>
+      <Name language="Cuman">Sharkil</Name>
+      <Name language="Czech_Medieval">Belaja Veža</Name>
+      <Name language="Georgian">Aspron Hospition</Name>
+      <Name language="Gothic_Crimean">Aspron Hospition</Name>
+      <Name language="Greek_Medieval">Aspron Hospition</Name>
+      <Name language="Karluk">Sharkil</Name>
+      <Name language="Khazar_Kabar">Sharkil</Name>
+      <Name language="Khazar">Sharkil</Name>
+      <Name language="Khitan">Sharkil</Name>
+      <Name language="Kyrgyz">Sharkil</Name>
+      <Name language="Mongol_Proto">Sharkil'</Name>
+      <Name language="Oghuz">Sharkil</Name>
+      <Name language="Pecheneg">Sharkil</Name>
+      <Name language="Polish_Old">Belaja Veža</Name>
+      <Name language="Romanian_Old">Belaja Veža</Name>
+      <Name language="Russian_Medieval">Belaja Veža</Name>
+      <Name language="Serbian_Medieval">Belaja Veža</Name>
+      <Name language="Slovak_Medieval">Belaja Veža</Name>
+      <Name language="Slovene_Medieval">Belaja Veža</Name>
+      <Name language="Sorbian">Belaja Veža</Name>
+      <Name language="Turkish_Old">Sharkil</Name>
+      <Name language="Turkmen_Medieval">Sharkil</Name>
+      <Name language="Uyghur">Sharkil</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88434,15 +90854,54 @@
       <GameId game="CK2HIP" parent="c_sarkel" order="4">b_tsimlyansk</GameId>
     </GameIds>
     <Names>
+      <Name language="Russian_Medieval">Ust-Tsimla</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>duna-juk</Id>
+    <GameIds>
+      <GameId game="CK2HIP" parent="d_sarkel" order="2">c_sugrov</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Avar_Old">Buzan-Jük</Name>
+      <Name language="Bosnian_Medieval">Donel'</Name>
+      <Name language="Bulgar">Buzan-Jük</Name>
+      <Name language="Bulgarian_Old">Donel'</Name>
+      <Name language="Croatian_Medieval">Donel'</Name>
+      <Name language="Cuman">Šugr'</Name>
+      <Name language="Czech_Medieval">Donel'</Name>
+      <Name language="Khazar_Kabar">Buzan-Jük</Name>
+      <Name language="Khazar">Buzan-Jük</Name>
+      <Name language="Lithuanian_Medieval">Donecas</Name>
+      <Name language="Mongol_Proto">Šugr'</Name>
+      <Name language="Polish_Old">Doniec</Name>
+      <Name language="Russian_Medieval">Donel'</Name>
+      <Name language="Serbian_Medieval">Donel'</Name>
+      <Name language="Slovak_Medieval">Donel'</Name>
+      <Name language="Slovene_Medieval">Donel'</Name>
+      <Name language="Sorbian">Doniec</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>sugrov</Id>
     <GameIds>
-      <GameId game="CK2HIP" parent="d_sarkel" order="2">c_sugrov</GameId>
       <GameId game="CK2HIP" parent="c_sugrov" order="4">b_sugrov</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Šugr'</Name>
+      <Name language="Bulgar">Šugr'</Name>
+      <Name language="Circassian">Šugr'</Name>
+      <Name language="Cuman">Šugr'</Name>
+      <Name language="Karluk">Šugr'</Name>
+      <Name language="Khazar_Kabar">Šugr'</Name>
+      <Name language="Khazar">Šugr'</Name>
+      <Name language="Kyrgyz">Šugr'</Name>
+      <Name language="Mongol_Proto">Šugr'</Name>
+      <Name language="Oghuz">Šugr'</Name>
+      <Name language="Pecheneg">Šugr'</Name>
+      <Name language="Turkish_Old">Šugr'</Name>
+      <Name language="Turkmen_Medieval">Šugr'</Name>
+      <Name language="Uyghur">Šugr'</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88503,6 +90962,10 @@
       <GameId game="CK2HIP" parent="c_lower_dniepr" order="2">b_tomakiv</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Tomakov</Name>
+      <Name language="Polish_Old">Tomakow</Name>
+      <Name language="Slovak_Medieval">Tomakov</Name>
+      <Name language="Sorbian">Tomakow</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88511,6 +90974,10 @@
       <GameId game="CK2HIP" parent="c_chortitza" order="1">b_kodak</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Kudak</Name>
+      <Name language="Polish_Old">Kudak</Name>
+      <Name language="Slovak_Medieval">Kudak</Name>
+      <Name language="Sorbian">Kudak</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88535,6 +91002,10 @@
       <GameId game="CK2HIP" parent="c_lower_don" order="3">b_poltava</GameId>
     </GameIds>
     <Names>
+      <Name language="Czech_Medieval">Poltava</Name>
+      <Name language="Polish_Old">Poltawa</Name>
+      <Name language="Slovak_Medieval">Poltava</Name>
+      <Name language="Sorbian">Poltawa</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -88755,6 +91226,30 @@
       <GameId game="CK2HIP" parent="c_philan" order="2">b_varachan</GameId>
     </GameIds>
     <Names>
+      <Name language="Arabic_Andalusia">Warashan</Name>
+      <Name language="Arabic_Bedouin">Warashan</Name>
+      <Name language="Arabic_Egypt">Warashan</Name>
+      <Name language="Arabic_Levant">Warashan</Name>
+      <Name language="Arabic_Maghreb">Warashan</Name>
+      <Name language="Arabic_Yemen">Warashan</Name>
+      <Name language="Balochi">V'hrarzan</Name>
+      <Name language="Daylami">V'hrarzan</Name>
+      <Name language="Hejazi_Arabic">Warashan</Name>
+      <Name language="Kurdish">Warashan</Name>
+      <Name language="Ladino">Varshan</Name>
+      <Name language="Masmuda">Warashan</Name>
+      <Name language="Pashto">V'hrarzan</Name>
+      <Name language="Persian_Middle">V'hrarzan</Name>
+      <Name language="Persian">V'hrarzan</Name>
+      <Name language="Sanhaja">Warashan</Name>
+      <Name language="Sicilian_Arabic">Warashan</Name>
+      <Name language="Sogdian">V'hrarzan</Name>
+      <Name language="Tajiki">V'hrarzan</Name>
+      <Name language="Tuareg_Tagelmust">Warashan</Name>
+      <Name language="Tuareg">Warashan</Name>
+      <Name language="Turkmen_Medieval">V'hrarzan</Name>
+      <Name language="Yiddish">Varshan</Name>
+      <Name language="Zenati">Warashan</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89558,6 +92053,22 @@
       <GameId game="CK2HIP" parent="d_samara" order="2">c_uzens</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Qaraösen</Name>
+      <Name language="Bashkir">Qaraösen</Name>
+      <Name language="Bulgar">Qaraösen</Name>
+      <Name language="Circassian">Qaraösen</Name>
+      <Name language="Cuman">Qaraösen</Name>
+      <Name language="Karluk">Qaraösen</Name>
+      <Name language="Khazar_Kabar">Qaraösen</Name>
+      <Name language="Khazar">Qaraösen</Name>
+      <Name language="Khitan">Qaraösen</Name>
+      <Name language="Kyrgyz">Qaraösen</Name>
+      <Name language="Mongol_Proto">Qaraösen</Name>
+      <Name language="Oghuz">Qaraösen</Name>
+      <Name language="Pecheneg">Qaraösen</Name>
+      <Name language="Turkish_Old">Qaraösen</Name>
+      <Name language="Turkmen_Medieval">Qaraösen</Name>
+      <Name language="Uyghur">Qaraösen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89583,6 +92094,23 @@
       <GameId game="CK2HIP" parent="d_samara" order="3">c_syrt</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Tëp Särt</Name>
+      <Name language="Bashkir">Töp Sirt</Name>
+      <Name language="Bulgar">Tëp Särt</Name>
+      <Name language="Circassian">Töp Sirt</Name>
+      <Name language="Cuman">Töp Sirt</Name>
+      <Name language="Karluk">Töp Sirt</Name>
+      <Name language="Khazar_Kabar">Tëp Särt</Name>
+      <Name language="Khazar">Tëp Särt</Name>
+      <Name language="Khitan">Töp Sirt</Name>
+      <Name language="Kyrgyz">Töp Sirt</Name>
+      <Name language="Mongol_Proto">Töp Sirt</Name>
+      <Name language="Oghuz">Töp Sirt</Name>
+      <Name language="Pecheneg">Töp Sirt</Name>
+      <Name language="Russian_Medieval">Obshchiy Syrt</Name>
+      <Name language="Turkish_Old">Töp Sirt</Name>
+      <Name language="Turkmen_Medieval">Töp Sirt</Name>
+      <Name language="Uyghur">Töp Sirt</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89603,27 +92131,53 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>burtasy</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_mordva" order="1">c_burtasy</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>penza</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_burtasy" order="1">b_penza</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Kazarki</Name>
+      <Name language="Bashkir">Kazarki</Name>
+      <Name language="Bulgar">Kazarki</Name>
+      <Name language="Circassian">Kazarki</Name>
+      <Name language="Cuman">Kazarki</Name>
+      <Name language="Karluk">Kazarki</Name>
+      <Name language="Khazar_Kabar">Kazarki</Name>
+      <Name language="Khazar">Kazarki</Name>
+      <Name language="Kyrgyz">Kazarki</Name>
+      <Name language="Mongol_Proto">Kazarki</Name>
+      <Name language="Oghuz">Kazarki</Name>
+      <Name language="Pecheneg">Kazarki</Name>
+      <Name language="Turkish_Old">Kazarki</Name>
+      <Name language="Turkmen_Medieval">Kazarki</Name>
+      <Name language="Uyghur">Kazarki</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
     <Id>barysh</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_burtasy" order="2">b_barysh</GameId>
+      <GameId game="CK2HIP" parent="d_mordva" order="1">c_burtasy</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Barish</Name>
+      <Name language="Bashkir">Barish</Name>
+      <Name language="Bulgar">Barish</Name>
+      <Name language="Circassian">Barish</Name>
+      <Name language="Cuman">Barish</Name>
+      <Name language="Karluk">Barish</Name>
+      <Name language="Khazar_Kabar">Barish</Name>
+      <Name language="Khazar">Barish</Name>
+      <Name language="Kyrgyz">Barish</Name>
+      <Name language="Latgalian">Baryshas</Name>
+      <Name language="Lithuanian_Medieval">Baryshas</Name>
+      <Name language="Mongol_Proto">Barish</Name>
+      <Name language="Oghuz">Barish</Name>
+      <Name language="Pecheneg">Barish</Name>
+      <Name language="Prussian_Old">Baryshas</Name>
+      <Name language="Turkish_Old">Barish</Name>
+      <Name language="Turkmen_Medieval">Barish</Name>
+      <Name language="Uyghur">Barish</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89632,6 +92186,36 @@
       <GameId game="CK2HIP" parent="d_mordva" order="2">c_khopyor</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Khopër</Name>
+      <Name language="Bashkir">Khopër</Name>
+      <Name language="Bulgar">Khopër</Name>
+      <Name language="Circassian">Khopër</Name>
+      <Name language="Cuman">Khopër</Name>
+      <Name language="Estonian">Khopra</Name>
+      <Name language="Finnish">Khopra</Name>
+      <Name language="Karelian">Khopra</Name>
+      <Name language="Karluk">Khopër</Name>
+      <Name language="Khanty">Khopra</Name>
+      <Name language="Khazar_Kabar">Khopër</Name>
+      <Name language="Khazar">Khopër</Name>
+      <Name language="Komi">Khopra</Name>
+      <Name language="Kyrgyz">Khopër</Name>
+      <Name language="Latgalian">Chopioras</Name>
+      <Name language="Lithuanian_Medieval">Chopioras</Name>
+      <Name language="Livonian">Khopra</Name>
+      <Name language="Mari">Khopra</Name>
+      <Name language="Moksha">Khopra</Name>
+      <Name language="Mongol_Proto">Khopër</Name>
+      <Name language="Oghuz">Khopër</Name>
+      <Name language="Pecheneg">Khopër</Name>
+      <Name language="Prussian_Old">Chopioras</Name>
+      <Name language="Russian_Medieval">Khopyor</Name>
+      <Name language="Sami">Khopra</Name>
+      <Name language="Samoyed">Khopra</Name>
+      <Name language="Turkish_Old">Khopër</Name>
+      <Name language="Turkmen_Medieval">Khopër</Name>
+      <Name language="Uyghur">Khopër</Name>
+      <Name language="Vepsian_Medieval">Khopra</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89640,6 +92224,25 @@
       <GameId game="CK2HIP" parent="c_khopyor" order="1">b_atkarsk</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Ïtkar</Name>
+      <Name language="Bashkir">Ïtkar</Name>
+      <Name language="Bulgar">Ïtkar</Name>
+      <Name language="Circassian">Ïtkar</Name>
+      <Name language="Cuman">Ïtkar</Name>
+      <Name language="Karluk">Ïtkar</Name>
+      <Name language="Khazar_Kabar">Ïtkar</Name>
+      <Name language="Khazar">Ïtkar</Name>
+      <Name language="Kyrgyz">Ïtkar</Name>
+      <Name language="Latgalian">Atkaras</Name>
+      <Name language="Lithuanian_Medieval">Atkaras</Name>
+      <Name language="Mongol_Proto">Ïtkar</Name>
+      <Name language="Oghuz">Ïtkar</Name>
+      <Name language="Pecheneg">Ïtkar</Name>
+      <Name language="Prussian_Old">Atkaras</Name>
+      <Name language="Russian_Medieval">Atkarsk</Name>
+      <Name language="Turkish_Old">Ïtkar</Name>
+      <Name language="Turkmen_Medieval">Ïtkar</Name>
+      <Name language="Uyghur">Ïtkar</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89648,6 +92251,36 @@
       <GameId game="CK2HIP" parent="c_khopyor" order="3">b_medveditsa</GameId>
     </GameIds>
     <Names>
+      <Name language="Alemannic_Medieval">Medwediza</Name>
+      <Name language="Avar_Old">Medvedïca</Name>
+      <Name language="Bashkir">Medvedïca</Name>
+      <Name language="Bavarian_Medieval">Medwediza</Name>
+      <Name language="Bulgar">Medvedïca</Name>
+      <Name language="Circassian">Medvedïca</Name>
+      <Name language="Cuman">Medvedïca</Name>
+      <Name language="Czech_Medieval">Medvedica</Name>
+      <Name language="Frankish_Low">Medwediza</Name>
+      <Name language="Frankish">Medwediza</Name>
+      <Name language="German_Middle_High">Medwediza</Name>
+      <Name language="German_Middle_Low">Medwediza</Name>
+      <Name language="German_Old_Low">Medwediza</Name>
+      <Name language="Karluk">Medvedïca</Name>
+      <Name language="Khazar_Kabar">Medvedïca</Name>
+      <Name language="Khazar">Medvedïca</Name>
+      <Name language="Kyrgyz">Medvedïca</Name>
+      <Name language="Latgalian">Medvedicas</Name>
+      <Name language="Lithuanian_Medieval">Medvedicas</Name>
+      <Name language="Mongol_Proto">Medvedïca</Name>
+      <Name language="Oghuz">Medvedïca</Name>
+      <Name language="Pecheneg">Medvedïca</Name>
+      <Name language="Polish_Old">Miedwiedica</Name>
+      <Name language="Prussian_Old">Medvedicas</Name>
+      <Name language="Slovak_Medieval">Medvedica</Name>
+      <Name language="Sorbian">Miedwiedica</Name>
+      <Name language="Thuringian_Medieval">Medwediza</Name>
+      <Name language="Turkish_Old">Medvedïca</Name>
+      <Name language="Turkmen_Medieval">Medvedïca</Name>
+      <Name language="Uyghur">Medvedïca</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89657,6 +92290,43 @@
       <GameId game="CK2HIP" parent="k_volga_bulgaria" order="4">d_mordva</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Mäqshä</Name>
+      <Name language="Bashkir">Muqshi</Name>
+      <Name language="Bosnian_Medieval">Naruchad'</Name>
+      <Name language="Bulgar">Mäqshä</Name>
+      <Name language="Bulgarian_Old">Naruchad'</Name>
+      <Name language="Circassian">Muqshi</Name>
+      <Name language="Croatian_Medieval">Naruchad'</Name>
+      <Name language="Cuman">Muqshi</Name>
+      <Name language="Czech_Medieval">Naruchad'</Name>
+      <Name language="Estonian">Jov</Name>
+      <Name language="Finnish">Jov</Name>
+      <Name language="Karelian">Jov</Name>
+      <Name language="Karluk">Muqshi</Name>
+      <Name language="Khanty">Jov</Name>
+      <Name language="Khazar_Kabar">Mäqshä</Name>
+      <Name language="Khazar">Mäqshä</Name>
+      <Name language="Khitan">Muqshi</Name>
+      <Name language="Komi">Jov</Name>
+      <Name language="Kyrgyz">Muqshi</Name>
+      <Name language="Livonian">Jov</Name>
+      <Name language="Mari">Jov</Name>
+      <Name language="Moksha">Jov</Name>
+      <Name language="Mongol_Proto">Muqshi</Name>
+      <Name language="Oghuz">Mukshi</Name>
+      <Name language="Pecheneg">Mukshi</Name>
+      <Name language="Polish_Old">Naruchad'</Name>
+      <Name language="Russian_Medieval">Naruchad'</Name>
+      <Name language="Sami">Jov</Name>
+      <Name language="Samoyed">Jov</Name>
+      <Name language="Serbian_Medieval">Naruchad'</Name>
+      <Name language="Slovak_Medieval">Naruchad'</Name>
+      <Name language="Slovene_Medieval">Naruchad'</Name>
+      <Name language="Sorbian">Naruchad'</Name>
+      <Name language="Turkish_Old">Mukshi</Name>
+      <Name language="Turkmen_Medieval">Mukshi</Name>
+      <Name language="Uyghur">Muqshi</Name>
+      <Name language="Vepsian_Medieval">Jov</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89744,19 +92414,15 @@
     </Names>
   </LocationEntity>
   <LocationEntity>
-    <Id>desht-i-kipchak</Id>
-    <GameIds>
-      <GameId game="CK2HIP" parent="d_podonye" order="2">c_desht-i-kipchak</GameId>
-    </GameIds>
-    <Names>
-    </Names>
-  </LocationEntity>
-  <LocationEntity>
     <Id>stary_oskol</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_desht-i-kipchak" order="1">b_stary_oskol</GameId>
+      <GameId game="CK2HIP" parent="d_podonye" order="2">c_desht-i-kipchak</GameId>
     </GameIds>
     <Names>
+      <Name language="Latgalian">Oskolas</Name>
+      <Name language="Lithuanian_Medieval">Oskolas</Name>
+      <Name language="Prussian_Old">Oskolas</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>
@@ -89765,6 +92431,21 @@
       <GameId game="CK2HIP" parent="c_desht-i-kipchak" order="4">b_osen</GameId>
     </GameIds>
     <Names>
+      <Name language="Avar_Old">Esen</Name>
+      <Name language="Bashkir">Esen</Name>
+      <Name language="Bulgar">Esen</Name>
+      <Name language="Circassian">Esen</Name>
+      <Name language="Cuman">Esen</Name>
+      <Name language="Karluk">Esen</Name>
+      <Name language="Khazar_Kabar">Esen</Name>
+      <Name language="Khazar">Esen</Name>
+      <Name language="Kyrgyz">Esen</Name>
+      <Name language="Mongol_Proto">Esen</Name>
+      <Name language="Oghuz">Esen</Name>
+      <Name language="Pecheneg">Esen</Name>
+      <Name language="Turkish_Old">Esen</Name>
+      <Name language="Turkmen_Medieval">Esen</Name>
+      <Name language="Uyghur">Esen</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>

--- a/titles.xml
+++ b/titles.xml
@@ -18735,6 +18735,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="k_cyprus" order="1">d_cyprus</GameId>
       <GameId game="CK2HIP" parent="e_byzantium" order="7">k_cyprus</GameId>
+      <GameId game="CK3">d_cyprus</GameId>
+      <GameId game="CK3">k_cyprus</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Qubrus</Name>
@@ -18745,6 +18747,7 @@
       <Name language="Arabic_Yemen">Qubrus</Name>
       <Name language="Dalmatian_Medieval">Cipro</Name>
       <Name language="French_Old">Chypre</Name>
+      <Name language="Greek_Medieval">Kyprou</Name>
       <Name language="Hejazi_Arabic">Qubrus</Name>
       <Name language="Italian_Central">Cipro</Name>
       <Name language="Italian_Medieval">Cipro</Name>
@@ -18752,13 +18755,14 @@
       <Name language="Ligurian">Cipro</Name>
       <Name language="Neapolitan">Cipro</Name>
       <Name language="Norman">Chypre</Name>
-      <Name language="Oghuz">Kibris</Name>
+      <Name language="Oghuz">Kıbrıs</Name>
       <Name language="Romanian">Cipru</Name>
       <Name language="Sardinian">Cipro</Name>
       <Name language="Sicilian_Arabic">Qubrus</Name>
       <Name language="Sicilian">Cipro</Name>
-      <Name language="Turkish_Old">Kibris</Name>
-      <Name language="Turkmen_Medieval">Kibris</Name>
+      <Name language="Spanish">Chipre</Name>
+      <Name language="Turkish_Old">Kıbrıs</Name>
+      <Name language="Turkmen_Medieval">Kıbrıs</Name>
       <Name language="Tuscan">Cipro</Name>
       <Name language="Umbrian_Medieval">Cipro</Name>
       <Name language="Venetian_Medieval">Cipro</Name>
@@ -18769,6 +18773,7 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_limisol" order="2">b_limmassol</GameId>
       <GameId game="CK2HIP" parent="d_cyprus" order="1">c_limisol</GameId>
+      <GameId game="CK3">b_limisol</GameId>
     </GameIds>
     <Names>
       <Name language="Castilian">Limassol</Name>
@@ -18777,6 +18782,7 @@
       <Name language="Finnish">Limassol</Name>
       <Name language="French_Old">Limassol</Name>
       <Name language="German">Limassol</Name>
+      <Name language="Greek_Medieval">Lemesós</Name>
       <Name language="Italian_Central">Limisso</Name>
       <Name language="Italian_Medieval">Limisso</Name>
       <Name language="Langobardic">Limisso</Name>
@@ -18802,6 +18808,7 @@
     <Id>paphos</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_limisol" order="1">b_paphos</GameId>
+      <GameId game="CK3">b_paphos</GameId>
       <GameId game="ImperatorRome">334</GameId> <!-- Paphos -->
     </GameIds>
     <Names>
@@ -18810,6 +18817,7 @@
       <Name language="Dalmatian">Pafo</Name>
       <Name language="Finnish">Pafos</Name>
       <Name language="Greek_Ancient">Paphos</Name>
+      <Name language="Greek_Medieval">Paphos</Name>
       <Name language="Italian_Central">Pafo</Name>
       <Name language="Italian_Medieval">Pafo</Name>
       <Name language="Langobardic">Pafo</Name>
@@ -18835,6 +18843,8 @@
       <GameId game="CK2HIP" parent="c_messina" order="5">b_nicosia</GameId>
       <GameId game="CK2HIP" parent="c_nicosia" order="2">b_nikosia</GameId>
       <GameId game="CK2HIP" parent="d_cyprus" order="2">c_nicosia</GameId>
+      <GameId game="CK3">b_nicosia</GameId>
+      <GameId game="CK3">c_nicosia</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Lefqosha</Name>
@@ -18852,6 +18862,7 @@
       <Name language="Croatian">Nikozija</Name>
       <Name language="Czech">Nikósie</Name>
       <Name language="Dalmatian">Nicosia</Name>
+      <Name language="English">Nicosia</Name>
       <Name language="Estonian">Nikosia</Name>
       <Name language="Finnish">Nikosia</Name>
       <Name language="French_Old">Nicosie</Name>
@@ -18859,6 +18870,7 @@
       <Name language="German_Middle_Low">Nikosia</Name>
       <Name language="German_Old_Low">Nikosia</Name>
       <Name language="German">Nikosia</Name>
+      <Name language="Greek_Medieval">Leukousía</Name>
       <Name language="Hejazi_Arabic">Lefqosha</Name>
       <Name language="Icelandic">Nikósía</Name>
       <Name language="Italian_Central">Nicosia</Name>
@@ -18872,7 +18884,7 @@
       <Name language="Neapolitan">Nicosia</Name>
       <Name language="Norman">Nicosie</Name>
       <Name language="Norwegian">Nikosia</Name>
-      <Name language="Oghuz">Lefkosa</Name>
+      <Name language="Oghuz">Lefkoşa</Name>
       <Name language="Polish">Nikozja</Name>
       <Name language="Portuguese">Nicósia</Name>
       <Name language="Romanian">Nicosia</Name>
@@ -18883,8 +18895,8 @@
       <Name language="Sicilian">Nicusìa</Name>
       <Name language="Slovak">Nikózia</Name>
       <Name language="Slovene">Nikozija</Name>
-      <Name language="Turkish_Old">Lefkosa</Name>
-      <Name language="Turkmen_Medieval">Lefkosa</Name>
+      <Name language="Turkish_Old">Lefkoşa</Name>
+      <Name language="Turkmen_Medieval">Lefkoşa</Name>
       <Name language="Tuscan">Nicosia</Name>
       <Name language="Umbrian_Medieval">Nicosia</Name>
       <Name language="Venetian">Nicosia</Name>
@@ -62481,14 +62493,17 @@
     <Id>solia</Id>
     <GameIds>
       <GameId game="CK2HIP" parent="c_limisol" order="3">b_solia</GameId>
+      <GameId game="CK3">b_soli_CYP</GameId>
       <GameId game="ImperatorRome">1444</GameId> <!-- Solia -->
     </GameIds>
     <Names>
       <Name language="Dalmatian_Medieval">Soli</Name>
       <Name language="French_Old">Soles</Name>
+      <Name language="Greek_Medieval">Soloi</Name>
       <Name language="Italian_Central">Soli</Name>
       <Name language="Italian_Medieval">Soli</Name>
       <Name language="Langobardic">Soli</Name>
+      <Name language="Latin_Old">Solia</Name>
       <Name language="Ligurian">Soli</Name>
       <Name language="Neapolitan">Soli</Name>
       <Name language="Norman">Soles</Name>
@@ -62595,6 +62610,8 @@
     <GameIds>
       <GameId game="CK2HIP" parent="c_famagusta" order="2">b_famagusta</GameId>
       <GameId game="CK2HIP" parent="d_cyprus" order="3">c_famagusta</GameId>
+      <GameId game="CK3">b_famagusta</GameId>
+      <GameId game="CK3">c_famagusta</GameId>
     </GameIds>
     <Names>
       <Name language="Arabic_Andalusia">Magosha</Name>
@@ -62605,6 +62622,7 @@
       <Name language="Arabic_Yemen">Magosha</Name>
       <Name language="Dalmatian">Famagosta</Name>
       <Name language="French_Old">Famagouste</Name>
+      <Name language="Greek_Medieval">Ammókhõstos</Name>
       <Name language="Hejazi_Arabic">Magosha</Name>
       <Name language="Italian_Central">Famagosta</Name>
       <Name language="Italian_Medieval">Famagosta</Name>
@@ -62621,6 +62639,17 @@
       <Name language="Tuscan">Famagosta</Name>
       <Name language="Umbrian_Medieval">Famagosta</Name>
       <Name language="Venetian">Famagosta</Name>
+    </Names>
+  </LocationEntity>
+  <LocationEntity>
+    <Id>cerynia</Id>
+    <GameIds>
+      <GameId game="CK3">b_cerynia</GameId>
+    </GameIds>
+    <Names>
+      <Name language="Greek">Kerýneia</Name> <!-- Or Kyrenia -->
+      <Name language="Hungarian">Kerínia</Name>
+      <Name language="Turkish">Girne</Name>
     </Names>
   </LocationEntity>
   <LocationEntity>


### PR DESCRIPTION
 - Added lots of new names to existing titles
 - Support for many more `Crusader Kings 3` cultures
 - Added the remaining titles in `Crusader Kings 3`'s Thessalonika
 - Added all of the titles in `Crusader Kings 3`'s Crete
 - Added all of the titles in `Crusader Kings 3`'s Cyprus
 - Added added some more titles in `Crusader Kings 3`'s Poland
 - Added many `Imperator: Rome` provinces
 - Tweaked some names and languages