### PR TITLE
More names

### DIFF
--- a/languages.xml
+++ b/languages.xml
@@ -518,7 +518,6 @@
     <Id>Berber</Id>
     <GameIds>
       <GameId game="CK2HIP">berber</GameId> <!-- Iznagen -->
-      <GameId game="CK3">berber</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Zenaga</LanguageId>
@@ -2790,7 +2789,6 @@
     <GameIds>
       <GameId game="CK2">manden</GameId>
       <GameId game="CK2HIP">manden</GameId>
-      <GameId game="CK3">mande</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Soninke</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -37,8 +37,9 @@
     <Id>Alemannic</Id>
     <Code iso-639-3="gsw" />
     <FallbackLanguages>
-      <LanguageId>Alemannic_Medieval</LanguageId>
       <LanguageId>German</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
+      <LanguageId>Thuringian</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -46,7 +47,10 @@
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -57,17 +61,21 @@
       <GameId game="CK3">swabian</GameId>
     </GameIds>
     <FallbackLanguages>
-      <LanguageId>German</LanguageId>
-      <LanguageId>German_Before1945</LanguageId>
-      <LanguageId>German_Before1942</LanguageId>
-      <LanguageId>German_Before1941</LanguageId>
-      <LanguageId>German_Before1940</LanguageId>
-      <LanguageId>German_Before1938</LanguageId>
-      <LanguageId>German_Before19Century</LanguageId>
-      <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before1940</LanguageId>
+      <LanguageId>German_Before1941</LanguageId>
+      <LanguageId>German_Before1942</LanguageId>
+      <LanguageId>German_Before1945</LanguageId>
       <LanguageId>Alemannic</LanguageId>
+      <LanguageId>German</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
+      <LanguageId>Thuringian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -440,8 +448,9 @@
     <Id>Bavarian</Id>
     <Code iso-639-3="bar" />
     <FallbackLanguages>
-      <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>German</LanguageId>
+      <LanguageId>Thuringian</LanguageId>
+      <LanguageId>Alemannic</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -449,7 +458,10 @@
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -460,8 +472,9 @@
       <GameId game="CK3">bavarian</GameId>
     </GameIds>
     <FallbackLanguages>
-      <LanguageId>Bavarian</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
@@ -470,7 +483,10 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
       <LanguageId>German</LanguageId>
+      <LanguageId>Thuringian</LanguageId>
+      <LanguageId>Alemannic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -1491,6 +1507,8 @@
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -1504,6 +1522,8 @@
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German</LanguageId>
     </FallbackLanguages>
@@ -1517,6 +1537,8 @@
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
       <LanguageId>German</LanguageId>
@@ -1530,6 +1552,8 @@
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
@@ -1543,6 +1567,8 @@
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
@@ -1556,6 +1582,8 @@
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1569,6 +1597,8 @@
     <FallbackLanguages>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
@@ -1582,6 +1612,8 @@
     <Id>German_New_High_Early</Id> <!-- c. 1350 – c. 1650 -->
     <FallbackLanguages>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
@@ -1601,6 +1633,8 @@
       <GameId game="CK3">german</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
@@ -1617,6 +1651,8 @@
     <Code iso-639-2="goh" iso-639-3="goh" />
     <FallbackLanguages>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
@@ -4207,8 +4243,9 @@
   <Language>
     <Id>Thuringian</Id>
     <FallbackLanguages>
-      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
+      <LanguageId>Alemannic</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -4216,7 +4253,10 @@
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -4226,17 +4266,21 @@
       <GameId game="CK2HIP">thuringian</GameId>
     </GameIds>
     <FallbackLanguages>
-      <LanguageId>German</LanguageId>
-      <LanguageId>German_Before1945</LanguageId>
-      <LanguageId>German_Before1942</LanguageId>
-      <LanguageId>German_Before1941</LanguageId>
-      <LanguageId>German_Before1940</LanguageId>
-      <LanguageId>German_Before1938</LanguageId>
-      <LanguageId>German_Before19Century</LanguageId>
-      <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before1940</LanguageId>
+      <LanguageId>German_Before1941</LanguageId>
+      <LanguageId>German_Before1942</LanguageId>
+      <LanguageId>German_Before1945</LanguageId>
       <LanguageId>Thuringian</LanguageId>
+      <LanguageId>German</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
+      <LanguageId>Alemannic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -2293,6 +2293,7 @@
       <GameId game="CK3">khwarezmian</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Kufichi</LanguageId>
       <LanguageId>Sogdian</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -2322,6 +2323,16 @@
   <Language>
     <Id>Korean</Id>
     <Code iso-639-1="ko" iso-639-2="kor" iso-639-3="kor" />
+  </Language>
+  <Language>
+    <Id>Kufichi</Id>
+    <GameIds>
+      <GameId game="CK2HIP">qufs</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Khwarezmi</LanguageId>
+      <LanguageId>Sogdian</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Kurdish</Id>
@@ -3973,6 +3984,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Khwarezmi</LanguageId>
+      <LanguageId>Kufichi</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -719,7 +719,7 @@
   </Language>
   <Language>
     <Id>Chamorro</Id>
-    <Code iso-639-2="ch" iso-639-2="cha" iso-639-3="cha" />
+    <Code iso-639-1="ch" iso-639-2="cha" iso-639-3="cha" />
     <GameIds>
     </GameIds>
   </Language>

--- a/languages.xml
+++ b/languages.xml
@@ -1262,7 +1262,25 @@
     <Code iso-639-3="frk" />
     <GameIds>
       <GameId game="CK2HIP">franconian</GameId>
+      <GameId game="CK3">franconian</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before1942</LanguageId>
+      <LanguageId>German_Before1941</LanguageId>
+      <LanguageId>German_Before1940</LanguageId>
+      <LanguageId>German_Before1945</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
+      <LanguageId>German</LanguageId>
+      <LanguageId>Thuringian</LanguageId>
+      <LanguageId>Alemannic</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Frankish_Low</Id>
@@ -1270,6 +1288,23 @@
     <GameIds>
       <GameId game="CK2HIP">low_frankish</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before1942</LanguageId>
+      <LanguageId>German_Before1941</LanguageId>
+      <LanguageId>German_Before1940</LanguageId>
+      <LanguageId>German_Before1945</LanguageId>
+      <LanguageId>Bavarian</LanguageId>
+      <LanguageId>German</LanguageId>
+      <LanguageId>Thuringian</LanguageId>
+      <LanguageId>Alemannic</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>French</Id>
@@ -1300,15 +1335,21 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>French_Old</LanguageId>
+      <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
     <Id>Frisian_Old</Id> <!-- c. 8th century – c. 16th century -->
     <Code iso-639-3="ofs" />
+    <GameIds>
+      <GameId game="CK2">frisian</GameId>
+      <GameId game="CK2HIP">frisian</GameId>
+      <GameId game="CK3">frisian</GameId>
+    </GameIds>
     <FallbackLanguages>
+      <LanguageId>Frisian_West</LanguageId>
       <LanguageId>Frisian_Middle</LanguageId>
       <LanguageId>Frisian_North</LanguageId>
-      <LanguageId>Frisian_West</LanguageId>
       <LanguageId>Frisian_East</LanguageId>
       <LanguageId>Frisian_Saterland</LanguageId>
     </FallbackLanguages>
@@ -1337,11 +1378,6 @@
   <Language>
     <Id>Frisian_West</Id>
     <Code iso-639-1="fy" iso-639-3="fry" />
-    <GameIds>
-      <GameId game="CK2">frisian</GameId>
-      <GameId game="CK2HIP">frisian</GameId>
-      <GameId game="CK3">frisian</GameId>
-    </GameIds>
     <FallbackLanguages>
       <LanguageId>Frisian_North</LanguageId>
       <LanguageId>Frisian_East</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -300,6 +300,7 @@
     <FallbackLanguages>
       <LanguageId>Spanish</LanguageId>
       <LanguageId>Castillan</LanguageId>
+      <LanguageId>Castillan_Medieval</LanguageId>
       <LanguageId>Spanish_Medieval</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -373,6 +374,7 @@
       <LanguageId>Leonese</LanguageId>
       <LanguageId>Spanish</LanguageId>
       <LanguageId>Castillan</LanguageId>
+      <LanguageId>Castillan_Medieval</LanguageId>
       <LanguageId>Spanish_Medieval</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -676,12 +678,23 @@
   <Language>
     <Id>Castilian</Id>
     <GameIds>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Castillan_Medieval</LanguageId>
+      <LanguageId>Spanish_Medieval</LanguageId>
+      <LanguageId>Spanish</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Castillan_Medieval</Id>
+    <GameIds>
       <GameId game="CK2">castillan</GameId>
       <GameId game="CK2HIP">castillan</GameId>
       <GameId game="CK3">castilian</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Spanish_Medieval</LanguageId>
+      <LanguageId>Castilian</LanguageId>
       <LanguageId>Spanish</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -1310,6 +1323,7 @@
     <Id>French</Id>
     <Code iso-639-1="fr" iso-639-3="fra" />
     <FallbackLanguages>
+      <LanguageId>Norman</LanguageId>
       <LanguageId>French_Old</LanguageId>
       <LanguageId>French_Outremer</LanguageId>
     </FallbackLanguages>
@@ -1323,6 +1337,7 @@
       <GameId game="CK3">french</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Norman</LanguageId>
       <LanguageId>French_Outremer</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
@@ -1335,6 +1350,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>French_Old</LanguageId>
+      <LanguageId>Norman</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -2559,6 +2575,7 @@
     <FallbackLanguages>
       <LanguageId>Asturian</LanguageId>
       <LanguageId>Spanish</LanguageId>
+      <LanguageId>Castillan_Medieval</LanguageId>
       <LanguageId>Spanish_Medieval</LanguageId>
       <LanguageId>Castillan</LanguageId>
     </FallbackLanguages>
@@ -2988,6 +3005,11 @@
       <GameId game="CK2HIP">norman</GameId>
       <GameId game="CK3">norman</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>French_Old</LanguageId>
+      <LanguageId>French_Outremer</LanguageId>
+      <LanguageId>French</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Norse</Id>
@@ -4141,6 +4163,7 @@
     <FallbackLanguages>
       <LanguageId>Castilian</LanguageId>
       <LanguageId>Spanish_Medieval</LanguageId>
+      <LanguageId>Castillan_Medieval</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -4149,6 +4172,7 @@
       <GameId game="CK2HIP">spanish</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Castillan_Medieval</LanguageId>
       <LanguageId>Castilian</LanguageId>
       <LanguageId>Spanish</LanguageId>
     </FallbackLanguages>

--- a/scripts/find-mistakes.sh
+++ b/scripts/find-mistakes.sh
@@ -5,7 +5,9 @@ grep -n "parent=\"[a-zA-Z][^_]" titles.xml
 grep -n "parent=\"[a-zA-Z][^_]" titles.xml
 
 # Find duplicated IDs
-grep "^ *<Id>" *.xml | sort | uniq -c | grep "^ *[2-9]"
+grep "^ *<Id>" *.xml | \
+    sort | uniq -c | \
+    grep "^ *[2-9]"
 
 # Find duplicated game IDs
 grep "<GameId game=" *.xml | \


### PR DESCRIPTION
 - Added more names to existing titles
 - Added all the titles for `Crusader Kings 3`'s Badajoz
 - Added all the titles for `Crusader Kings 3`'s Burgundy
 - Added all the titles for `Crusader Kings 3`'s Croatia
 - Added all the titles for `Crusader Kings 3`'s Epirus
 - Added all the titles for `Crusader Kings 3`'s Ghana
 - Added all the titles for `Crusader Kings 3`'s Hellas
 - Added all the titles for `Crusader Kings 3`'s Kashmir
 - Added all the titles for `Crusader Kings 3`'s Leon
 - Added all the titles for `Crusader Kings 3`'s Lithuania
 - Added all the titles for `Crusader Kings 3`'s Sicily
 - Reorganised the german fallback languages
 - Documented the default names for most `Crusader Kings 2 (HIP)` and `Crusader Kings 3` titles