### PR TITLE
Title localisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Supported games:
  - `Hearts of Iron IV`
  - `Imperator: Rome`
 
-The common database currently has over **55 thousand** names for over **450** languages, settings and time periods.
+The common database currently has over **60 thousand** names for over **450** languages, settings and time periods.
 
 # Installation
 

--- a/assets/steam-workshop-description.txt
+++ b/assets/steam-workshop-description.txt
@@ -12,7 +12,7 @@ Supported games:
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2217534250]Crusader Kings 3[/url]
  - [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2219177532]Imperator: Rome[/url]
 
-The common database currently has over [b]55 thousand[/b] names for over [b]450[/b] languages, settings and time periods.
+The common database currently has over [b]60 thousand[/b] names for over [b]450[/b] languages, settings and time periods.
 
 [img=https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/banner_useful_links.png][/img]
 

--- a/languages.xml
+++ b/languages.xml
@@ -2942,11 +2942,9 @@
       <LanguageId>Lombard_East</LanguageId>
       <LanguageId>Italian</LanguageId>
       <LanguageId>Tuscan</LanguageId>
-      <LanguageId>Dalmatian</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
       <LanguageId>Lombard_Medieval</LanguageId>
       <LanguageId>Tuscan_Medieval</LanguageId>
-      <LanguageId>Dalmatian_Medieval</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2958,13 +2956,11 @@
     <FallbackLanguages>
       <LanguageId>Tuscan_Medieval</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
-      <LanguageId>Dalmatian_Medieval</LanguageId>
       <LanguageId>Lombard</LanguageId>
       <LanguageId>Lombard_West</LanguageId>
       <LanguageId>Lombard_East</LanguageId>
       <LanguageId>Italian</LanguageId>
       <LanguageId>Tuscan</LanguageId>
-      <LanguageId>Dalmatian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2976,11 +2972,9 @@
       <LanguageId>Lombard_East</LanguageId>
       <LanguageId>Italian</LanguageId>
       <LanguageId>Tuscan</LanguageId>
-      <LanguageId>Dalmatian</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
       <LanguageId>Lombard_Medieval</LanguageId>
       <LanguageId>Tuscan_Medieval</LanguageId>
-      <LanguageId>Dalmatian_Medieval</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2992,11 +2986,9 @@
       <LanguageId>Lombard_West</LanguageId>
       <LanguageId>Italian</LanguageId>
       <LanguageId>Tuscan</LanguageId>
-      <LanguageId>Dalmatian</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
       <LanguageId>Lombard_Medieval</LanguageId>
       <LanguageId>Tuscan_Medieval</LanguageId>
-      <LanguageId>Dalmatian_Medieval</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -3667,6 +3667,12 @@
     <GameIds>
       <GameId game="CK3">polabian</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Pomeranian</LanguageId>
+      <LanguageId>Sorbian</LanguageId>
+      <LanguageId>Sorbian_Lower</LanguageId>
+      <LanguageId>Sorbian_Upper</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Polish</Id>
@@ -3719,6 +3725,21 @@
       <LanguageId>Polish_Middle</LanguageId>
       <LanguageId>Polish_Before1974</LanguageId>
       <LanguageId>Polish</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Pomeranian</Id>
+    <Code iso-639-2="wen" />
+    <GameIds>
+      <GameId game="CK2">pommeranian</GameId>
+      <GameId game="CK2HIP">pommeranian</GameId> <!-- Vendi -->
+      <GameId game="CK3">pommeranian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Polabian</LanguageId>
+      <LanguageId>Sorbian</LanguageId>
+      <LanguageId>Sorbian_Lower</LanguageId>
+      <LanguageId>Sorbian_Upper</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -4697,13 +4718,12 @@
     <Id>Sorbian</Id>
     <Code iso-639-2="wen" />
     <GameIds>
-      <GameId game="CK2">pommeranian</GameId>
-      <GameId game="CK2HIP">pommeranian</GameId> <!-- Vendi -->
-      <GameId game="CK3">pommeranian</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Sorbian_Lower</LanguageId>
       <LanguageId>Sorbian_Upper</LanguageId>
+      <LanguageId>Pomeranian</LanguageId>
+      <LanguageId>Polabian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -4712,6 +4732,8 @@
     <FallbackLanguages>
       <LanguageId>Sorbian</LanguageId>
       <LanguageId>Sorbian_Upper</LanguageId>
+      <LanguageId>Pomeranian</LanguageId>
+      <LanguageId>Polabian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -4720,6 +4742,8 @@
     <FallbackLanguages>
       <LanguageId>Sorbian</LanguageId>
       <LanguageId>Sorbian_Lower</LanguageId>
+      <LanguageId>Pomeranian</LanguageId>
+      <LanguageId>Polabian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>


### PR DESCRIPTION
 - Added `Crusader Kings 2` and `Crusader Kings 2 HIP` title (landed, noble, job, court) localisations for some cultures
 - Removed the old title localistions from CK2HIP extras
 - Removed the old location localistions from CK2HIP extras **(1)**

**(1)**: They were not updated in a very long time and became inconsistent. Keeping them updated is against the long-term plan of the project.