### PR TITLE
More names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@
 
 This is a mod for various strategy games, that adds new place names based on their culture/faction.
 
+The common database currently has over **65 thousand** names for over **450** languages, settings and time periods.
+
 The names are meant to provide an immersive and accurate experience for the game's setting and time period.
 
-The common database currently has over **65 thousand** names for over **450** languages, settings and time periods.
+However, if explicit names are not set for a specific language for a given time period, names from other time periods or related languages will be used instead, as long as it makes sense. Examples:
+ - If a Middle Welsh name is not set, the Old Welsh one will be used if it exists, or the modern Welsh otherwise
+ - If an Occitan name does not exist, the French one will be used
+ - Croatian, Serbian and Bosnian will also use each other as backups, and so will Czech and Slovak, etc...
 
 # Supported games
 
@@ -65,29 +70,42 @@ Currently, the development focuses on the following:
  - For the names of which you are not sure, please include a comment
  - For alternative names in the same language and time period, consider documenting them in a comment alongside the main "active" one
 
-# Sources / Bibliography
+# Sources
 
-The following is a list of sources that attest the authenticity of the names provided by this mod:
+The following is a list of sources that were used in the making of this mod:
 
-English:
-- [Bulgar titles and names](http://www.chitatel.net/forum/topic/375-bulgar-titles-and-names/)
-- [Historical Romanian ranks and titles](https://en.wikipedia.org/wiki/Historical_Romanian_ranks_and_titles)
-- [Medieval Names Archive - English Place Names](https://www.s-gabriel.org/names/engplacenames.shtml)
-- [Word and Power in Mediaeval Bulgaria](https://books.google.co.uk/books?id=O-j66lYzINEC)
-
-Non-english:
-- RO [Dregătorie](https://ro.wikipedia.org/wiki/Dreg%C4%83torie)
-- RO [Institutii feudale in Tarile Romane sec XIV - XVI](http://www.ebacalaureat.ro/c/institutii-feudale-in-tarile-romane-sec-xiv---xvi/1158)
-- RO [Institutii Medievale Romanesti](https://www.scribd.com/doc/103239549/Institutii-Medievale-Romanesti)
+## Toponyms
 
 Mods:
-- [Historical Immersion Project](https://ck2.paradoxwikis.com/Historical_Immersion_Project)
-- [Schattenzeitalter](http://www.moddb.com/mods/schattenzeitalter)
+ - [Historical Immersion Project](https://ck2.paradoxwikis.com/Historical_Immersion_Project)
+ - [Schattenzeitalter](http://www.moddb.com/mods/schattenzeitalter)
+ - More Dynamic Cultural Names
 
 Databases:
  - [GeoNames](http://www.geonames.org/) - A vast database containing exonyms in various languages
 
 Other:
-- Wikipedia pages of cities and places, in various languages
+ - Wikipedia pages of cities and places, in various languages
+ - Wiktionary pages of specific names, to find older variants and accurate transliterations
+ - The cultural names from the unmodded versions of the supported games
+
+## Titles
+
+ - ![EN:](https://github.com/markjames/famfamfam-flag-icons/blob/master/icons/png/gb.png?raw=true) [Bulgar titles and names](http://www.chitatel.net/forum/topic/375-bulgar-titles-and-names/)
+ - ![EN:](https://github.com/markjames/famfamfam-flag-icons/blob/master/icons/png/gb.png?raw=true) [Historical Romanian ranks and titles](https://en.wikipedia.org/wiki/Historical_Romanian_ranks_and_titles)
+ - ![EN:](https://github.com/markjames/famfamfam-flag-icons/blob/master/icons/png/gb.png?raw=true) [Word and Power in Mediaeval Bulgaria](https://books.google.co.uk/books?id=O-j66lYzINEC)
+ - ![RO:](https://github.com/markjames/famfamfam-flag-icons/blob/master/icons/png/ro.png?raw=true) [Dregătorie](https://ro.wikipedia.org/wiki/Dreg%C4%83torie)
+ - ![RO:](https://github.com/markjames/famfamfam-flag-icons/blob/master/icons/png/ro.png?raw=true) [Institutii feudale in Tarile Romane sec XIV - XVI](http://www.ebacalaureat.ro/c/institutii-feudale-in-tarile-romane-sec-xiv---xvi/1158)
+ - ![RO:](https://github.com/markjames/famfamfam-flag-icons/blob/master/icons/png/ro.png?raw=true) [Institutii Medievale Romanesti](https://www.scribd.com/doc/103239549/Institutii-Medievale-Romanesti)
+
+Mods:
+ - [Historical Immersion Project](https://ck2.paradoxwikis.com/Historical_Immersion_Project)
+ - [Community Title Project](https://github.com/Gr770/CK3-Community-Title-Project)
+
+Other:
+ - [Orbis Latinus](http://www.columbia.edu/acis/ets/Graesse/orblatv.html)
+ - [RBMS Latin place names](http://rbms.info/lpn/a/)
+ - Wikipedia
+ - Wiktionary to find older and/or feminine variants
 
 [![Support this on Patreon](https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/patreon.png)](https://www.patreon.com/hmlendea)

--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ Currently, the development focuses on the following:
 
 # Development guidelines
 
- - Make sure the names you add are historically accurate for the medieval era
- - Make sure you include all the original special characters of the name
+ - Make sure the names you add are historically accurate
+ - Include all the original special characters of the name
+ - Use the appropriate language for the names *(e.g. Welsh vs Welsh_Middle)*
  - For the names of which you are not sure, please include a comment
- - For alternative names in the same language, please put them in a commend alongside the main "active" one
+ - For alternative names in the same language and time period, consider documenting them in a comment alongside the main "active" one
 
 # Sources / Bibliography
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Alternatively, please consider supporting this project on [Patreon](https://www.
 Currently, the development focuses on the following:
 
  1. Add more localisations to existing locations
+ 1. Update the slavic names with correct transliterations and special characters
  2. Support more `Crusader Kings 3` locations
  3. Finish and publish the `Hearts of Iron 4` edition
  3. Support more `Hearts of Iron 4` locations

--- a/assets/steam-workshop-description.txt
+++ b/assets/steam-workshop-description.txt
@@ -6,9 +6,15 @@
 
 This is a mod for various strategy games, that adds new place names based on their culture/faction.
 
-The names are meant to provide an immersive and accurate experience for the game's setting and time period.
-
 There are currently [b]over 65 thousand[/b] names for [b]over 450[/b] languages, settings and time periods, in the main common database.
+
+The names are meant to provide an immersive and accurate experience for the game's setting and time period.
+However, if explicit names are not set for a specific language for a given time period, names from other time periods or related languages will be used instead, as long as it makes sense. Examples:
+[list]
+[*] If a Middle Welsh name is not set, the Old Welsh one will be used if it exists, or the modern Welsh otherwise
+[*] If an Occitan name does not exist, the French one will be used
+[*] Croatian, Serbian and Bosnian will also use each other as backups, and so will Czech and Slovak, etc...
+[/list]
 
 [img=https://raw.githubusercontent.com/hmlendea/more-cultural-names/master/assets/banner_supported_games.png][/img]
 

--- a/languages.xml
+++ b/languages.xml
@@ -51,6 +51,7 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
@@ -74,6 +75,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -397,6 +399,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
     </FallbackLanguages>
@@ -523,6 +526,7 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
@@ -545,6 +549,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1510,6 +1515,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1534,6 +1540,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1810,6 +1817,7 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
@@ -1835,6 +1843,7 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
@@ -1850,6 +1859,7 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
@@ -1865,6 +1875,7 @@
     <FallbackLanguages>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
@@ -1880,6 +1891,7 @@
     <Id>German_Before1940</Id>
     <FallbackLanguages>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
@@ -1895,12 +1907,30 @@
   <Language>
     <Id>German_Before1938</Id>
     <FallbackLanguages>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_Before1940</LanguageId>
+      <LanguageId>German_Before1941</LanguageId>
+      <LanguageId>German_Before1942</LanguageId>
+      <LanguageId>German_Before1945</LanguageId>
+      <LanguageId>German</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>German_Before20Century</Id>
+    <FallbackLanguages>
+      <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_New_High_Early</LanguageId>
+      <LanguageId>German_Middle_High</LanguageId>
+      <LanguageId>Bavarian_Medieval</LanguageId>
+      <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
@@ -1916,6 +1946,7 @@
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1932,6 +1963,7 @@
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1954,6 +1986,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1971,6 +2004,7 @@
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -3895,6 +3929,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Aromanian</LanguageId>
@@ -3912,6 +3947,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian</LanguageId>
@@ -3929,6 +3965,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1993</LanguageId>
@@ -3946,6 +3983,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1991</LanguageId>
@@ -3965,6 +4003,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1974</LanguageId>
@@ -3986,6 +4025,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1964</LanguageId>
@@ -4003,6 +4043,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1945</LanguageId>
@@ -4020,6 +4061,7 @@
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1940</LanguageId>
@@ -4037,6 +4079,7 @@
     <FallbackLanguages>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1930</LanguageId>
@@ -4054,6 +4097,7 @@
     <Id>Romanian_Before1916</Id>
     <FallbackLanguages>
       <LanguageId>Romanian_Before1913</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
       <LanguageId>Romanian_Before1918</LanguageId>
@@ -4071,8 +4115,28 @@
   <Language>
     <Id>Romanian_Before1913</Id>
     <FallbackLanguages>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before19Century</LanguageId>
       <LanguageId>Romanian_Old</LanguageId>
+      <LanguageId>Romanian_Before1916</LanguageId>
+      <LanguageId>Romanian_Before1918</LanguageId>
+      <LanguageId>Romanian_Before1930</LanguageId>
+      <LanguageId>Romanian_Before1940</LanguageId>
+      <LanguageId>Romanian_Before1945</LanguageId>
+      <LanguageId>Romanian_Before1964</LanguageId>
+      <LanguageId>Romanian_Before1974</LanguageId>
+      <LanguageId>Romanian_Before1991</LanguageId>
+      <LanguageId>Romanian_Before1993</LanguageId>
+      <LanguageId>Romanian</LanguageId>
+      <LanguageId>Aromanian</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Romanian_Before20Century</Id>
+    <FallbackLanguages>
+      <LanguageId>Romanian_Before19Century</LanguageId>
+      <LanguageId>Romanian_Old</LanguageId>
+      <LanguageId>Romanian_Before1913</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1918</LanguageId>
       <LanguageId>Romanian_Before1930</LanguageId>
@@ -4090,6 +4154,7 @@
     <Id>Romanian_Before19Century</Id>
     <FallbackLanguages>
       <LanguageId>Romanian_Old</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1918</LanguageId>
@@ -4113,6 +4178,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Romanian_Before19Century</LanguageId>
+      <LanguageId>Romanian_Before20Century</LanguageId>
       <LanguageId>Romanian_Before1913</LanguageId>
       <LanguageId>Romanian_Before1916</LanguageId>
       <LanguageId>Romanian_Before1918</LanguageId>
@@ -4834,6 +4900,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -4994,6 +5061,7 @@
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
@@ -5015,6 +5083,7 @@
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
+      <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -626,6 +626,7 @@
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Masmuda</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -643,6 +644,7 @@
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Masmuda</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -660,6 +662,7 @@
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Masmuda</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -2691,6 +2694,7 @@
       <LanguageId>Zenaga</LanguageId>
       <LanguageId>Tuareg</LanguageId>
       <LanguageId>Tuareg_Tagelmust</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -3299,6 +3303,7 @@
       <LanguageId>Zenaga</LanguageId>
       <LanguageId>Tuareg</LanguageId>
       <LanguageId>Tuareg_Tagelmust</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -4490,6 +4495,7 @@
       <LanguageId>Zenaga</LanguageId>
       <LanguageId>Tuareg</LanguageId>
       <LanguageId>Tuareg_Tagelmust</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -5242,6 +5248,7 @@
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Masmuda</LanguageId>
       <LanguageId>Zenaga</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -5259,6 +5266,7 @@
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Masmuda</LanguageId>
       <LanguageId>Zenaga</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -5708,6 +5716,7 @@
       <LanguageId>Kabyle</LanguageId>
       <LanguageId>Sanhaja</LanguageId>
       <LanguageId>Masmuda</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -5722,6 +5731,7 @@
       <LanguageId>Tuareg</LanguageId>
       <LanguageId>Tuareg_Tagelmust</LanguageId>
       <LanguageId>Zenaga</LanguageId>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
     <GameIds>
       <GameId game="CK2HIP">zanata</GameId>

--- a/languages.xml
+++ b/languages.xml
@@ -409,6 +409,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>French_Old</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -1557,8 +1558,20 @@
     </FallbackLanguages>
   </Language>
   <Language>
-    <Id>French_Old</Id>
-    <Code iso-639-3="fro" />
+    <Id>French_Middle</Id> <!-- c. 14th century – c. 17th century -->
+    <Code iso-639-2="frm" iso-639-3="frm" />
+    <GameIds>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Norman</LanguageId>
+      <LanguageId>French_Old</LanguageId>
+      <LanguageId>French_Outremer</LanguageId>
+      <LanguageId>French</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>French_Old</Id> <!-- c. 8th century – c. 14th century -->
+    <Code iso-639-2="fro" iso-639-3="fro" />
     <GameIds>
       <GameId game="CK2">frankish</GameId>
       <GameId game="CK2HIP">frankish</GameId>
@@ -1567,6 +1580,7 @@
     <FallbackLanguages>
       <LanguageId>Norman</LanguageId>
       <LanguageId>French_Outremer</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -1579,6 +1593,7 @@
     <FallbackLanguages>
       <LanguageId>French_Old</LanguageId>
       <LanguageId>Norman</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -2207,6 +2222,7 @@
     <Code iso-639-3="gcr" />
     <FallbackLanguages>
       <LanguageId>French</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French_Old</LanguageId>
       <LanguageId>French_Outremer</LanguageId>
     </FallbackLanguages>
@@ -3374,6 +3390,7 @@
     <FallbackLanguages>
       <LanguageId>French_Old</LanguageId>
       <LanguageId>French_Outremer</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -3483,9 +3500,10 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Occitan_Gascon</LanguageId>
-      <LanguageId>French</LanguageId>
       <LanguageId>Occitan_Old</LanguageId>
       <LanguageId>Occitan_Gascon_Old</LanguageId>
+      <LanguageId>French</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French_Old</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -3499,9 +3517,10 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Occitan_Gascon_Old</LanguageId>
-      <LanguageId>French_Old</LanguageId>
       <LanguageId>Occitan</LanguageId>
       <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>French_Old</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -3510,9 +3529,10 @@
     <Code iso-639-3="gsc" />
     <FallbackLanguages>
       <LanguageId>Occitan</LanguageId>
-      <LanguageId>French</LanguageId>
       <LanguageId>Occitan_Gascon_Old</LanguageId>
       <LanguageId>Occitan_Old</LanguageId>
+      <LanguageId>French</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French_Old</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -3523,9 +3543,10 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Occitan_Old</LanguageId>
-      <LanguageId>French_Old</LanguageId>
       <LanguageId>Occitan</LanguageId>
       <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>French_Old</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
     </FallbackLanguages>
   </Language>

--- a/languages.xml
+++ b/languages.xml
@@ -3839,10 +3839,12 @@
       <GameId game="CK3">polabian</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Polish_Old</LanguageId>
       <LanguageId>Pomeranian</LanguageId>
       <LanguageId>Sorbian</LanguageId>
       <LanguageId>Sorbian_Lower</LanguageId>
       <LanguageId>Sorbian_Upper</LanguageId>
+      <LanguageId>Polish</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -3856,6 +3858,7 @@
       <LanguageId>Polish_Before1953</LanguageId>
       <LanguageId>Polish_Middle</LanguageId>
       <LanguageId>Polish_Old</LanguageId>
+      <LanguageId>Polabian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -3864,6 +3867,7 @@
       <LanguageId>Polish_Before1953</LanguageId>
       <LanguageId>Polish_Middle</LanguageId>
       <LanguageId>Polish_Old</LanguageId>
+      <LanguageId>Polabian</LanguageId>
       <LanguageId>Polish</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -3872,6 +3876,7 @@
     <FallbackLanguages>
       <LanguageId>Polish_Middle</LanguageId>
       <LanguageId>Polish_Old</LanguageId>
+      <LanguageId>Polabian</LanguageId>
       <LanguageId>Polish_Before1974</LanguageId>
       <LanguageId>Polish</LanguageId>
     </FallbackLanguages>
@@ -3880,6 +3885,7 @@
     <Id>Polish_Middle</Id> <!-- c. 16th century – c. 18th century -->
     <FallbackLanguages>
       <LanguageId>Polish_Old</LanguageId>
+      <LanguageId>Polabian</LanguageId>
       <LanguageId>Polish_Before1953</LanguageId>
       <LanguageId>Polish_Before1974</LanguageId>
       <LanguageId>Polish</LanguageId>
@@ -3893,6 +3899,7 @@
       <GameId game="CK3">polish</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Polabian</LanguageId>
       <LanguageId>Polish_Middle</LanguageId>
       <LanguageId>Polish_Before1974</LanguageId>
       <LanguageId>Polish</LanguageId>
@@ -5697,6 +5704,7 @@
       <GameId game="CK3">zaghawa</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Arabic</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -2042,6 +2042,7 @@
     <Code iso-639-3="gml" />
     <GameIds>
       <GameId game="CK2HIP">low_german</GameId>
+      <GameId game="CK3">saxon</GameId>
     </GameIds>
     <FallbackLanguages>
       <LanguageId>German_Low</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -58,6 +58,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>Suebi</LanguageId>
     </FallbackLanguages>
@@ -72,6 +73,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
@@ -443,7 +445,22 @@
       <GameId game="CK3">avar</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Cuman</LanguageId>
+      <LanguageId>Pecheneg</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
+      <LanguageId>Bashkir</LanguageId>
+      <LanguageId>Gagauz</LanguageId>
+      <LanguageId>Oghuz</LanguageId>
+      <LanguageId>Khazar</LanguageId>
+      <LanguageId>Khazar_Kabar</LanguageId>
+      <LanguageId>Turkmen_Medieval</LanguageId>
+      <LanguageId>Turkish_Old</LanguageId>
       <LanguageId>Avar</LanguageId>
+      <LanguageId>Turkish_Ottoman</LanguageId>
+      <LanguageId>Turkmen</LanguageId>
+      <LanguageId>Turkish_Before1923</LanguageId>
+      <LanguageId>Turkish_Before2005</LanguageId>
+      <LanguageId>Turkish</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -489,6 +506,7 @@
       <LanguageId>Oghuz</LanguageId>
       <LanguageId>Pecheneg</LanguageId>
       <LanguageId>Cuman</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
       <LanguageId>Gagauz</LanguageId>
       <LanguageId>Khazar</LanguageId>
       <LanguageId>Khazar_Kabar</LanguageId>
@@ -533,6 +551,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -546,6 +565,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
@@ -766,6 +786,24 @@
       <GameId game="CK2HIP">bolghar</GameId>
       <GameId game="CK3">bolghar</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Pecheneg</LanguageId>
+      <LanguageId>Cuman</LanguageId>
+      <LanguageId>Avar_Old</LanguageId>
+      <LanguageId>Bashkir</LanguageId>
+      <LanguageId>Gagauz</LanguageId>
+      <LanguageId>Oghuz</LanguageId>
+      <LanguageId>Khazar</LanguageId>
+      <LanguageId>Khazar_Kabar</LanguageId>
+      <LanguageId>Turkmen_Medieval</LanguageId>
+      <LanguageId>Turkish_Old</LanguageId>
+      <LanguageId>Avar</LanguageId>
+      <LanguageId>Turkish_Ottoman</LanguageId>
+      <LanguageId>Turkmen</LanguageId>
+      <LanguageId>Turkish_Before1923</LanguageId>
+      <LanguageId>Turkish_Before2005</LanguageId>
+      <LanguageId>Turkish</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Bulgarian</Id>
@@ -1090,6 +1128,8 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Pecheneg</LanguageId>
+      <LanguageId>Avar_Old</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
       <LanguageId>Bashkir</LanguageId>
       <LanguageId>Gagauz</LanguageId>
       <LanguageId>Oghuz</LanguageId>
@@ -1097,6 +1137,7 @@
       <LanguageId>Khazar_Kabar</LanguageId>
       <LanguageId>Turkmen_Medieval</LanguageId>
       <LanguageId>Turkish_Old</LanguageId>
+      <LanguageId>Avar</LanguageId>
       <LanguageId>Turkish_Ottoman</LanguageId>
       <LanguageId>Turkmen</LanguageId>
       <LanguageId>Turkish_Before1923</LanguageId>
@@ -1516,6 +1557,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
@@ -1538,6 +1580,7 @@
       <GameId game="CK2HIP">low_frankish</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
@@ -1692,6 +1735,7 @@
       <LanguageId>Oghuz</LanguageId>
       <LanguageId>Pecheneg</LanguageId>
       <LanguageId>Cuman</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
       <LanguageId>Khazar</LanguageId>
       <LanguageId>Khazar_Kabar</LanguageId>
       <LanguageId>Turkmen_Medieval</LanguageId>
@@ -1829,6 +1873,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -1855,6 +1900,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German</LanguageId>
     </FallbackLanguages>
@@ -1871,6 +1917,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
       <LanguageId>German</LanguageId>
@@ -1887,6 +1934,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
       <LanguageId>German_Before1945</LanguageId>
@@ -1903,6 +1951,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
       <LanguageId>German_Before1942</LanguageId>
@@ -1919,6 +1968,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
       <LanguageId>German_Before1941</LanguageId>
@@ -1935,6 +1985,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
       <LanguageId>German_Before1940</LanguageId>
@@ -1951,6 +2002,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before20Century</LanguageId>
       <LanguageId>German_Before1938</LanguageId>
@@ -1967,6 +2019,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_Before20Century</LanguageId>
@@ -1989,6 +2042,7 @@
     <FallbackLanguages>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
@@ -2008,6 +2062,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Thuringian_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>
       <LanguageId>German_Before20Century</LanguageId>
@@ -2025,6 +2080,7 @@
     <FallbackLanguages>
       <LanguageId>German_Low_Dutch</LanguageId>
       <LanguageId>German_Middle_Low</LanguageId>
+      <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>German_Old_Low</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -2045,6 +2101,7 @@
       <GameId game="CK3">saxon</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>German_Low</LanguageId>
       <LanguageId>German_Low_Dutch</LanguageId>
       <LanguageId>German_Old_Low</LanguageId>
@@ -2061,6 +2118,7 @@
       <LanguageId>Frisian_Old</LanguageId>
       <LanguageId>English_Old</LanguageId>
       <LanguageId>German_Middle_Low</LanguageId>
+      <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>German_Low</LanguageId>
       <LanguageId>German_Low_Dutch</LanguageId>
     </FallbackLanguages>
@@ -2719,6 +2777,7 @@
       <LanguageId>Oghuz</LanguageId>
       <LanguageId>Pecheneg</LanguageId>
       <LanguageId>Cuman</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
       <LanguageId>Gagauz</LanguageId>
       <LanguageId>Turkmen_Medieval</LanguageId>
       <LanguageId>Turkish_Old</LanguageId>
@@ -3624,6 +3683,7 @@
       <LanguageId>Bashkir</LanguageId>
       <LanguageId>Pecheneg</LanguageId>
       <LanguageId>Cuman</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
       <LanguageId>Gagauz</LanguageId>
       <LanguageId>Khazar</LanguageId>
       <LanguageId>Khazar_Kabar</LanguageId>
@@ -3686,6 +3746,7 @@
     <FallbackLanguages>
       <LanguageId>Bashkir</LanguageId>
       <LanguageId>Cuman</LanguageId>
+      <LanguageId>Bulgar</LanguageId>
       <LanguageId>Oghuz</LanguageId>
       <LanguageId>Gagauz</LanguageId>
       <LanguageId>Khazar</LanguageId>
@@ -4630,6 +4691,7 @@
       <GameId game="CK3">russian</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Russian_Medieval</LanguageId>
       <LanguageId>Ruthenian</LanguageId>
       <LanguageId>Ukrainian_Before2017</LanguageId>
       <LanguageId>Russian</LanguageId>
@@ -5092,6 +5154,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -5104,6 +5167,7 @@
       <LanguageId>German_Middle_High</LanguageId>
       <LanguageId>Bavarian_Medieval</LanguageId>
       <LanguageId>Alemannic_Medieval</LanguageId>
+      <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Old_High</LanguageId>
       <LanguageId>German_New_High_Early</LanguageId>
       <LanguageId>German_Before19Century</LanguageId>

--- a/languages.xml
+++ b/languages.xml
@@ -578,10 +578,11 @@
       <LanguageId>Russian</LanguageId>
       <LanguageId>Ukrainian</LanguageId>
       <LanguageId>Ukrainian_Before2017</LanguageId>
+      <LanguageId>Slavic_East_Old</LanguageId>
       <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
       <LanguageId>Ruthenian</LanguageId>
     </FallbackLanguages>
   </Language>
@@ -2435,6 +2436,24 @@
     <Code iso-639-1="io" iso-639-2="ido" iso-639-3="ido" />
   </Language>
   <Language>
+    <Id>Ilmenian</Id>
+    <GameIds>
+      <GameId game="CK2">ilmenian</GameId>
+      <GameId game="CK3">ilmenian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Russian_Medieval</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Ruthenian</LanguageId>
+      <LanguageId>Ukrainian_Before2017</LanguageId>
+      <LanguageId>Russian</LanguageId>
+      <LanguageId>Belarussian</LanguageId>
+      <LanguageId>Ukrainian</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
     <Id>Indonesian</Id>
     <Code iso-639-1="id" iso-639-3="ind" />
     <GameIds>
@@ -4128,75 +4147,21 @@
       <LanguageId>Belarussian</LanguageId>
       <LanguageId>Ukrainian</LanguageId>
       <LanguageId>Ukrainian_Before2017</LanguageId>
+      <LanguageId>Slavic_East_Old</LanguageId>
       <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
       <LanguageId>Ruthenian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
-    <Id>Russian_Medieval</Id>
-    <GameIds>
-      <GameId game="CK2">russian</GameId>
-      <GameId game="CK2HIP">russian</GameId>
-      <GameId game="CK3">russian</GameId>
-    </GameIds>
+    <Id>Russian_Medieval</Id> <!-- TODO: THIS IS OBSOLETE/DEPRECATED!!! Use Russian or Slavic_East_Old and replace existing names that use this ID -->
     <FallbackLanguages>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
-      <LanguageId>Ruthenian</LanguageId>
-      <LanguageId>Ukrainian_Before2017</LanguageId>
-      <LanguageId>Russian</LanguageId>
-      <LanguageId>Belarussian</LanguageId>
-      <LanguageId>Ukrainian</LanguageId>
-    </FallbackLanguages>
-  </Language>
-  <Language>
-    <Id>Russian_Medieval_Ilmenian</Id>
-    <GameIds>
-      <GameId game="CK2">severian</GameId>
-      <GameId game="CK3">severian</GameId>
-    </GameIds>
-    <FallbackLanguages>
-      <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Ruthenian</LanguageId>
-      <LanguageId>Ukrainian_Before2017</LanguageId>
-      <LanguageId>Russian</LanguageId>
-      <LanguageId>Belarussian</LanguageId>
-      <LanguageId>Ukrainian</LanguageId>
-    </FallbackLanguages>
-  </Language>
-  <Language>
-    <Id>Russian_Medieval_Severian</Id>
-    <GameIds>
-      <GameId game="CK2">ilmenian</GameId>
-      <GameId game="CK3">ilmenian</GameId>
-    </GameIds>
-    <FallbackLanguages>
-      <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
-      <LanguageId>Ruthenian</LanguageId>
-      <LanguageId>Ukrainian_Before2017</LanguageId>
-      <LanguageId>Russian</LanguageId>
-      <LanguageId>Belarussian</LanguageId>
-      <LanguageId>Ukrainian</LanguageId>
-    </FallbackLanguages>
-  </Language>
-  <Language>
-    <Id>Russian_Medieval_Volhynian</Id>
-    <GameIds>
-      <GameId game="CK2">volhynian</GameId>
-      <GameId game="CK3">volhynian</GameId>
-    </GameIds>
-    <FallbackLanguages>
-      <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
       <LanguageId>Ruthenian</LanguageId>
       <LanguageId>Ukrainian_Before2017</LanguageId>
       <LanguageId>Russian</LanguageId>
@@ -4206,6 +4171,10 @@
   </Language>
   <Language>
     <Id>Ruthenian</Id>
+    <FallbackLanguages>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Russian_Medieval</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Sabaean</Id>
@@ -4552,6 +4521,40 @@
       <GameId game="CK3">serer</GameId>
     </GameIds>
     <FallbackLanguages>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Severian</Id>
+    <GameIds>
+      <GameId game="CK2">severian</GameId>
+      <GameId game="CK3">severian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Russian_Medieval</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
+      <LanguageId>Ruthenian</LanguageId>
+      <LanguageId>Ukrainian_Before2017</LanguageId>
+      <LanguageId>Russian</LanguageId>
+      <LanguageId>Belarussian</LanguageId>
+      <LanguageId>Ukrainian</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Slavic_East_Old</Id>
+    <Code iso-639-3="orv" />
+    <GameIds>
+      <GameId game="CK2">russian</GameId>
+      <GameId game="CK2HIP">russian</GameId>
+      <GameId game="CK3">russian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Ruthenian</LanguageId>
+      <LanguageId>Ukrainian_Before2017</LanguageId>
+      <LanguageId>Russian</LanguageId>
+      <LanguageId>Belarussian</LanguageId>
+      <LanguageId>Ukrainian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -5258,11 +5261,12 @@
       <LanguageId>Ukrainian_Before2017</LanguageId>
       <LanguageId>Russian</LanguageId>
       <LanguageId>Belarussian</LanguageId>
-      <LanguageId>Ruthenian</LanguageId>
       <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
+      <LanguageId>Ruthenian</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -5271,11 +5275,12 @@
       <GameId game="HOI4">UKR</GameId> <!-- Ukraine -->
     </GameIds>
     <FallbackLanguages>
-      <LanguageId>Ruthenian</LanguageId>
       <LanguageId>Russian_Medieval</LanguageId>
-      <LanguageId>Russian_Medieval_Volhynian</LanguageId>
-      <LanguageId>Russian_Medieval_Severian</LanguageId>
-      <LanguageId>Russian_Medieval_Ilmenian</LanguageId>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Volhynian</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
+      <LanguageId>Ruthenian</LanguageId>
       <LanguageId>Ukrainian</LanguageId>
       <LanguageId>Russian</LanguageId>
       <LanguageId>Belarussian</LanguageId>
@@ -5418,6 +5423,24 @@
   <Language>
     <Id>Volapuk</Id>
     <Code iso-639-3="vro" />
+  </Language>
+  <Language>
+    <Id>Volhynian</Id>
+    <GameIds>
+      <GameId game="CK2">volhynian</GameId>
+      <GameId game="CK3">volhynian</GameId>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Slavic_East_Old</LanguageId>
+      <LanguageId>Russian_Medieval</LanguageId>
+      <LanguageId>Severian</LanguageId>
+      <LanguageId>Ilmenian</LanguageId>
+      <LanguageId>Ruthenian</LanguageId>
+      <LanguageId>Ukrainian_Before2017</LanguageId>
+      <LanguageId>Russian</LanguageId>
+      <LanguageId>Belarussian</LanguageId>
+      <LanguageId>Ukrainian</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Voro</Id>

--- a/languages.xml
+++ b/languages.xml
@@ -3109,6 +3109,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Neapolitan</LanguageId>
+      <LanguageId>Sicilian</LanguageId>
       <LanguageId>Italian</LanguageId>
       <LanguageId>Tuscan</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
@@ -3418,6 +3419,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Tarantino</LanguageId>
+      <LanguageId>Sicilian</LanguageId>
       <LanguageId>Italian</LanguageId>
       <LanguageId>Tuscan</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
@@ -3433,6 +3435,7 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Langobardic</LanguageId>
+      <LanguageId>Sicilian</LanguageId>
       <LanguageId>Tuscan_Medieval</LanguageId>
       <LanguageId>Italian_Before1922</LanguageId>
       <LanguageId>Neapolitan</LanguageId>
@@ -4722,6 +4725,16 @@
       <GameId game="CK2HIP">sicilian</GameId>
       <GameId game="CK3">sicilian</GameId>
     </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Neapolitan</LanguageId>
+      <LanguageId>Tarantino</LanguageId>
+      <LanguageId>Langobardic</LanguageId>
+      <LanguageId>Italian</LanguageId>
+      <LanguageId>Tuscan</LanguageId>
+      <LanguageId>Italian_Before1922</LanguageId>
+      <LanguageId>Neapolitan_Medieval</LanguageId>
+      <LanguageId>Tuscan_Medieval</LanguageId>
+    </FallbackLanguages>
   </Language>
   <Language>
     <Id>Sicilian_Arabic</Id>

--- a/languages.xml
+++ b/languages.xml
@@ -1414,6 +1414,8 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>English_Old_Norse</LanguageId>
+      <LanguageId>German_Old_Low</LanguageId>
+      <LanguageId>Frisian_Old</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>
@@ -1423,6 +1425,8 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>English_Old</LanguageId>
+      <LanguageId>German_Old_Low</LanguageId>
+      <LanguageId>Frisian_Old</LanguageId>
       <LanguageId>English_Middle</LanguageId>
       <LanguageId>English_Before1926</LanguageId>
       <LanguageId>English_Before1974</LanguageId>
@@ -1614,6 +1618,8 @@
       <GameId game="CK3">frisian</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>English_Old</LanguageId>
+      <LanguageId>German_Old_Low</LanguageId>
       <LanguageId>Frisian_West</LanguageId>
       <LanguageId>Frisian_Middle</LanguageId>
       <LanguageId>Frisian_North</LanguageId>
@@ -2051,6 +2057,8 @@
       <GameId game="CK3">old_saxon</GameId>
     </GameIds>
     <FallbackLanguages>
+      <LanguageId>Frisian_Old</LanguageId>
+      <LanguageId>English_Old</LanguageId>
       <LanguageId>German_Middle_Low</LanguageId>
       <LanguageId>German_Low</LanguageId>
       <LanguageId>German_Low_Dutch</LanguageId>
@@ -4462,6 +4470,8 @@
       <LanguageId>Scots</LanguageId>
       <LanguageId>English</LanguageId>
       <LanguageId>English_Old</LanguageId>
+      <LanguageId>German_Old_Low</LanguageId>
+      <LanguageId>Frisian_Old</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -3630,6 +3630,8 @@
     </GameIds>
     <FallbackLanguages>
       <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>Occitan_Limousin</LanguageId>
+      <LanguageId>Occitan_Croissant</LanguageId>
       <LanguageId>Occitan_Old</LanguageId>
       <LanguageId>Occitan_Gascon_Old</LanguageId>
       <LanguageId>French</LanguageId>
@@ -3649,6 +3651,8 @@
       <LanguageId>Occitan_Gascon_Old</LanguageId>
       <LanguageId>Occitan</LanguageId>
       <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>Occitan_Limousin</LanguageId>
+      <LanguageId>Occitan_Croissant</LanguageId>
       <LanguageId>French_Old</LanguageId>
       <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
@@ -3659,6 +3663,8 @@
     <Code iso-639-3="gsc" />
     <FallbackLanguages>
       <LanguageId>Occitan</LanguageId>
+      <LanguageId>Occitan_Limousin</LanguageId>
+      <LanguageId>Occitan_Croissant</LanguageId>
       <LanguageId>Occitan_Gascon_Old</LanguageId>
       <LanguageId>Occitan_Old</LanguageId>
       <LanguageId>French</LanguageId>
@@ -3675,9 +3681,41 @@
       <LanguageId>Occitan_Old</LanguageId>
       <LanguageId>Occitan</LanguageId>
       <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>Occitan_Limousin</LanguageId>
+      <LanguageId>Occitan_Croissant</LanguageId>
       <LanguageId>French_Old</LanguageId>
       <LanguageId>French_Middle</LanguageId>
       <LanguageId>French</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Occitan_Limousin</Id>
+    <GameIds>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Occitan</LanguageId>
+      <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>Occitan_Croissant</LanguageId>
+      <LanguageId>Occitan_Old</LanguageId>
+      <LanguageId>Occitan_Gascon_Old</LanguageId>
+      <LanguageId>French</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
+      <LanguageId>French_Old</LanguageId>
+    </FallbackLanguages>
+  </Language>
+  <Language>
+    <Id>Occitan_Croissant</Id>
+    <GameIds>
+    </GameIds>
+    <FallbackLanguages>
+      <LanguageId>Occitan</LanguageId>
+      <LanguageId>Occitan_Gascon</LanguageId>
+      <LanguageId>Occitan_Limousin</LanguageId>
+      <LanguageId>Occitan_Old</LanguageId>
+      <LanguageId>Occitan_Gascon_Old</LanguageId>
+      <LanguageId>French</LanguageId>
+      <LanguageId>French_Middle</LanguageId>
+      <LanguageId>French_Old</LanguageId>
     </FallbackLanguages>
   </Language>
   <Language>

--- a/languages.xml
+++ b/languages.xml
@@ -2163,6 +2163,7 @@
   <Language>
     <Id>Gothic_Visigoth</Id>
     <GameIds>
+      <GameId game="CK2">visigothic</GameId>
       <GameId game="CK2HIP">visigothic</GameId>
       <GameId game="CK3">visigothic</GameId>
     </GameIds>

--- a/scripts/prepare-landed-titles.sh
+++ b/scripts/prepare-landed-titles.sh
@@ -8,11 +8,20 @@ if [ ! -f "${FILE}" ]; then
     exit
 fi
 
+FILE_CHARSET=$(file -i "${FILE}" | sed 's/.*charset=\([a-zA-Z0-9-]*\).*/\1/g')
+
+if [ "${FILE_CHARSET}" != "utf-8" ]; then
+    iconv -f WINDOWS-1252 -t UTF-8 "${FILE}" > "${FILE}.utf8.temp"
+    mv "${FILE}.utf8.temp" "${FILE}"
+fi
+
 sed -i 's/\t/    /g' "${FILE}"
 
 if [ "${GAME}" == "CK3" ]; then
     sed -i '/[=\">]cn_/d' "${FILE}"
 fi
+
+sed -i '/cultural_names\s*=/d' "${FILE}"
 
 # Remove brackets
 sed -i 's/=\s*{/=/g' "${FILE}"
@@ -118,7 +127,7 @@ if [ "${GAME}" == "CK2" ] || [ "${GAME}" == "CK2HIP" ]; then
     replace-cultural-name "romanian" "Romanian_Old"
     replace-cultural-name "saxon" "English_Old"
     replace-cultural-name "scottish" "Scottish_Gaelic"
-    replace-cultural-name "sephardi" "sephardi"
+    replace-cultural-name "sephardi" "Ladino"
     replace-cultural-name "slovieni" "Slovak_Medieval"
     replace-cultural-name "ugricbaltic" "Estonian"
 fi
@@ -198,3 +207,8 @@ fi
 
 sed -i 's/> \+/>/g' "${FILE}"
 sed -i 's/ \+<\//<\//g' "${FILE}"
+
+# Combine arabic names
+sed -i 's/Arabic_Andalusia/Arabic/g' "${FILE}"
+sed -i '/.*_Arabic.*/d' "${FILE}"
+sed -i '/.*Arabic_.*/d' "${FILE}"

--- a/scripts/prepare-landed-titles.sh
+++ b/scripts/prepare-landed-titles.sh
@@ -14,8 +14,11 @@ if [ "${GAME}" == "CK3" ]; then
     sed -i '/[=\">]cn_/d' "${FILE}"
 fi
 
-sed -i 's/\r//g' "${FILE}"
+# Remove brackets
+sed -i 's/=\s*{/=/g' "${FILE}"
 sed -i '/^\s*[\{\}]*\s*$/d' "${FILE}"
+
+sed -i 's/\r//g' "${FILE}"
 sed -i 's/^\s*\([ekdcb]_[^\t =]*\)\s*=\s*/\1 =/g' "${FILE}"
 perl -i -p0e 's/( *([ekdcb]_[^\t =]*) *= *\n)+ *([ekdcb]_[^\t =]*) *= */\3 =/g' "${FILE}"
 sed -i 's/^ \+/      /g' "${FILE}"
@@ -192,3 +195,6 @@ if [ "${GAME}" == "CK3" ]; then
     # Blacklisted for now
     sed -i '/^ *\(frankish\) *=.*$/d' "${FILE}"
 fi
+
+sed -i 's/> \+/>/g' "${FILE}"
+sed -i 's/ \+<\//<\//g' "${FILE}"

--- a/scripts/prepare-landed-titles.sh
+++ b/scripts/prepare-landed-titles.sh
@@ -14,6 +14,12 @@ if [ "${GAME}" == "CK3" ]; then
     sed -i '/[=\">]cn_/d' "${FILE}"
 fi
 
+sed -i 's/\r//g' "${FILE}"
+sed -i '/^\s*[\{\}]*\s*$/d' "${FILE}"
+sed -i 's/^\s*\([ekdcb]_[^\t =]*\)\s*=\s*/\1 =/g' "${FILE}"
+perl -i -p0e 's/( *([ekdcb]_[^\t =]*) *= *\n)+ *([ekdcb]_[^\t =]*) *= */\3 =/g' "${FILE}"
+sed -i 's/^ \+/      /g' "${FILE}"
+
 function replace-cultural-name {
     CULTURE_ID="$1"
     LANGUAGE_ID="$2"
@@ -119,15 +125,18 @@ if [ "${GAME}" == "CK2" ] || [ "${GAME}" == "CK3" ]; then
     replace-cultural-name "italian" "Tuscan_Medieval"
     replace-cultural-name "meshchera" "Meshchera"
     replace-cultural-name "old_saxon" "German_Old_Low"
-    replace-cultural-name "outremer" "French_Outremer"
     replace-cultural-name "severian" "Severian"
     replace-cultural-name "suebi" "Suebi_Medieval"
     replace-cultural-name "tocharian" "Tocharian"
     replace-cultural-name "visigothic" "Gothic_Visigoth"
     replace-cultural-name "volhynian" "Volhynian"
+
+    # Blacklisted
+    sed -i '/^ *\(ilmenian\|outremer\|severian\|volhynian\) *=.*$/d' "${FILE}"
 fi
 
 if [ "${GAME}" == "CK2HIP" ]; then
+    replace-cultural-name "langobardisch" "Langobardic"
     replace-cultural-name "low_saxon" "German_Old_Low"
     replace-cultural-name "tajik" "Tajiki"
     replace-cultural-name "vepsian" "Vepsian_Medieval"
@@ -167,6 +176,7 @@ if [ "${GAME}" == "CK3" ]; then
     replace-cultural-name "gaelic" "Scottish_Gaelic"
     replace-cultural-name "latgalian" "Latgalian"
     replace-cultural-name "levantine" "Arabic_Levant"
+    replace-cultural-name "lombard" "Langobardic"
     replace-cultural-name "maghrebi" "Arabic_Maghreb"
     replace-cultural-name "merya" "Merya"
     replace-cultural-name "mogyer" "Hungarian_Old_Early"
@@ -178,7 +188,7 @@ if [ "${GAME}" == "CK3" ]; then
     replace-cultural-name "slovien" "Slovak_Medieval"
     replace-cultural-name "vlach" "Romanian_Old"
     replace-cultural-name "yughur" "Uyghur_Yellow"
-fi
 
-sed -i '/^\s*[\{\}]*\s*$/d' "${FILE}"
-sed -i 's/^[\t ]*\([ekdcb]_\)/\1/g' "${FILE}"
+    # Blacklisted for now
+    sed -i '/^ *\(frankish\) *=.*$/d' "${FILE}"
+fi

--- a/scripts/prepare-landed-titles.sh
+++ b/scripts/prepare-landed-titles.sh
@@ -115,16 +115,16 @@ if [ "${GAME}" == "CK2" ] || [ "${GAME}" == "CK2HIP" ]; then
 fi
 
 if [ "${GAME}" == "CK2" ] || [ "${GAME}" == "CK3" ]; then
-    replace-cultural-name "ilmenian" "Russian_Medieval_Ilmenian"
+    replace-cultural-name "ilmenian" "Ilmenian"
     replace-cultural-name "italian" "Tuscan_Medieval"
     replace-cultural-name "meshchera" "Meshchera"
     replace-cultural-name "old_saxon" "German_Old_Low"
     replace-cultural-name "outremer" "French_Outremer"
-    replace-cultural-name "severian" "Russian_Medieval_Severian"
+    replace-cultural-name "severian" "Severian"
     replace-cultural-name "suebi" "Suebi_Medieval"
     replace-cultural-name "tocharian" "Tocharian"
     replace-cultural-name "visigothic" "Gothic_Visigoth"
-    replace-cultural-name "volhynian" "Russian_Medieval_Volhynian"
+    replace-cultural-name "volhynian" "Volhynian"
 fi
 
 if [ "${GAME}" == "CK2HIP" ]; then
@@ -173,6 +173,7 @@ if [ "${GAME}" == "CK3" ]; then
     replace-cultural-name "muroma" "Muroma"
     replace-cultural-name "polabian" "Polabian"
     replace-cultural-name "sami" "Sami"
+    replace-cultural-name "saxon" "German_Middle_Low"
     replace-cultural-name "scottish" "Scots_Early"
     replace-cultural-name "slovien" "Slovak_Medieval"
     replace-cultural-name "vlach" "Romanian_Old"

--- a/scripts/prepare-landed-titles.sh
+++ b/scripts/prepare-landed-titles.sh
@@ -103,7 +103,7 @@ fi
 
 if [ "${GAME}" == "CK2" ] || [ "${GAME}" == "CK2HIP" ]; then
     replace-cultural-name "andalusian_arabic" "Arabic_Andalusia"
-    replace-cultural-name "arberian" "arberian"
+    replace-cultural-name "arberian" "Arberian"
     replace-cultural-name "bedouin_arabic" "Arabic_Bedouin"
     replace-cultural-name "bohemian" "Czech_Medieval"
     replace-cultural-name "carantanian" "Slovene_Medieval"


### PR DESCRIPTION
 - Added many new names to existing locations
 - Added many new links to `Crusader Kings 2` locations
 - Added many new links to `Crusader Kings 3` locations
 - Reorganised some existing languages
 - Added some new languages
 - Greatly extended language fallbacks
 - Replaced some of the names with more accurate ones
 - Removed all `Volhynian`. `Ilmenian` and `Severian` names
 - Deprecated the `Russian_Medieval` language in favour of `Slavic_East_Old` **(1)**
 - Deduplicated all arabic names **(2)**
 - Deduplicated many location definitions

**(1)**: `Russian_Medieval` is still available for legacy names but those will slowly be phased out and replaced with proper and accurate OES variants. The old language ID will be kept until that process is complete
**(2)**: All the names like `Arabic_Levant`, `Egyptian_Arabic`, etc. have been combined into a single, generic `Arabic` name since they are all the same anyway