### PR TITLE
Replace Travis-CI with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,5 @@ jobs:
       - uses: actions/checkout@v2
 
       # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      - name: Build the mods
+        run: bash scripts/build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,5 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Validate the data
+        run: |
+          VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
+          if [ -n "${VALIDATE_DATA}" ]; then
+              echo "Input files validation failed!"
+              echo "${VALIDATE_DATA}"
+              exit 1
+          fi
+
+      - name: Download the builder
+        run: bash scripts/update-builder.sh
+
       - name: Build the mods
-        run: bash scripts/build.sh
+        run: bash scripts/build.sh --skip-validation --skip-updates

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,9 @@ jobs:
 
       - name: Validate the data
         run: |
-          VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
-          if [ -n "${VALIDATE_DATA}" ]; then
-              echo "Input files validation failed!"
-              echo "${VALIDATE_DATA}"
+          VALIDATE_DATA_OUTPUT="$(bash scripts/validate-data.sh | tr '\0' '\n')"
+          if [ -n "${VALIDATE_DATA_OUTPUT}" ]; then
+              echo "${VALIDATE_DATA_OUTPUT}"
               exit 1
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,19 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
       - name: Build the mods
         run: bash scripts/build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Validation
+name: CI
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,7 @@
-name: Build
+name: Validation
 
 on:
-  push:
+  pull_request:
     branches: [ master ]
 
   workflow_dispatch:
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build the mods
-        run: bash scripts/build.sh
+        run: bash scripts/validate-data.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build the mods
+      - name: Validate the data
         run: |
           VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
           if [ -n "${VALIDATE_DATA}" ]; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,4 +14,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build the mods
-        run: bash scripts/validate-data.sh
+        run: |
+          VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
+          if [ -n "${VALIDATE_DATA}" ]; then
+              echo "Input files validation failed!"
+              echo "${VALIDATE_DATA}"
+              exit 1
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,9 +15,8 @@ jobs:
 
       - name: Validate the data
         run: |
-          VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
-          if [ -n "${VALIDATE_DATA}" ]; then
-              echo "Input files validation failed!"
-              echo "${VALIDATE_DATA}"
+          VALIDATE_DATA_OUTPUT="$(bash scripts/validate-data.sh | tr '\0' '\n')"
+          if [ -n "${VALIDATE_DATA_OUTPUT}" ]; then
+              echo "${VALIDATE_DATA_OUTPUT}"
               exit 1
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: shell
-
-script:
- - bash scripts/build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 STARTDIR="$(pwd)"
+SCRIPTSDIR="${STARTDIR}/scripts"
 OUTDIR="${STARTDIR}/out"
 EXTRAS_DIR="${STARTDIR}/extras"
 VANILLA_FILES_DIR="${STARTDIR}/vanilla"
@@ -17,31 +18,8 @@ fi
 
 VERSION=$(date +"%y").$(date +"%j").${BUILD_VERSION}
 
-MOD_BUILDER_NAME="more-cultural-names-builder"
-MOD_BUILDER_VERSION=$(curl --silent "https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/latest" | sed 's/.*\/tag\/v\([^\"]*\)">redir.*/\1/g')
-MOD_BUILDER_ZIP_URL="https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/download/v${MOD_BUILDER_VERSION}/${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip"
-MOD_BUILDER_BIN_FILE_PATH="${STARTDIR}/${MOD_BUILDER_NAME}/MoreCulturalNamesModBuilder"
-NEEDS_DOWNLOADING=true
-
 if [[ $* != *--skip-updates* ]]; then
-    echo "Checking for builder updates..."
-    if [ -d "${STARTDIR}/${MOD_BUILDER_NAME}" ]; then
-        if [ -f "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt" ]; then
-            CURRENT_VERSION=$(cat "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt")
-            if [ "${CURRENT_VERSION}" == "${MOD_BUILDER_VERSION}" ]; then
-                NEEDS_DOWNLOADING=false
-            fi
-        fi
-    fi
-
-    if [ ${NEEDS_DOWNLOADING} == true ]; then
-        [ -d "${STARTDIR}/${MOD_BUILDER_NAME}" ] && rm -rf "${STARTDIR}/${MOD_BUILDER_NAME}"
-
-        wget -c "${MOD_BUILDER_ZIP_URL}"
-        mkdir "${STARTDIR}/${MOD_BUILDER_NAME}"
-        unzip "${STARTDIR}/${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip" -d "${STARTDIR}/${MOD_BUILDER_NAME}"
-        echo "${MOD_BUILDER_VERSION}" > "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt"
-    fi
+    bash "${SCRIPTSDIR}/update-builder.sh"
 fi
 
 echo "Validating the files..."

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,12 +22,14 @@ if [[ $* != *--skip-updates* ]]; then
     bash "${SCRIPTSDIR}/update-builder.sh"
 fi
 
-echo "Validating the files..."
-VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
-if [ -n "${VALIDATE_DATA}" ]; then
-    echo "Input files validation failed!"
-    echo "${VALIDATE_DATA}"
-    exit 1
+if [[ $* != *--skip-validation* ]]; then
+    echo "Validating the files..."
+    VALIDATE_DATA="$(bash scripts/validate-data.sh | tr '\0' '\n')"
+    if [ -n "${VALIDATE_DATA}" ]; then
+        echo "Input files validation failed!"
+        echo "${VALIDATE_DATA}"
+        exit 1
+    fi
 fi
 
 function build-edition {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,7 @@ function build-edition {
     [ -f "${OUTDIR}/${PACKAGE_NAME}.zip" ] && rm "${OUTDIR}/${PACKAGE_NAME}.zip"
 
     cd "${STARTDIR}"
-    "${MOD_BUILDER_BIN_FILE_PATH}" \
+    "${STARTDIR}/more-cultural-names-builder/MoreCulturalNamesModBuilder" \
         --lang "${LANGUAGES_FILE}" \
         --loc "${LOCATIONS_FILE}" \
         --titles "${TITLES_FILE}" \

--- a/scripts/update-builder.sh
+++ b/scripts/update-builder.sh
@@ -3,8 +3,8 @@
 STARTDIR="$(pwd)"
 MOD_BUILDER_NAME="more-cultural-names-builder"
 MOD_BUILDER_VERSION=$(curl --silent "https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/latest" | sed 's/.*\/tag\/v\([^\"]*\)">redir.*/\1/g')
-MOD_BUILDER_ZIP_URL="https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/download/v${MOD_BUILDER_VERSION}/${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip"
-MOD_BUILDER_BIN_FILE_PATH="${STARTDIR}/${MOD_BUILDER_NAME}/MoreCulturalNamesModBuilder"
+MOD_BUILDER_PACKAGE_NAME="${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip"
+MOD_BUILDER_PACKAGE_URL="https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/download/v${MOD_BUILDER_VERSION}/${MOD_BUILDER_PACKAGE_NAME}"
 NEEDS_DOWNLOADING=true
 
 echo "Checking for builder updates..."
@@ -19,8 +19,12 @@ fi
 
 if [ ${NEEDS_DOWNLOADING} == true ]; then
     [ -d "${STARTDIR}/${MOD_BUILDER_NAME}" ] && rm -rf "${STARTDIR}/${MOD_BUILDER_NAME}"
-    wget -c "${MOD_BUILDER_ZIP_URL}"
+
+    echo " > Downloading v${MOD_BUILDER_VERSION}..."
+    wget -q -c "${MOD_BUILDER_PACKAGE_URL}"
+    
+    echo " > Extracting..."
     mkdir "${STARTDIR}/${MOD_BUILDER_NAME}"
-    unzip "${STARTDIR}/${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip" -d "${STARTDIR}/${MOD_BUILDER_NAME}"
+    unzip -q "${STARTDIR}/${MOD_BUILDER_PACKAGE_NAME}" -d "${STARTDIR}/${MOD_BUILDER_NAME}"
     echo "${MOD_BUILDER_VERSION}" > "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt"
 fi

--- a/scripts/update-builder.sh
+++ b/scripts/update-builder.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+STARTDIR="$(pwd)"
+MOD_BUILDER_NAME="more-cultural-names-builder"
+MOD_BUILDER_VERSION=$(curl --silent "https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/latest" | sed 's/.*\/tag\/v\([^\"]*\)">redir.*/\1/g')
+MOD_BUILDER_ZIP_URL="https://github.com/hmlendea/${MOD_BUILDER_NAME}/releases/download/v${MOD_BUILDER_VERSION}/${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip"
+MOD_BUILDER_BIN_FILE_PATH="${STARTDIR}/${MOD_BUILDER_NAME}/MoreCulturalNamesModBuilder"
+NEEDS_DOWNLOADING=true
+
+echo "Checking for builder updates..."
+if [ -d "${STARTDIR}/${MOD_BUILDER_NAME}" ]; then
+    if [ -f "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt" ]; then
+        CURRENT_VERSION=$(cat "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt")
+        if [ "${CURRENT_VERSION}" == "${MOD_BUILDER_VERSION}" ]; then
+            NEEDS_DOWNLOADING=false
+        fi
+    fi
+fi
+
+if [ ${NEEDS_DOWNLOADING} == true ]; then
+    [ -d "${STARTDIR}/${MOD_BUILDER_NAME}" ] && rm -rf "${STARTDIR}/${MOD_BUILDER_NAME}"
+    wget -c "${MOD_BUILDER_ZIP_URL}"
+    mkdir "${STARTDIR}/${MOD_BUILDER_NAME}"
+    unzip "${STARTDIR}/${MOD_BUILDER_NAME}_${MOD_BUILDER_VERSION}_linux-x64.zip" -d "${STARTDIR}/${MOD_BUILDER_NAME}"
+    echo "${MOD_BUILDER_VERSION}" > "${STARTDIR}/${MOD_BUILDER_NAME}/version.txt"
+fi


### PR DESCRIPTION
 - Replaced `Travis-CI` with `GitHub Actions`
 - The full build is now only performed on merges _(into master)_
 - The pull request checks now only perform data integrity validations